### PR TITLE
Add contract detail side panel

### DIFF
--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -2,10 +2,12 @@
 
 import React, { useEffect, useState } from "react";
 import axios from "axios";
+import ContractDetailsPanel from "./ContractDetailsPanel";
 
 const Buy = () => {
     const [contracts, setContracts] = useState([]);
     const [error, setError] = useState("");
+    const [selectedContract, setSelectedContract] = useState(null);
 
     useEffect(() => {
         const fetchContracts = async () => {
@@ -16,6 +18,7 @@ const Buy = () => {
                 });
                 setContracts(res.data);
             } catch (err) {
+                console.error(err);
                 setError("Failed to fetch contracts.");
             }
         };
@@ -32,6 +35,7 @@ const Buy = () => {
             );
             alert("Contract purchased successfully!");
         } catch (err) {
+            console.error(err);
             alert("Failed to purchase contract.");
         }
     };
@@ -42,13 +46,17 @@ const Buy = () => {
             {error && <p className="text-red-500 mb-4">{error}</p>}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {contracts.map((contract) => (
-                    <div key={contract.id} className="bg-gray-800 p-6 rounded shadow">
+                    <div
+                        key={contract.id}
+                        className="bg-gray-800 p-6 rounded shadow cursor-pointer"
+                        onClick={() => setSelectedContract(contract)}
+                    >
                         <h2 className="text-xl font-semibold mb-2">{contract.title}</h2>
                         <p className="text-sm text-gray-400 mb-1">Category: {contract.category}</p>
                         <p className="text-sm text-gray-400 mb-1">End Date: {contract.deliveryDate}</p>
                         <p className="text-sm text-gray-400 mb-4">Price: ${contract.price}</p>
                         <button
-                            onClick={() => handleBuy(contract.id)}
+                            onClick={(e) => { e.stopPropagation(); handleBuy(contract.id); }}
                             className="bg-green-600 hover:bg-green-700 px-4 py-2 rounded text-white"
                         >
                             Buy Contract
@@ -56,6 +64,10 @@ const Buy = () => {
                     </div>
                 ))}
             </div>
+            <ContractDetailsPanel
+                contract={selectedContract}
+                onClose={() => setSelectedContract(null)}
+            />
         </div>
     );
 };

--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+const ContractDetailsPanel = ({ contract, onClose }) => {
+    if (!contract) return null;
+
+    return (
+        <div className="fixed top-0 right-0 w-full sm:w-96 h-full bg-gray-900 text-white p-6 overflow-auto shadow-lg z-20">
+            <button
+                className="mb-4 bg-red-600 hover:bg-red-700 px-3 py-1 rounded"
+                onClick={onClose}
+            >
+                Close
+            </button>
+            <h2 className="text-xl font-bold mb-4">{contract.title}</h2>
+            <ul className="space-y-1">
+                {Object.entries(contract).map(([key, value]) => (
+                    <li key={key}>
+                        <span className="font-semibold capitalize mr-2">{key}:</span>
+                        {String(value)}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+};
+
+export default ContractDetailsPanel;

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -3,9 +3,11 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
+import ContractDetailsPanel from "./ContractDetailsPanel";
 
 const Dashboard = () => {
     const [contracts, setContracts] = useState([]);
+    const [selectedContract, setSelectedContract] = useState(null);
     const navigate = useNavigate();
 
     useEffect(() => {
@@ -109,7 +111,11 @@ const Dashboard = () => {
                     </thead>
                     <tbody>
                     {contracts.map((contract) => (
-                        <tr key={contract.id} className="hover:bg-gray-600">
+                        <tr
+                            key={contract.id}
+                            className="hover:bg-gray-600 cursor-pointer"
+                            onClick={() => setSelectedContract(contract)}
+                        >
                             <td className="border p-2">{contract.title}</td>
                             <td className="border p-2">{contract.seller}</td>
                             <td className="border p-2">${contract.price}</td>
@@ -120,6 +126,10 @@ const Dashboard = () => {
                     </tbody>
                     </table>
                 </main>
+                <ContractDetailsPanel
+                    contract={selectedContract}
+                    onClose={() => setSelectedContract(null)}
+                />
             </div>
         </div>
     );

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -1,7 +1,6 @@
 // src/components/Login.jsx
 
 import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
 import axios from "axios";
 
 const Login = () => {

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
+import ContractDetailsPanel from "./ContractDetailsPanel";
 
 const Reports = () => {
     const [contracts, setContracts] = useState([]);
     const [error, setError] = useState("");
+    const [selectedContract, setSelectedContract] = useState(null);
 
     useEffect(() => {
         const fetchPurchased = async () => {
@@ -35,7 +37,11 @@ const Reports = () => {
                 </thead>
                 <tbody>
                     {contracts.map((contract) => (
-                        <tr key={contract.id} className="hover:bg-gray-600">
+                        <tr
+                            key={contract.id}
+                            className="hover:bg-gray-600 cursor-pointer"
+                            onClick={() => setSelectedContract(contract)}
+                        >
                             <td className="border p-2">{contract.title}</td>
                             <td className="border p-2">{contract.seller}</td>
                             <td className="border p-2">${contract.price}</td>
@@ -44,6 +50,10 @@ const Reports = () => {
                     ))}
                 </tbody>
             </table>
+            <ContractDetailsPanel
+                contract={selectedContract}
+                onClose={() => setSelectedContract(null)}
+            />
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- add a `ContractDetailsPanel` component
- display contract details in dashboard, buy, and reports screens
- fix lint errors

## Testing
- `npm run lint`
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685919081f288329baa1787e5461e20b