### PR TITLE
Add purchased contracts reports screen

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -38,6 +38,11 @@ public class ForwardContractController {
         return repository.findByStatus("Available");
     }
 
+    @GetMapping("/purchased")
+    public List<ForwardContract> getPurchased() {
+        return repository.findByStatus("Purchased");
+    }
+
     @PutMapping("/{id}")
     public ResponseEntity<ForwardContract> update(@PathVariable Long id, @RequestBody ForwardContract updated) {
         return repository.findById(id)

--- a/bellingham-frontend/src/App.jsx
+++ b/bellingham-frontend/src/App.jsx
@@ -4,6 +4,7 @@ import Login from "./components/Login";
 import Dashboard from "./components/Dashboard";
 import Buy from "./components/Buy";
 import Sell from "./components/Sell";
+import Reports from "./components/Reports";
 
 const App = () => {
     const token = localStorage.getItem("token");
@@ -22,6 +23,10 @@ const App = () => {
             <Route
                 path="/sell"
                 element={token ? <Sell /> : <Navigate to="/login" />}
+            />
+            <Route
+                path="/reports"
+                element={token ? <Reports /> : <Navigate to="/login" />}
             />
         </Routes>
     );

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -68,7 +68,7 @@ const Dashboard = () => {
                             Sell
                         </button>
                         <button
-                            onClick={() => alert("Reports screen not implemented yet")}
+                            onClick={() => navigate("/reports")}
                             className="text-left hover:bg-gray-700 px-4 py-2 rounded"
                         >
                             Reports

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+
+const Reports = () => {
+    const [contracts, setContracts] = useState([]);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        const fetchPurchased = async () => {
+            try {
+                const token = localStorage.getItem("token");
+                const res = await axios.get("http://localhost:8080/api/contracts/purchased", {
+                    headers: { Authorization: `Bearer ${token}` },
+                });
+                setContracts(res.data);
+            } catch {
+                setError("Failed to load purchased contracts.");
+            }
+        };
+        fetchPurchased();
+    }, []);
+
+    return (
+        <div className="p-8 text-white bg-black min-h-screen font-poppins">
+            <h1 className="text-3xl font-bold mb-6">Purchased Contracts</h1>
+            {error && <p className="text-red-500 mb-4">{error}</p>}
+            <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+                <thead>
+                    <tr className="bg-gray-700 text-left">
+                        <th className="border p-2">Title</th>
+                        <th className="border p-2">Seller</th>
+                        <th className="border p-2">Price</th>
+                        <th className="border p-2">Delivery</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {contracts.map((contract) => (
+                        <tr key={contract.id} className="hover:bg-gray-600">
+                            <td className="border p-2">{contract.title}</td>
+                            <td className="border p-2">{contract.seller}</td>
+                            <td className="border p-2">${contract.price}</td>
+                            <td className="border p-2">{contract.deliveryDate}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+export default Reports;


### PR DESCRIPTION
## Summary
- add `/api/contracts/purchased` backend endpoint
- create `Reports` component to display purchased contracts
- hook Reports screen into navigation and routes

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*
- `npm -s run lint` *(fails: 3 errors)*
- `npm -s run build`

------
https://chatgpt.com/codex/tasks/task_e_68591613026c8329bac98df5970a7433