### PR TITLE
Enable open CORS access

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/CorsConfig.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/CorsConfig.java
@@ -13,8 +13,8 @@ public class CorsConfig {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/api/**")
-                        // Open up CORS for development tools running on any host
+                // Apply global CORS policy allowing any origin
+                registry.addMapping("/**")
                         .allowedOriginPatterns("*")
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("Authorization", "Content-Type")

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
+@CrossOrigin(origins = "*")
 @RequestMapping("/api/contracts")
 public class ForwardContractController {
 


### PR DESCRIPTION
## Summary
- allow any origin in `CorsConfig`
- expose all contract routes to cross-origin requests

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685957cdfab483299c2eb43383e0c5a9