### PR TITLE
Support storing contract agreement text

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
@@ -17,6 +17,8 @@ public class ForwardContract {
     private LocalDate deliveryDate;
     private String dataDescription;
     private String termsFileName;
+    @Lob
+    @Column(columnDefinition = "TEXT")
     private String agreementText;
     private String status;
 


### PR DESCRIPTION
## Summary
- expand `ForwardContract.agreementText` to use a database `TEXT` column so large agreement documents can be stored

## Testing
- `mvn -q test` *(fails: `mvn` not found)*
- `npm run lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68593027edd4832994730e4296eb93d2