### PR TITLE
Improve auth layout and persistent logo

### DIFF
--- a/bellingham-frontend/src/App.jsx
+++ b/bellingham-frontend/src/App.jsx
@@ -7,11 +7,13 @@ import Sell from "./components/Sell";
 import Reports from "./components/Reports";
 import Signup from "./components/Signup";
 import Account from "./components/Account";
+import Logo from "./components/Logo";
 
 const App = () => {
     const token = localStorage.getItem("token");
 
     return (
+        <>
         <Routes>
             <Route
                 path="/"
@@ -36,6 +38,8 @@ const App = () => {
                 element={token ? <Account /> : <Navigate to="/login" />}
             />
         </Routes>
+        <Logo />
+        </>
     );
 };
 

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -47,7 +47,7 @@ const Login = () => {
 
     return (
         <div
-            className="relative flex flex-col items-center justify-start pt-64 h-screen"
+            className="relative flex flex-col items-center justify-center h-screen"
             style={{
                 backgroundImage: `url(${LoginImage})`,
                 backgroundSize: "150px",

--- a/bellingham-frontend/src/components/Logo.jsx
+++ b/bellingham-frontend/src/components/Logo.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import logoImage from "../assets/login.png";
+
+const Logo = () => (
+    <img
+        src={logoImage}
+        alt="Logo"
+        className="fixed bottom-4 right-4 w-24 h-24 pointer-events-none"
+    />
+);
+
+export default Logo;


### PR DESCRIPTION
## Summary
- center login form
- add a persistent logo component
- render logo from `App`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866ab1878008329a5766dc8d0a6ed1c