### PR TITLE
Add header to login screen

### DIFF
--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -42,7 +42,10 @@ const Login = () => {
     };
 
     return (
-        <div className="flex h-screen items-center justify-center bg-gray-100">
+        <div className="flex flex-col h-screen items-center justify-center bg-gray-100">
+            <h1 className="text-3xl font-bold mb-6 text-center">
+                Bellingham Data Futures
+            </h1>
             <form
                 onSubmit={handleLogin}
                 className="bg-white shadow-lg rounded-2xl p-8 w-96"


### PR DESCRIPTION
## Summary
- center a new heading `Bellingham Data Futures` on the login page

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `./mvnw -q test` *(fails: Unable to fetch Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857aac029bc8329aecb259a08f3ffb3