### PR TITLE
Handle optional auth header

### DIFF
--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -13,9 +13,11 @@ const Buy = () => {
         const fetchContracts = async () => {
             try {
                 const token = localStorage.getItem("token");
-                const res = await axios.get("http://localhost:8080/api/contracts/available", {
-                    headers: { Authorization: `Bearer ${token}` },
-                });
+                const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
+                const res = await axios.get(
+                    "http://localhost:8080/api/contracts/available",
+                    config
+                );
                 setContracts(res.data);
             } catch (err) {
                 console.error(err);
@@ -28,10 +30,11 @@ const Buy = () => {
     const handleBuy = async (contractId) => {
         try {
             const token = localStorage.getItem("token");
+            const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
             await axios.post(
                 `http://localhost:8080/api/contracts/${contractId}/buy`,
                 {},
-                { headers: { Authorization: `Bearer ${token}` } }
+                config
             );
             alert("Contract purchased successfully!");
         } catch (err) {

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -19,11 +19,13 @@ const Dashboard = () => {
                     return;
                 }
 
-                const res = await axios.get("http://localhost:8080/api/contracts", {
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                    },
-                });
+                const config = token
+                    ? { headers: { Authorization: `Bearer ${token}` } }
+                    : {};
+                const res = await axios.get(
+                    "http://localhost:8080/api/contracts",
+                    config
+                );
 
                 setContracts(res.data);
             } catch (err) {

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -16,9 +16,11 @@ const Reports = () => {
         const fetchPurchased = async () => {
             try {
                 const token = localStorage.getItem("token");
-                const res = await axios.get("http://localhost:8080/api/contracts/purchased", {
-                    headers: { Authorization: `Bearer ${token}` },
-                });
+                const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
+                const res = await axios.get(
+                    "http://localhost:8080/api/contracts/purchased",
+                    config
+                );
                 setContracts(res.data);
             } catch {
                 setError("Failed to load purchased contracts.");

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -65,6 +65,7 @@ const Sell = () => {
     const handleSubmit = async (e) => {
         e.preventDefault();
         const token = localStorage.getItem("token");
+        const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
 
         const data = {
             title: form.title,
@@ -78,11 +79,11 @@ const Sell = () => {
         }
 
         try {
-            await axios.post("http://localhost:8080/api/contracts", data, {
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                },
-            });
+            await axios.post(
+                "http://localhost:8080/api/contracts",
+                data,
+                config
+            );
             setMessage("✅ Data contract submitted!");
             setForm({
                 deliveryDate: "",


### PR DESCRIPTION
## Summary
- handle auth token being missing when fetching contracts
- make auth header optional when buying contracts
- build `config` headers when token exists in dashboard
- check for token when viewing purchase reports
- send auth header only when logged in for selling data contracts

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68593ff5fa8c83299db3a131c249238c