### PR TITLE
Auto-fill seller details on contract create

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -2,6 +2,9 @@ package com.bellingham.datafutures.controller;
 
 import com.bellingham.datafutures.model.ForwardContract;
 import com.bellingham.datafutures.repository.ForwardContractRepository;
+import com.bellingham.datafutures.repository.UserRepository;
+import com.bellingham.datafutures.model.User;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +18,9 @@ public class ForwardContractController {
 
     @Autowired
     private ForwardContractRepository repository;
+
+    @Autowired
+    private UserRepository userRepository;
 
     @GetMapping
     public List<ForwardContract> getAll() {
@@ -31,7 +37,27 @@ public class ForwardContractController {
     @PostMapping
     public ForwardContract create(@RequestBody ForwardContract contract) {
         contract.setStatus("Available");
+
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        userRepository.findByUsername(username).ifPresent(user -> fillSellerDetails(contract, user));
+
         return repository.save(contract);
+    }
+
+    private void fillSellerDetails(ForwardContract contract, User user) {
+        contract.setSeller(user.getLegalBusinessName());
+        contract.setLegalBusinessName(user.getLegalBusinessName());
+        contract.setName(user.getName());
+        contract.setCountryOfIncorporation(user.getCountryOfIncorporation());
+        contract.setTaxId(user.getTaxId());
+        contract.setCompanyRegistrationNumber(user.getCompanyRegistrationNumber());
+        contract.setPrimaryContactName(user.getPrimaryContactName());
+        contract.setPrimaryContactEmail(user.getPrimaryContactEmail());
+        contract.setPrimaryContactPhone(user.getPrimaryContactPhone());
+        contract.setTechnicalContactName(user.getTechnicalContactName());
+        contract.setTechnicalContactEmail(user.getTechnicalContactEmail());
+        contract.setTechnicalContactPhone(user.getTechnicalContactPhone());
+        contract.setCompanyDescription(user.getCompanyDescription());
     }
 
     @GetMapping("/available")

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -86,19 +86,6 @@ const Sell = () => {
             price: parseFloat(form.price || 0),
             dataDescription: form.dataDescription,
             agreementText: form.agreementText,
-            seller: profile?.legalBusinessName || "",
-            legalBusinessName: profile?.legalBusinessName,
-            name: profile?.name,
-            countryOfIncorporation: profile?.countryOfIncorporation,
-            taxId: profile?.taxId,
-            companyRegistrationNumber: profile?.companyRegistrationNumber,
-            primaryContactName: profile?.primaryContactName,
-            primaryContactEmail: profile?.primaryContactEmail,
-            primaryContactPhone: profile?.primaryContactPhone,
-            technicalContactName: profile?.technicalContactName,
-            technicalContactEmail: profile?.technicalContactEmail,
-            technicalContactPhone: profile?.technicalContactPhone,
-            companyDescription: profile?.companyDescription,
         };
         if (snippet) {
             data.termsFileName = snippet.name;


### PR DESCRIPTION
## Summary
- auto-populate seller information on the backend when a contract is created
- remove seller data from the frontend request

## Testing
- `./mvnw -q test` *(fails: could not resolve Spring parent POM)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685fc6d815e08329a168e899486803fb