### PR TITLE
Add backend README

### DIFF
--- a/bellingham-datafutures/README.md
+++ b/bellingham-datafutures/README.md
@@ -13,3 +13,43 @@ jwt.secret=your-strong-secret
 ```
 
 If the property is missing the application will fail to start.
+
+## Running the application
+
+The API requires Java 17+ and a PostgreSQL instance. By default the
+datasource is configured for a local database named `bdf` using the
+credentials `bdf_user`/`bdf_pass` as defined in
+`src/main/resources/application.properties`:
+
+```
+spring.datasource.url=jdbc:postgresql://localhost:5432/bdf
+spring.datasource.username=bdf_user
+spring.datasource.password=bdf_pass
+```
+
+The following environment variables can be used to configure the runtime:
+
+- `JWT_SECRET` – secret used for signing tokens (required if
+  `jwt.secret` is not set).
+- `server.port` – optional port the API listens on. Defaults to `8080`.
+
+Start the service with the Maven wrapper:
+
+```bash
+./mvnw spring-boot:run
+```
+
+Or build a runnable jar and execute it manually:
+
+```bash
+./mvnw package
+java -jar target/datafutures-0.0.1-SNAPSHOT.jar
+```
+
+## Running tests
+
+Execute the unit tests using Maven:
+
+```bash
+./mvnw test
+```


### PR DESCRIPTION
## Summary
- document configuration and runtime settings for `bellingham-datafutures`

## Testing
- `./mvnw test` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685db1178eac8329a4f656a7405c207c