### PR TITLE
Shift logo on login page

### DIFF
--- a/bellingham-frontend/src/components/Logo.jsx
+++ b/bellingham-frontend/src/components/Logo.jsx
@@ -1,12 +1,20 @@
 import React from "react";
 import logoImage from "../assets/login.png";
 
-const Logo = () => (
-    <img
-        src={logoImage}
-        alt="Logo"
-        className="fixed bottom-4 right-4 w-24 h-24 pointer-events-none"
-    />
-);
+const Logo = () => {
+    const style =
+        window.location.pathname === "/login"
+            ? { right: "calc(1rem + 10px)" }
+            : {};
+
+    return (
+        <img
+            src={logoImage}
+            alt="Logo"
+            className="fixed bottom-4 right-4 w-24 h-24 pointer-events-none"
+            style={style}
+        />
+    );
+};
 
 export default Logo;


### PR DESCRIPTION
## Summary
- update Logo component to offset right position when the location path is `/login`

## Testing
- `npm run lint`
- `./mvnw -q test` *(fails: Could not resolve Spring parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6866adbc0c2c8329a08edea8e2b98bb6