### PR TITLE
Fix contract panel overlay

### DIFF
--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -97,7 +97,11 @@ const Dashboard = () => {
                 </aside>
 
                 {/* Main Content */}
-                <main className="flex-1 p-8 overflow-auto bg-black">
+                <main
+                    className={`flex-1 p-8 overflow-auto bg-black transition-all duration-300 ${
+                        selectedContract ? "sm:mr-96" : ""
+                    }`}
+                >
                     <h2 className="text-3xl font-bold mb-6 text-white">Contracts</h2>
                     <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
                     <thead>


### PR DESCRIPTION
## Summary
- shift main dashboard content to the left when a contract is selected

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685928999e7083299c29e98fbcf5013c