### PR TITLE
Ensure default admin seeded on startup

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/DefaultAdminSetup.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/DefaultAdminSetup.java
@@ -2,7 +2,7 @@ package com.bellingham.datafutures.config;
 
 import com.bellingham.datafutures.model.User;
 import com.bellingham.datafutures.repository.UserRepository;
-import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -11,7 +11,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class DefaultAdminSetup {
 
     @Bean
-    public CommandLineRunner ensureDefaultAdmin(UserRepository users, PasswordEncoder encoder) {
+    public ApplicationRunner ensureDefaultAdmin(UserRepository users, PasswordEncoder encoder) {
         return args -> {
             if (users.findByUsername("admin").isEmpty()) {
                 User user = new User();
@@ -20,6 +20,8 @@ public class DefaultAdminSetup {
                 user.setRole("ROLE_USER");
                 users.save(user);
                 System.out.println("✅ Default admin user created");
+            } else {
+                System.out.println("ℹ️ Admin user already present");
             }
         };
     }


### PR DESCRIPTION
## Summary
- create admin user via `ApplicationRunner` so the account is seeded once the app is ready

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685960f8eaac8329bf37e4382c6f520c