### PR TITLE
Fix admin seeding so login works

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/DefaultAdminSetup.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/DefaultAdminSetup.java
@@ -13,16 +13,23 @@ public class DefaultAdminSetup {
     @Bean
     public ApplicationRunner ensureDefaultAdmin(UserRepository users, PasswordEncoder encoder) {
         return args -> {
-            if (users.findByUsername("admin").isEmpty()) {
+            users.findByUsername("admin").ifPresentOrElse(user -> {
+                // If admin exists but password is not encoded, update it
+                if (!user.getPassword().startsWith("$2")) {
+                    user.setPassword(encoder.encode("admin"));
+                    users.save(user);
+                    System.out.println("🔑 Updated admin password hash");
+                } else {
+                    System.out.println("ℹ️ Admin user already present");
+                }
+            }, () -> {
                 User user = new User();
                 user.setUsername("admin");
                 user.setPassword(encoder.encode("admin"));
                 user.setRole("ROLE_USER");
                 users.save(user);
                 System.out.println("✅ Default admin user created");
-            } else {
-                System.out.println("ℹ️ Admin user already present");
-            }
+            });
         };
     }
 }


### PR DESCRIPTION
## Summary
- ensure default admin password is hashed if existing account was created before encryption

## Testing
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68596389eebc83298ac9d193da99909f