### PR TITLE
Fix 403 on buy screen

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/security/WebSecurityConfig.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/security/WebSecurityConfig.java
@@ -54,6 +54,7 @@ public class WebSecurityConfig {
                 .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/api/authenticate", "/api/register-default", "/api/contracts/available").permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## Summary
- allow all HTTP OPTIONS requests through security filter chain so browser CORS preflights succeed

## Testing
- `npm install --ignore-scripts`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68595b8926808329ab737990ebc14370