### PR TITLE
Add .env and clarify env setup

### DIFF
--- a/bellingham-frontend/.env
+++ b/bellingham-frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8080

--- a/bellingham-frontend/README.md
+++ b/bellingham-frontend/README.md
@@ -19,12 +19,11 @@ npm run dev
 ### API configuration
 
 The frontend expects an API base URL provided via the `VITE_API_BASE_URL`
-environment variable. Copy `.env.example` as a starting point and adjust the value
-for your environment:
+environment variable. When first setting up the project or deploying,
+copy `.env.example` to `.env` and adjust the value for your environment:
 
 ```bash
-cp .env.example .env # if deploying
-# or edit .env directly
+cp .env.example .env
 ```
 
 For local development the default value is `http://localhost:8080`.


### PR DESCRIPTION
## Summary
- create `.env` for the frontend using the example
- clarify README instructions about copying `.env.example` to `.env`

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685948381f0c8329886e0898b5ae082b