### PR TITLE
Add sign up feature with user-specific purchases

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
@@ -61,4 +61,22 @@ public class AuthController {
         userRepository.save(user);
         return "✅ Default user created";
     }
+
+    @PostMapping("/register")
+    public String registerUser(@RequestBody Map<String, String> creds) {
+        String username = creds.get("username");
+        String password = creds.get("password");
+        if (username == null || password == null) {
+            return "Username and password required";
+        }
+        if (userRepository.findByUsername(username).isPresent()) {
+            return "Username already exists";
+        }
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword(encoder.encode(password));
+        user.setRole("ROLE_USER");
+        userRepository.save(user);
+        return "User registered";
+    }
 }

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -41,7 +41,9 @@ public class ForwardContractController {
 
     @GetMapping("/purchased")
     public List<ForwardContract> getPurchased() {
-        return repository.findByStatus("Purchased");
+        String username = org.springframework.security.core.context.SecurityContextHolder
+                .getContext().getAuthentication().getName();
+        return repository.findByStatusAndBuyerUsername("Purchased", username);
     }
 
     @PutMapping("/{id}")
@@ -73,6 +75,9 @@ public class ForwardContractController {
                         return ResponseEntity.badRequest().<ForwardContract>build();
                     }
                     contract.setStatus("Purchased");
+                    String username = org.springframework.security.core.context.SecurityContextHolder
+                            .getContext().getAuthentication().getName();
+                    contract.setBuyerUsername(username);
                     ForwardContract saved = repository.save(contract);
                     return ResponseEntity.ok(saved);
                 })

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
@@ -20,6 +20,7 @@ public class ForwardContract {
     @Column(columnDefinition = "TEXT")
     private String agreementText;
     private String status;
+    private String buyerUsername;
 
     // Getters and setters
 
@@ -93,5 +94,13 @@ public class ForwardContract {
 
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    public String getBuyerUsername() {
+        return buyerUsername;
+    }
+
+    public void setBuyerUsername(String buyerUsername) {
+        this.buyerUsername = buyerUsername;
     }
 }

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/repository/ForwardContractRepository.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/repository/ForwardContractRepository.java
@@ -9,5 +9,7 @@ import java.util.List;
 @Repository
 public interface ForwardContractRepository extends JpaRepository<ForwardContract, Long> {
     List<ForwardContract> findByStatus(String status);
+    List<ForwardContract> findByStatusAndBuyerUsername(String status, String buyerUsername);
+    List<ForwardContract> findByBuyerUsername(String buyerUsername);
 }
 

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/security/WebSecurityConfig.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/security/WebSecurityConfig.java
@@ -55,7 +55,7 @@ public class WebSecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
-                        .requestMatchers("/api/authenticate", "/api/register-default", "/api/contracts/available").permitAll()
+                        .requestMatchers("/api/authenticate", "/api/register", "/api/register-default", "/api/contracts/available").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session

--- a/bellingham-frontend/src/App.jsx
+++ b/bellingham-frontend/src/App.jsx
@@ -5,6 +5,7 @@ import Dashboard from "./components/Dashboard";
 import Buy from "./components/Buy";
 import Sell from "./components/Sell";
 import Reports from "./components/Reports";
+import Signup from "./components/Signup";
 
 const App = () => {
     const token = localStorage.getItem("token");
@@ -16,6 +17,7 @@ const App = () => {
                 element={token ? <Dashboard /> : <Navigate to="/login" />}
             />
             <Route path="/login" element={<Login />} />
+            <Route path="/signup" element={<Signup />} />
             <Route
                 path="/buy"
                 element={token ? <Buy /> : <Navigate to="/login" />}

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
 import ContractDetailsPanel from "./ContractDetailsPanel";
+import Header from "./Header";
 
 const Buy = () => {
     const [contracts, setContracts] = useState([]);
@@ -53,6 +54,7 @@ const Buy = () => {
 
     return (
         <div className="relative p-8 text-white bg-black min-h-screen font-poppins">
+            <Header />
             <h1 className="text-3xl font-bold mb-6">Available Contracts</h1>
             {error && <p className="text-red-500 mb-4">{error}</p>}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import ContractDetailsPanel from "./ContractDetailsPanel";
+import Header from "./Header";
 
 const Dashboard = () => {
     const [contracts, setContracts] = useState([]);
@@ -40,15 +41,13 @@ const Dashboard = () => {
 
     const handleLogout = () => {
         localStorage.removeItem("token");
+        localStorage.removeItem("username");
         navigate("/login");
     };
 
     return (
         <div className="flex flex-col h-screen font-poppins bg-black text-white">
-            {/* Top Banner */}
-            <header className="bg-gray-800 p-4">
-                <h1 className="text-2xl font-bold">Bellingham Data Futures</h1>
-            </header>
+            <Header />
             <div className="flex flex-1 relative">
                 {/* Sidebar */}
                 <aside className="w-64 bg-gray-900 p-6 flex flex-col justify-between">

--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+const Header = () => {
+    const username = localStorage.getItem("username");
+    return (
+        <header className="bg-gray-800 p-4 flex justify-between items-center">
+            <h1 className="text-2xl font-bold">Bellingham Data Futures</h1>
+            {username && (
+                <span className="text-sm text-white">Logged in as: {username}</span>
+            )}
+        </header>
+    );
+};
+
+export default Header;

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -27,6 +27,7 @@ const Login = () => {
             const token = res.data.id_token;
             if (token) {
                 localStorage.setItem("token", token);
+                localStorage.setItem("username", username);
 
                 // Force full page reload to refresh state
                 window.location.href = "/";
@@ -73,6 +74,13 @@ const Login = () => {
                     className="w-full bg-blue-600 text-white p-2 rounded-lg hover:bg-blue-700"
                 >
                     Sign In
+                </button>
+                <button
+                    type="button"
+                    className="w-full mt-2 text-blue-600"
+                    onClick={() => (window.location.href = "/signup")}
+                >
+                    Create Account
                 </button>
             </form>
         </div>

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
 import ContractDetailsPanel from "./ContractDetailsPanel";
+import Header from "./Header";
 
 const Reports = () => {
     const [contracts, setContracts] = useState([]);
@@ -31,6 +32,7 @@ const Reports = () => {
 
     return (
         <div className="relative p-8 text-white bg-black min-h-screen font-poppins">
+            <Header />
             <h1 className="text-3xl font-bold mb-6">Purchased Contracts</h1>
             {error && <p className="text-red-500 mb-4">{error}</p>}
             <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import Header from "./Header";
 
 const defaultAgreement = `DATA PURCHASE AGREEMENT
 
@@ -101,6 +102,7 @@ const Sell = () => {
 
     return (
         <div className="p-8 bg-black min-h-screen text-white font-poppins">
+            <Header />
             <h1 className="text-3xl font-bold mb-6">Sell Your Data Contract</h1>
             {message && <p className="mb-4">{message}</p>}
             <form onSubmit={handleSubmit} className="space-y-6 max-w-xl">

--- a/bellingham-frontend/src/components/Signup.jsx
+++ b/bellingham-frontend/src/components/Signup.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from "react";
+import axios from "axios";
+import { useNavigate } from "react-router-dom";
+
+const Signup = () => {
+    const [username, setUsername] = useState("");
+    const [password, setPassword] = useState("");
+    const [message, setMessage] = useState("");
+    const [error, setError] = useState("");
+    const navigate = useNavigate();
+
+    const handleSignup = async (e) => {
+        e.preventDefault();
+        setError("");
+        setMessage("");
+        try {
+            await axios.post(
+                `${import.meta.env.VITE_API_BASE_URL}/api/register`,
+                { username, password }
+            );
+            setMessage("Registration successful. Please log in.");
+            setUsername("");
+            setPassword("");
+        } catch (err) {
+            console.error(err);
+            setError("Registration failed.");
+        }
+    };
+
+    return (
+        <div className="flex flex-col h-screen items-center justify-center bg-gray-100">
+            <h1 className="text-3xl font-bold mb-6 text-center">Bellingham Data Futures</h1>
+            <form onSubmit={handleSignup} className="bg-white shadow-lg rounded-2xl p-8 w-96">
+                <h2 className="text-2xl font-bold mb-4 text-center">Sign Up</h2>
+                {message && <div className="text-green-600 mb-2">{message}</div>}
+                {error && <div className="text-red-600 mb-2">{error}</div>}
+                <input
+                    type="text"
+                    placeholder="Username"
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                    className="w-full p-2 mb-4 border rounded-lg"
+                />
+                <input
+                    type="password"
+                    placeholder="Password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="w-full p-2 mb-6 border rounded-lg"
+                />
+                <button type="submit" className="w-full bg-blue-600 text-white p-2 rounded-lg hover:bg-blue-700">
+                    Register
+                </button>
+                <button
+                    type="button"
+                    className="w-full mt-2 text-blue-600"
+                    onClick={() => navigate("/login")}
+                >
+                    Back to Login
+                </button>
+            </form>
+        </div>
+    );
+};
+
+export default Signup;


### PR DESCRIPTION
## Summary
- backend: support user registration and track purchaser for contracts
- frontend: add signup page and header displaying logged-in username
- show username across screens and store in `localStorage`

## Testing
- `./mvnw -q test` *(fails: Could not resolve parent POM)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e4a3abe648329b8e2144520c94f5c