### PR TITLE
Use configurable JWT secret

### DIFF
--- a/bellingham-datafutures/README.md
+++ b/bellingham-datafutures/README.md
@@ -1,0 +1,15 @@
+# Bellingham DataFutures Backend
+
+This module contains the Spring Boot API used by the platform.
+
+## Configuration
+
+The API requires a secret key for signing JSON Web Tokens. Provide the key via
+`jwt.secret` in `application.properties` or set an environment variable named
+`JWT_SECRET` when running the application.
+
+```
+jwt.secret=your-strong-secret
+```
+
+If the property is missing the application will fail to start.

--- a/bellingham-datafutures/src/main/resources/application.properties
+++ b/bellingham-datafutures/src/main/resources/application.properties
@@ -7,3 +7,6 @@ spring.datasource.password=bdf_pass
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+# === JWT Configuration ===
+jwt.secret=change-me


### PR DESCRIPTION
## Summary
- read JWT secret from `jwt.secret` property or `JWT_SECRET`
- add a placeholder property in `application.properties`
- document backend setup and the `jwt.secret` property

## Testing
- `./mvnw -q test` *(fails: could not download parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685db02d2c408329b296166cba15c96b