### PR TITLE
Update login style

### DIFF
--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -46,14 +46,17 @@ const Login = () => {
     };
 
     return (
-        <div className="flex flex-col h-screen items-center justify-center bg-gray-100">
-            <img src={LoginImage} alt="Login logo" className="w-48 mb-4" />
-            <h1 className="text-3xl font-bold mb-6 text-center">
+        <div
+            className="relative flex flex-col items-center justify-center h-screen bg-cover bg-center"
+            style={{ backgroundImage: `url(${LoginImage})` }}
+        >
+            <div className="absolute inset-0 bg-black opacity-60" />
+            <h1 className="relative z-10 text-3xl font-bold mb-6 text-center text-white">
                 Bellingham Data Futures
             </h1>
             <form
                 onSubmit={handleLogin}
-                className="bg-white shadow-lg rounded-2xl p-8 w-96"
+                className="relative z-10 bg-white bg-opacity-90 shadow-lg rounded-2xl p-8 w-96"
             >
                 <h2 className="text-2xl font-bold mb-4 text-center">Login</h2>
                 {error && <div className="text-red-600 mb-2">{error}</div>}

--- a/bellingham-frontend/src/components/Signup.jsx
+++ b/bellingham-frontend/src/components/Signup.jsx
@@ -56,7 +56,7 @@ const Signup = () => {
     };
 
     return (
-        <div className="flex flex-col h-screen items-center justify-center bg-gray-100">
+        <div className="flex flex-col h-screen items-center justify-center bg-black text-white font-poppins">
             <h1 className="text-3xl font-bold mb-6 text-center">Bellingham Data Futures</h1>
             <form onSubmit={handleSignup} className="bg-white shadow-lg rounded-2xl p-8 w-96">
                 <h2 className="text-2xl font-bold mb-4 text-center">Sign Up</h2>

--- a/bellingham-frontend/src/index.css
+++ b/bellingham-frontend/src/index.css
@@ -30,6 +30,8 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  background-color: #000;
+  color: #fff;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- make login background full-screen with form overlay
- use consistent black background on signup screen
- ensure body defaults to black in global css

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686691663f348329880415f230c6acfb