### PR TITLE
Improve JWT validation in filter

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/security/JwtFilter.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/security/JwtFilter.java
@@ -34,7 +34,15 @@ public class JwtFilter extends OncePerRequestFilter {
 
         if (header != null && header.startsWith("Bearer ")) {
             token = header.substring(7);
-            username = jwtUtil.extractUsername(token);
+            try {
+                if (jwtUtil.validateToken(token)) {
+                    username = jwtUtil.extractUsername(token);
+                } else {
+                    System.out.println("❌ Token validation failed.");
+                }
+            } catch (Exception e) {
+                System.out.println("❌ Error parsing JWT: " + e.getMessage());
+            }
         }
 
         if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {


### PR DESCRIPTION
## Summary
- gracefully handle invalid JWTs in `JwtFilter`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68593ff321ac8329a9784528ecbeaecd