### PR TITLE
Implement extended signup fields with profile prefill

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
@@ -76,7 +76,46 @@ public class AuthController {
         user.setUsername(username);
         user.setPassword(encoder.encode(password));
         user.setRole("ROLE_USER");
+
+        user.setLegalBusinessName(creds.get("legalBusinessName"));
+        user.setName(creds.get("name"));
+        user.setCountryOfIncorporation(creds.get("countryOfIncorporation"));
+        user.setTaxId(creds.get("taxId"));
+        user.setCompanyRegistrationNumber(creds.get("companyRegistrationNumber"));
+        user.setPrimaryContactName(creds.get("primaryContactName"));
+        user.setPrimaryContactEmail(creds.get("primaryContactEmail"));
+        user.setPrimaryContactPhone(creds.get("primaryContactPhone"));
+        user.setTechnicalContactName(creds.get("technicalContactName"));
+        user.setTechnicalContactEmail(creds.get("technicalContactEmail"));
+        user.setTechnicalContactPhone(creds.get("technicalContactPhone"));
+        user.setCompanyDescription(creds.get("companyDescription"));
+
         userRepository.save(user);
         return "User registered";
+    }
+
+    @GetMapping("/profile")
+    public Map<String, Object> getProfile(Authentication authentication) {
+        String username = authentication.getName();
+        User user = userRepository.findByUsername(username).orElse(null);
+        if (user == null) {
+            return Map.of();
+        }
+        Map<String, Object> map = new HashMap<>();
+        map.put("id", user.getId());
+        map.put("username", user.getUsername());
+        map.put("legalBusinessName", user.getLegalBusinessName());
+        map.put("name", user.getName());
+        map.put("countryOfIncorporation", user.getCountryOfIncorporation());
+        map.put("taxId", user.getTaxId());
+        map.put("companyRegistrationNumber", user.getCompanyRegistrationNumber());
+        map.put("primaryContactName", user.getPrimaryContactName());
+        map.put("primaryContactEmail", user.getPrimaryContactEmail());
+        map.put("primaryContactPhone", user.getPrimaryContactPhone());
+        map.put("technicalContactName", user.getTechnicalContactName());
+        map.put("technicalContactEmail", user.getTechnicalContactEmail());
+        map.put("technicalContactPhone", user.getTechnicalContactPhone());
+        map.put("companyDescription", user.getCompanyDescription());
+        return map;
     }
 }

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
@@ -22,6 +22,19 @@ public class ForwardContract {
     private String status;
     private String buyerUsername;
 
+    private String legalBusinessName;
+    private String name;
+    private String countryOfIncorporation;
+    private String taxId;
+    private String companyRegistrationNumber;
+    private String primaryContactName;
+    private String primaryContactEmail;
+    private String primaryContactPhone;
+    private String technicalContactName;
+    private String technicalContactEmail;
+    private String technicalContactPhone;
+    private String companyDescription;
+
     // Getters and setters
 
     public Long getId() {
@@ -102,5 +115,101 @@ public class ForwardContract {
 
     public void setBuyerUsername(String buyerUsername) {
         this.buyerUsername = buyerUsername;
+    }
+
+    public String getLegalBusinessName() {
+        return legalBusinessName;
+    }
+
+    public void setLegalBusinessName(String legalBusinessName) {
+        this.legalBusinessName = legalBusinessName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCountryOfIncorporation() {
+        return countryOfIncorporation;
+    }
+
+    public void setCountryOfIncorporation(String countryOfIncorporation) {
+        this.countryOfIncorporation = countryOfIncorporation;
+    }
+
+    public String getTaxId() {
+        return taxId;
+    }
+
+    public void setTaxId(String taxId) {
+        this.taxId = taxId;
+    }
+
+    public String getCompanyRegistrationNumber() {
+        return companyRegistrationNumber;
+    }
+
+    public void setCompanyRegistrationNumber(String companyRegistrationNumber) {
+        this.companyRegistrationNumber = companyRegistrationNumber;
+    }
+
+    public String getPrimaryContactName() {
+        return primaryContactName;
+    }
+
+    public void setPrimaryContactName(String primaryContactName) {
+        this.primaryContactName = primaryContactName;
+    }
+
+    public String getPrimaryContactEmail() {
+        return primaryContactEmail;
+    }
+
+    public void setPrimaryContactEmail(String primaryContactEmail) {
+        this.primaryContactEmail = primaryContactEmail;
+    }
+
+    public String getPrimaryContactPhone() {
+        return primaryContactPhone;
+    }
+
+    public void setPrimaryContactPhone(String primaryContactPhone) {
+        this.primaryContactPhone = primaryContactPhone;
+    }
+
+    public String getTechnicalContactName() {
+        return technicalContactName;
+    }
+
+    public void setTechnicalContactName(String technicalContactName) {
+        this.technicalContactName = technicalContactName;
+    }
+
+    public String getTechnicalContactEmail() {
+        return technicalContactEmail;
+    }
+
+    public void setTechnicalContactEmail(String technicalContactEmail) {
+        this.technicalContactEmail = technicalContactEmail;
+    }
+
+    public String getTechnicalContactPhone() {
+        return technicalContactPhone;
+    }
+
+    public void setTechnicalContactPhone(String technicalContactPhone) {
+        this.technicalContactPhone = technicalContactPhone;
+    }
+
+    public String getCompanyDescription() {
+        return companyDescription;
+    }
+
+    public void setCompanyDescription(String companyDescription) {
+        this.companyDescription = companyDescription;
     }
 }

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/User.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/User.java
@@ -14,6 +14,19 @@ public class User {
     private String password;
     private String role = "ROLE_USER";
 
+    private String legalBusinessName;
+    private String name;
+    private String countryOfIncorporation;
+    private String taxId;
+    private String companyRegistrationNumber;
+    private String primaryContactName;
+    private String primaryContactEmail;
+    private String primaryContactPhone;
+    private String technicalContactName;
+    private String technicalContactEmail;
+    private String technicalContactPhone;
+    private String companyDescription;
+
     // Getters and Setters
 
     public Long getId() {
@@ -46,5 +59,101 @@ public class User {
 
     public void setRole(String role) {
         this.role = role;
+    }
+
+    public String getLegalBusinessName() {
+        return legalBusinessName;
+    }
+
+    public void setLegalBusinessName(String legalBusinessName) {
+        this.legalBusinessName = legalBusinessName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCountryOfIncorporation() {
+        return countryOfIncorporation;
+    }
+
+    public void setCountryOfIncorporation(String countryOfIncorporation) {
+        this.countryOfIncorporation = countryOfIncorporation;
+    }
+
+    public String getTaxId() {
+        return taxId;
+    }
+
+    public void setTaxId(String taxId) {
+        this.taxId = taxId;
+    }
+
+    public String getCompanyRegistrationNumber() {
+        return companyRegistrationNumber;
+    }
+
+    public void setCompanyRegistrationNumber(String companyRegistrationNumber) {
+        this.companyRegistrationNumber = companyRegistrationNumber;
+    }
+
+    public String getPrimaryContactName() {
+        return primaryContactName;
+    }
+
+    public void setPrimaryContactName(String primaryContactName) {
+        this.primaryContactName = primaryContactName;
+    }
+
+    public String getPrimaryContactEmail() {
+        return primaryContactEmail;
+    }
+
+    public void setPrimaryContactEmail(String primaryContactEmail) {
+        this.primaryContactEmail = primaryContactEmail;
+    }
+
+    public String getPrimaryContactPhone() {
+        return primaryContactPhone;
+    }
+
+    public void setPrimaryContactPhone(String primaryContactPhone) {
+        this.primaryContactPhone = primaryContactPhone;
+    }
+
+    public String getTechnicalContactName() {
+        return technicalContactName;
+    }
+
+    public void setTechnicalContactName(String technicalContactName) {
+        this.technicalContactName = technicalContactName;
+    }
+
+    public String getTechnicalContactEmail() {
+        return technicalContactEmail;
+    }
+
+    public void setTechnicalContactEmail(String technicalContactEmail) {
+        this.technicalContactEmail = technicalContactEmail;
+    }
+
+    public String getTechnicalContactPhone() {
+        return technicalContactPhone;
+    }
+
+    public void setTechnicalContactPhone(String technicalContactPhone) {
+        this.technicalContactPhone = technicalContactPhone;
+    }
+
+    public String getCompanyDescription() {
+        return companyDescription;
+    }
+
+    public void setCompanyDescription(String companyDescription) {
+        this.companyDescription = companyDescription;
     }
 }

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Header from "./Header";
 
 const defaultAgreement = `DATA PURCHASE AGREEMENT
@@ -54,6 +54,18 @@ const Sell = () => {
     });
     const [snippet, setSnippet] = useState(null);
     const [message, setMessage] = useState("");
+    const [profile, setProfile] = useState(null);
+
+    useEffect(() => {
+        const token = localStorage.getItem("token");
+        if (!token) return;
+        axios
+            .get(`${import.meta.env.VITE_API_BASE_URL}/api/profile`, {
+                headers: { Authorization: `Bearer ${token}` },
+            })
+            .then((res) => setProfile(res.data))
+            .catch((err) => console.error(err));
+    }, []);
 
     const handleChange = (e) => {
         setForm({ ...form, [e.target.name]: e.target.value });
@@ -74,6 +86,19 @@ const Sell = () => {
             price: parseFloat(form.price || 0),
             dataDescription: form.dataDescription,
             agreementText: form.agreementText,
+            seller: profile?.legalBusinessName || "",
+            legalBusinessName: profile?.legalBusinessName,
+            name: profile?.name,
+            countryOfIncorporation: profile?.countryOfIncorporation,
+            taxId: profile?.taxId,
+            companyRegistrationNumber: profile?.companyRegistrationNumber,
+            primaryContactName: profile?.primaryContactName,
+            primaryContactEmail: profile?.primaryContactEmail,
+            primaryContactPhone: profile?.primaryContactPhone,
+            technicalContactName: profile?.technicalContactName,
+            technicalContactEmail: profile?.technicalContactEmail,
+            technicalContactPhone: profile?.technicalContactPhone,
+            companyDescription: profile?.companyDescription,
         };
         if (snippet) {
             data.termsFileName = snippet.name;

--- a/bellingham-frontend/src/components/Signup.jsx
+++ b/bellingham-frontend/src/components/Signup.jsx
@@ -3,8 +3,22 @@ import axios from "axios";
 import { useNavigate } from "react-router-dom";
 
 const Signup = () => {
-    const [username, setUsername] = useState("");
-    const [password, setPassword] = useState("");
+    const [form, setForm] = useState({
+        username: "",
+        password: "",
+        legalBusinessName: "",
+        name: "",
+        countryOfIncorporation: "",
+        taxId: "",
+        companyRegistrationNumber: "",
+        primaryContactName: "",
+        primaryContactEmail: "",
+        primaryContactPhone: "",
+        technicalContactName: "",
+        technicalContactEmail: "",
+        technicalContactPhone: "",
+        companyDescription: "",
+    });
     const [message, setMessage] = useState("");
     const [error, setError] = useState("");
     const navigate = useNavigate();
@@ -16,11 +30,25 @@ const Signup = () => {
         try {
             await axios.post(
                 `${import.meta.env.VITE_API_BASE_URL}/api/register`,
-                { username, password }
+                form
             );
             setMessage("Registration successful. Please log in.");
-            setUsername("");
-            setPassword("");
+            setForm({
+                username: "",
+                password: "",
+                legalBusinessName: "",
+                name: "",
+                countryOfIncorporation: "",
+                taxId: "",
+                companyRegistrationNumber: "",
+                primaryContactName: "",
+                primaryContactEmail: "",
+                primaryContactPhone: "",
+                technicalContactName: "",
+                technicalContactEmail: "",
+                technicalContactPhone: "",
+                companyDescription: "",
+            });
         } catch (err) {
             console.error(err);
             setError("Registration failed.");
@@ -37,15 +65,99 @@ const Signup = () => {
                 <input
                     type="text"
                     placeholder="Username"
-                    value={username}
-                    onChange={(e) => setUsername(e.target.value)}
+                    value={form.username}
+                    onChange={(e) => setForm({ ...form, username: e.target.value })}
                     className="w-full p-2 mb-4 border rounded-lg"
                 />
                 <input
                     type="password"
                     placeholder="Password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
+                    value={form.password}
+                    onChange={(e) => setForm({ ...form, password: e.target.value })}
+                    className="w-full p-2 mb-4 border rounded-lg"
+                />
+                <input
+                    type="text"
+                    placeholder="Legal Business Name"
+                    value={form.legalBusinessName}
+                    onChange={(e) => setForm({ ...form, legalBusinessName: e.target.value })}
+                    className="w-full p-2 mb-4 border rounded-lg"
+                />
+                <input
+                    type="text"
+                    placeholder="Your Name"
+                    value={form.name}
+                    onChange={(e) => setForm({ ...form, name: e.target.value })}
+                    className="w-full p-2 mb-4 border rounded-lg"
+                />
+                <input
+                    type="text"
+                    placeholder="Country of Incorporation"
+                    value={form.countryOfIncorporation}
+                    onChange={(e) => setForm({ ...form, countryOfIncorporation: e.target.value })}
+                    className="w-full p-2 mb-4 border rounded-lg"
+                />
+                <input
+                    type="text"
+                    placeholder="UK or US Tax ID Code"
+                    value={form.taxId}
+                    onChange={(e) => setForm({ ...form, taxId: e.target.value })}
+                    className="w-full p-2 mb-4 border rounded-lg"
+                />
+                <input
+                    type="text"
+                    placeholder="Company Registration Number"
+                    value={form.companyRegistrationNumber}
+                    onChange={(e) => setForm({ ...form, companyRegistrationNumber: e.target.value })}
+                    className="w-full p-2 mb-4 border rounded-lg"
+                />
+                <input
+                    type="text"
+                    placeholder="Primary Contact Name"
+                    value={form.primaryContactName}
+                    onChange={(e) => setForm({ ...form, primaryContactName: e.target.value })}
+                    className="w-full p-2 mb-4 border rounded-lg"
+                />
+                <input
+                    type="email"
+                    placeholder="Primary Contact Email"
+                    value={form.primaryContactEmail}
+                    onChange={(e) => setForm({ ...form, primaryContactEmail: e.target.value })}
+                    className="w-full p-2 mb-4 border rounded-lg"
+                />
+                <input
+                    type="text"
+                    placeholder="Primary Contact Phone"
+                    value={form.primaryContactPhone}
+                    onChange={(e) => setForm({ ...form, primaryContactPhone: e.target.value })}
+                    className="w-full p-2 mb-4 border rounded-lg"
+                />
+                <input
+                    type="text"
+                    placeholder="Technical Contact Name"
+                    value={form.technicalContactName}
+                    onChange={(e) => setForm({ ...form, technicalContactName: e.target.value })}
+                    className="w-full p-2 mb-4 border rounded-lg"
+                />
+                <input
+                    type="email"
+                    placeholder="Technical Contact Email"
+                    value={form.technicalContactEmail}
+                    onChange={(e) => setForm({ ...form, technicalContactEmail: e.target.value })}
+                    className="w-full p-2 mb-4 border rounded-lg"
+                />
+                <input
+                    type="text"
+                    placeholder="Technical Contact Phone"
+                    value={form.technicalContactPhone}
+                    onChange={(e) => setForm({ ...form, technicalContactPhone: e.target.value })}
+                    className="w-full p-2 mb-4 border rounded-lg"
+                />
+                <input
+                    type="text"
+                    placeholder="One line company description"
+                    value={form.companyDescription}
+                    onChange={(e) => setForm({ ...form, companyDescription: e.target.value })}
                     className="w-full p-2 mb-6 border rounded-lg"
                 />
                 <button type="submit" className="w-full bg-blue-600 text-white p-2 rounded-lg hover:bg-blue-700">


### PR DESCRIPTION
## Summary
- extend `User` model with business and contact fields
- save those fields during registration and expose a `/profile` endpoint
- include business details in `ForwardContract`
- fetch user profile in the Sell page and send details when creating contracts
- expand Signup form to capture full business information

## Testing
- `./mvnw test` *(fails: Network is unreachable)*
- `npm install --ignore-scripts`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685fc278e8fc8329a7c6daf0e37300f7