### PR TITLE
Allow 127.0.0.1 in CORS

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/CorsConfig.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/CorsConfig.java
@@ -14,7 +14,12 @@ public class CorsConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/api/**")
-                        .allowedOrigins("http://localhost:5173", "http://localhost:5174")
+                        // Allow common local development hosts
+                        .allowedOrigins(
+                                "http://localhost:5173",
+                                "http://localhost:5174",
+                                "http://127.0.0.1:5173",
+                                "http://127.0.0.1:5174")
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("Authorization", "Content-Type")
                         .exposedHeaders("Authorization")


### PR DESCRIPTION
## Summary
- expand the allowed CORS origins to include `127.0.0.1` ports for local development

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594ac00c4c83298fd5361746b04cfb