### PR TITLE
Add endpoint for available contracts

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -29,7 +29,13 @@ public class ForwardContractController {
 
     @PostMapping
     public ForwardContract create(@RequestBody ForwardContract contract) {
+        contract.setStatus("Available");
         return repository.save(contract);
+    }
+
+    @GetMapping("/available")
+    public List<ForwardContract> getAvailable() {
+        return repository.findByStatus("Available");
     }
 
     @PutMapping("/{id}")

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/repository/ForwardContractRepository.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/repository/ForwardContractRepository.java
@@ -4,7 +4,10 @@ import com.bellingham.datafutures.model.ForwardContract;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ForwardContractRepository extends JpaRepository<ForwardContract, Long> {
+    List<ForwardContract> findByStatus(String status);
 }
 

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/security/WebSecurityConfig.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/security/WebSecurityConfig.java
@@ -54,7 +54,7 @@ public class WebSecurityConfig {
                 .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/authenticate", "/api/register-default").permitAll()
+                        .requestMatchers("/api/authenticate", "/api/register-default", "/api/contracts/available").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session


### PR DESCRIPTION
## Summary
- allow querying forward contracts by status
- default new forward contracts to `Available`
- expose `/api/contracts/available` endpoint
- permit `/api/contracts/available` in security config

## Testing
- `./mvnw -q package` *(fails: Non-resolvable parent POM)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68590d9dac9883299047f04e8c9a2676