### PR TITLE
Restrict CORS origin for forward contracts

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@CrossOrigin(origins = "*")
+@CrossOrigin(origins = "http://localhost:5173", allowCredentials = "true")
 @RequestMapping("/api/contracts")
 public class ForwardContractController {
 


### PR DESCRIPTION
## Summary
- limit CORS configuration on `ForwardContractController`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685daf58261483299916df23f317e593