### PR TITLE
Fix auth provider wiring

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/security/CustomUserDetailsService.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/security/CustomUserDetailsService.java
@@ -20,6 +20,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         System.out.println("🔍 Looking up user: " + username);
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        System.out.println("🔐 Loaded user: " + user.getUsername());
         return new org.springframework.security.core.userdetails.User(
                 user.getUsername(),
                 user.getPassword(),

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/security/WebSecurityConfig.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/security/WebSecurityConfig.java
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -41,8 +41,11 @@ public class WebSecurityConfig {
     }
 
     @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
-        return config.getAuthenticationManager(); // ✅ Works with Spring Boot 3 / Spring Security 6
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        AuthenticationManagerBuilder builder =
+                http.getSharedObject(AuthenticationManagerBuilder.class);
+        builder.authenticationProvider(authenticationProvider());
+        return builder.build();
     }
 
     @Bean


### PR DESCRIPTION
## Summary
- configure `AuthenticationManager` bean with `DaoAuthenticationProvider`
- log loaded user in `CustomUserDetailsService`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857b7f04ac08329ac0cae9d7266b233