### PR TITLE
Fix details panel alignment

### DIFF
--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -41,7 +41,7 @@ const Buy = () => {
     };
 
     return (
-        <div className="p-8 text-white bg-black min-h-screen font-poppins">
+        <div className="relative p-8 text-white bg-black min-h-screen font-poppins">
             <h1 className="text-3xl font-bold mb-6">Available Contracts</h1>
             {error && <p className="text-red-500 mb-4">{error}</p>}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -4,7 +4,7 @@ const ContractDetailsPanel = ({ contract, onClose }) => {
     if (!contract) return null;
 
     return (
-        <div className="fixed top-0 right-0 w-full sm:w-96 h-full bg-gray-900 text-white p-6 overflow-auto shadow-lg z-20">
+        <div className="absolute top-0 right-0 w-full sm:w-96 h-full bg-gray-900 text-white p-6 overflow-auto shadow-lg z-20 max-w-md">
             <button
                 className="mb-4 bg-red-600 hover:bg-red-700 px-3 py-1 rounded"
                 onClick={onClose}

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -47,7 +47,7 @@ const Dashboard = () => {
             <header className="bg-gray-800 p-4">
                 <h1 className="text-2xl font-bold">Bellingham Data Futures</h1>
             </header>
-            <div className="flex flex-1">
+            <div className="flex flex-1 relative">
                 {/* Sidebar */}
                 <aside className="w-64 bg-gray-900 p-6 flex flex-col justify-between">
                     <nav className="flex flex-col space-y-4">

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -23,7 +23,7 @@ const Reports = () => {
     }, []);
 
     return (
-        <div className="p-8 text-white bg-black min-h-screen font-poppins">
+        <div className="relative p-8 text-white bg-black min-h-screen font-poppins">
             <h1 className="text-3xl font-bold mb-6">Purchased Contracts</h1>
             {error && <p className="text-red-500 mb-4">{error}</p>}
             <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">


### PR DESCRIPTION
## Summary
- anchor `ContractDetailsPanel` to the right inside its parent containers
- make page containers relative to position the panel correctly

## Testing
- `npm run lint` in `bellingham-frontend`
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68592046e6108329a3d63a2b9be1bc74