### PR TITLE
Ensure default admin user exists

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/DefaultAdminSetup.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/DefaultAdminSetup.java
@@ -1,0 +1,26 @@
+package com.bellingham.datafutures.config;
+
+import com.bellingham.datafutures.model.User;
+import com.bellingham.datafutures.repository.UserRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class DefaultAdminSetup {
+
+    @Bean
+    public CommandLineRunner ensureDefaultAdmin(UserRepository users, PasswordEncoder encoder) {
+        return args -> {
+            if (users.findByUsername("admin").isEmpty()) {
+                User user = new User();
+                user.setUsername("admin");
+                user.setPassword(encoder.encode("admin"));
+                user.setRole("ROLE_USER");
+                users.save(user);
+                System.out.println("✅ Default admin user created");
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add a startup CommandLineRunner that creates the default admin user if missing

## Testing
- `./mvnw -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68595d3009bc832987f80621be993f7e