### PR TITLE
Fix CORS config to allow credentials

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/CorsConfig.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/CorsConfig.java
@@ -13,9 +13,9 @@ public class CorsConfig {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
-                // Apply global CORS policy allowing any origin
+                // Apply global CORS policy allowing any origin with credentials
                 registry.addMapping("/**")
-                        .allowedOrigins("*")
+                        .allowedOriginPatterns("*")
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("Authorization", "Content-Type")
                         .exposedHeaders("Authorization")


### PR DESCRIPTION
## Summary
- allow origin patterns in CORS config so cookies work with any origin

## Testing
- `./mvnw -q test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685ba44a4800832986598eaf0a80b50c