### PR TITLE
Fix CORS annotations for older Spring versions

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/CorsConfig.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/CorsConfig.java
@@ -15,7 +15,7 @@ public class CorsConfig {
             public void addCorsMappings(CorsRegistry registry) {
                 // Apply global CORS policy allowing any origin
                 registry.addMapping("/**")
-                        .allowedOriginPatterns("*")
+                        .allowedOrigins("*")
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("Authorization", "Content-Type")
                         .exposedHeaders("Authorization")

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@CrossOrigin(allowedOriginPatterns = "*")
+@CrossOrigin(origins = "*")
 @RequestMapping("/api/contracts")
 public class ForwardContractController {
 


### PR DESCRIPTION
## Summary
- fix `CrossOrigin` annotation in `ForwardContractController`
- use `.allowedOrigins()` in the global `CorsConfig`

## Testing
- `mvnw dependency:tree` *(fails: Could not resolve spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68596a529c2483299c6ada94c7cfb06f