### PR TITLE
Add account page

### DIFF
--- a/bellingham-frontend/src/App.jsx
+++ b/bellingham-frontend/src/App.jsx
@@ -6,6 +6,7 @@ import Buy from "./components/Buy";
 import Sell from "./components/Sell";
 import Reports from "./components/Reports";
 import Signup from "./components/Signup";
+import Account from "./components/Account";
 
 const App = () => {
     const token = localStorage.getItem("token");
@@ -29,6 +30,10 @@ const App = () => {
             <Route
                 path="/reports"
                 element={token ? <Reports /> : <Navigate to="/login" />}
+            />
+            <Route
+                path="/account"
+                element={token ? <Account /> : <Navigate to="/login" />}
             />
         </Routes>
     );

--- a/bellingham-frontend/src/components/Account.jsx
+++ b/bellingham-frontend/src/components/Account.jsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import Header from "./Header";
+import { useNavigate } from "react-router-dom";
+
+const Account = () => {
+    const [profile, setProfile] = useState(null);
+    const [error, setError] = useState("");
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        const fetchProfile = async () => {
+            try {
+                const token = localStorage.getItem("token");
+                if (!token) {
+                    navigate("/login");
+                    return;
+                }
+                const res = await axios.get(
+                    `${import.meta.env.VITE_API_BASE_URL}/api/profile`,
+                    { headers: { Authorization: `Bearer ${token}` } }
+                );
+                setProfile(res.data);
+            } catch (err) {
+                console.error(err);
+                setError("Failed to load profile");
+            }
+        };
+        fetchProfile();
+    }, [navigate]);
+
+    if (error) {
+        return (
+            <div className="p-8 bg-black min-h-screen text-white font-poppins">
+                <Header />
+                <p className="text-red-500">{error}</p>
+            </div>
+        );
+    }
+
+    if (!profile) {
+        return (
+            <div className="p-8 bg-black min-h-screen text-white font-poppins">
+                <Header />
+                <p>Loading...</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="p-8 bg-black min-h-screen text-white font-poppins">
+            <Header />
+            <h1 className="text-3xl font-bold mb-6">Account Details</h1>
+            <div className="space-y-2">
+                <p><strong>Username:</strong> {profile.username}</p>
+                <p><strong>Legal Business Name:</strong> {profile.legalBusinessName}</p>
+                <p><strong>Name:</strong> {profile.name}</p>
+                <p><strong>Country of Incorporation:</strong> {profile.countryOfIncorporation}</p>
+                <p><strong>Tax ID:</strong> {profile.taxId}</p>
+                <p><strong>Company Registration Number:</strong> {profile.companyRegistrationNumber}</p>
+                <p><strong>Primary Contact Name:</strong> {profile.primaryContactName}</p>
+                <p><strong>Primary Contact Email:</strong> {profile.primaryContactEmail}</p>
+                <p><strong>Primary Contact Phone:</strong> {profile.primaryContactPhone}</p>
+                <p><strong>Technical Contact Name:</strong> {profile.technicalContactName}</p>
+                <p><strong>Technical Contact Email:</strong> {profile.technicalContactEmail}</p>
+                <p><strong>Technical Contact Phone:</strong> {profile.technicalContactPhone}</p>
+                <p><strong>Company Description:</strong> {profile.companyDescription}</p>
+            </div>
+        </div>
+    );
+};
+
+export default Account;

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -83,7 +83,7 @@ const Dashboard = () => {
                             Settings
                         </button>
                         <button
-                            onClick={() => alert("Account screen not implemented yet")}
+                            onClick={() => navigate("/account")}
                             className="text-left hover:bg-gray-700 px-4 py-2 rounded"
                         >
                             Account

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import Header from "./Header";
 
 const defaultAgreement = `DATA PURCHASE AGREEMENT
@@ -54,18 +54,6 @@ const Sell = () => {
     });
     const [snippet, setSnippet] = useState(null);
     const [message, setMessage] = useState("");
-    const [profile, setProfile] = useState(null);
-
-    useEffect(() => {
-        const token = localStorage.getItem("token");
-        if (!token) return;
-        axios
-            .get(`${import.meta.env.VITE_API_BASE_URL}/api/profile`, {
-                headers: { Authorization: `Bearer ${token}` },
-            })
-            .then((res) => setProfile(res.data))
-            .catch((err) => console.error(err));
-    }, []);
 
     const handleChange = (e) => {
         setForm({ ...form, [e.target.name]: e.target.value });


### PR DESCRIPTION
## Summary
- create Account component to display profile information
- wire `/account` route
- hook up sidebar Account button
- cleanup Sell component and remove unused code

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685fc8d37b2c8329b2a461e2aab5134f