### PR TITLE
Add agreement text support

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
@@ -17,6 +17,7 @@ public class ForwardContract {
     private LocalDate deliveryDate;
     private String dataDescription;
     private String termsFileName;
+    private String agreementText;
     private String status;
 
     // Getters and setters
@@ -75,6 +76,14 @@ public class ForwardContract {
 
     public void setTermsFileName(String termsFileName) {
         this.termsFileName = termsFileName;
+    }
+
+    public String getAgreementText() {
+        return agreementText;
+    }
+
+    public void setAgreementText(String agreementText) {
+        this.agreementText = agreementText;
     }
 
     public String getStatus() {

--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -16,7 +16,11 @@ const ContractDetailsPanel = ({ contract, onClose }) => {
                 {Object.entries(contract).map(([key, value]) => (
                     <li key={key}>
                         <span className="font-semibold capitalize mr-2">{key}:</span>
-                        {String(value)}
+                        {key === "agreementText" ? (
+                            <pre className="whitespace-pre-wrap">{value}</pre>
+                        ) : (
+                            String(value)
+                        )}
                     </li>
                 ))}
             </ul>

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -1,4 +1,46 @@
 import React, { useState } from "react";
+
+const defaultAgreement = `DATA PURCHASE AGREEMENT
+
+Seller: [Seller's Full Legal Name], a [Entity Type] with a principal place of business at [Seller's Address]
+Buyer: [Buyer’s Full Legal Name], a [Entity Type] with a principal place of business at [Buyer’s Address]
+
+1. DEFINITIONS
+1.1 "Data" means the dataset(s) or information described in Exhibit A.
+
+1.2 "Confidential Information" means any non-public, proprietary information disclosed in connection with this Agreement.
+
+2. SALE AND TRANSFER OF DATA
+2.1 Data Transfer. Seller agrees to sell, and Buyer agrees to purchase, the Data described in Exhibit A.
+2.2 Delivery. The Data will be delivered in [format] via [delivery method] within [number] business days of execution.
+2.3 Acceptance. Buyer will have [X] business days to inspect and accept the Data.
+
+3. PAYMENT TERMS
+3.1 Purchase Price. Buyer shall pay Seller a total amount of $[amount] (the "Purchase Price").
+3.2 Payment Schedule. Payment shall be made in full upon execution / [installments with milestones].
+3.3 Taxes. Each Party shall be responsible for its own tax obligations.
+
+4. WARRANTIES AND REPRESENTATIONS
+4.1 Seller Warranties. Seller represents and warrants that it has full rights and authority to sell the Data; the Data is accurate to the best of its knowledge; the Data does not infringe upon any third-party rights.
+4.2 Buyer Acknowledgement. Buyer understands the Data is provided "as-is," except as otherwise stated.
+
+5. CONFIDENTIALITY
+5.1 Non-Disclosure. Each Party agrees not to disclose any Confidential Information without the other Party's prior written consent.
+5.2 Exceptions. Disclosure is permitted if required by law or with prior written approval.
+
+6. LIMITATIONS AND LIABILITY
+6.1 Limitation of Liability. Neither Party shall be liable for indirect, incidental, or consequential damages.
+6.2 Indemnification. Each Party agrees to indemnify the other for any claims arising from a breach of this Agreement.
+
+7. TERM AND TERMINATION
+7.1 Term. This Agreement shall commence on the Effective Date and remain in effect unless terminated in accordance with this section.
+7.2 Termination for Cause. Either Party may terminate this Agreement upon written notice in case of material breach.
+
+8. MISCELLANEOUS
+8.1 Governing Law. This Agreement shall be governed by the laws of the State of [State].
+8.2 Entire Agreement. This document contains the entire agreement between the Parties.
+8.3 Amendments. Any changes to this Agreement must be in writing and signed by both Parties.
+8.4 Assignment. Neither Party may assign its rights under this Agreement without the other Party's written consent.`;
 import axios from "axios";
 
 const Sell = () => {
@@ -7,6 +49,7 @@ const Sell = () => {
         title: "",
         price: "",
         dataDescription: "",
+        agreementText: defaultAgreement,
     });
     const [snippet, setSnippet] = useState(null);
     const [message, setMessage] = useState("");
@@ -28,6 +71,7 @@ const Sell = () => {
             deliveryDate: form.deliveryDate,
             price: parseFloat(form.price || 0),
             dataDescription: form.dataDescription,
+            agreementText: form.agreementText,
         };
         if (snippet) {
             data.termsFileName = snippet.name;
@@ -40,7 +84,13 @@ const Sell = () => {
                 },
             });
             setMessage("✅ Data contract submitted!");
-            setForm({ deliveryDate: "", title: "", price: "", dataDescription: "" });
+            setForm({
+                deliveryDate: "",
+                title: "",
+                price: "",
+                dataDescription: "",
+                agreementText: defaultAgreement,
+            });
             setSnippet(null);
         } catch (err) {
             setMessage("❌ Submission failed.");
@@ -95,6 +145,16 @@ const Sell = () => {
                         onChange={handleChange}
                         className="w-full p-2 mt-1 bg-gray-800 rounded"
                         required
+                    />
+                </div>
+                <div>
+                    <label>Data Purchase Agreement</label>
+                    <textarea
+                        name="agreementText"
+                        value={form.agreementText}
+                        onChange={handleChange}
+                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        rows="10"
                     />
                 </div>
                 <div>


### PR DESCRIPTION
## Summary
- support new Data Purchase Agreement text in contract model
- show agreement text in details panel
- capture purchase agreement text when submitting a new contract

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68592e258efc83299f80403a88e023da