### PR TITLE
Fix 403 error when fetching contracts

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
@@ -17,7 +17,6 @@ public class ForwardContract {
     private LocalDate deliveryDate;
     private String dataDescription;
     private String termsFileName;
-    @Lob
     @Column(columnDefinition = "TEXT")
     private String agreementText;
     private String status;


### PR DESCRIPTION
## Summary
- remove `@Lob` annotation from `ForwardContract.agreementText`

The LOB mapping caused PostgreSQL to require non-autocommit mode, which produced server errors when fetching contracts.

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685e47e6a9dc83299b1ae7f3b759a68e