### PR TITLE
Add API base URL env var

### DIFF
--- a/bellingham-frontend/.env.example
+++ b/bellingham-frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8080

--- a/bellingham-frontend/README.md
+++ b/bellingham-frontend/README.md
@@ -16,6 +16,19 @@ During development run:
 npm run dev
 ```
 
+### API configuration
+
+The frontend expects an API base URL provided via the `VITE_API_BASE_URL`
+environment variable. Copy `.env.example` as a starting point and adjust the value
+for your environment:
+
+```bash
+cp .env.example .env # if deploying
+# or edit .env directly
+```
+
+For local development the default value is `http://localhost:8080`.
+
 To create a production build:
 
 ```bash

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -15,7 +15,7 @@ const Buy = () => {
                 const token = localStorage.getItem("token");
                 const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
                 const res = await axios.get(
-                    "http://localhost:8080/api/contracts/available",
+                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/available`,
                     config
                 );
                 setContracts(res.data);
@@ -32,7 +32,7 @@ const Buy = () => {
             const token = localStorage.getItem("token");
             const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
             await axios.post(
-                `http://localhost:8080/api/contracts/${contractId}/buy`,
+                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${contractId}/buy`,
                 {},
                 config
             );

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -23,7 +23,7 @@ const Dashboard = () => {
                     ? { headers: { Authorization: `Bearer ${token}` } }
                     : {};
                 const res = await axios.get(
-                    "http://localhost:8080/api/contracts",
+                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts`,
                     config
                 );
 

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -14,10 +14,13 @@ const Login = () => {
         setError(""); // Clear previous errors
 
         try {
-            const res = await axios.post("http://localhost:8080/api/authenticate", {
+            const res = await axios.post(
+                `${import.meta.env.VITE_API_BASE_URL}/api/authenticate`,
+                {
                 username,
                 password,
-            });
+                }
+            );
 
             console.log("✅ Login API success:", res.data);
 

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -18,7 +18,7 @@ const Reports = () => {
                 const token = localStorage.getItem("token");
                 const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
                 const res = await axios.get(
-                    "http://localhost:8080/api/contracts/purchased",
+                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/purchased`,
                     config
                 );
                 setContracts(res.data);

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -80,7 +80,7 @@ const Sell = () => {
 
         try {
             await axios.post(
-                "http://localhost:8080/api/contracts",
+                `${import.meta.env.VITE_API_BASE_URL}/api/contracts`,
                 data,
                 config
             );


### PR DESCRIPTION
## Summary
- define `VITE_API_BASE_URL` in `.env.example`
- reference the env var from React components instead of hardcoded URLs
- document API environment variable in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859434b991c8329914475cdc125ae10