### PR TITLE
Replace headers with logo

### DIFF
--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -1,10 +1,15 @@
 import React from "react";
+import logoImage from "../assets/login.png";
 
 const Header = () => {
     const username = localStorage.getItem("username");
     return (
         <header className="bg-gray-800 p-4 flex justify-between items-center">
-            <h1 className="text-2xl font-bold">Bellingham Data Futures</h1>
+            <img
+                src={logoImage}
+                alt="Bellingham Data Futures logo"
+                className="h-24 w-24"
+            />
             {username && (
                 <span className="text-sm text-white">Logged in as: {username}</span>
             )}

--- a/bellingham-frontend/src/components/Signup.jsx
+++ b/bellingham-frontend/src/components/Signup.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
+import logoImage from "../assets/login.png";
 
 const Signup = () => {
     const [form, setForm] = useState({
@@ -57,7 +58,11 @@ const Signup = () => {
 
     return (
         <div className="flex flex-col h-screen items-center justify-center bg-black text-white font-poppins">
-            <h1 className="text-3xl font-bold mb-6 text-center">Bellingham Data Futures</h1>
+            <img
+                src={logoImage}
+                alt="Bellingham Data Futures logo"
+                className="h-24 w-24 mb-6"
+            />
             <form onSubmit={handleSignup} className="bg-white shadow-lg rounded-2xl p-8 w-96">
                 <h2 className="text-2xl font-bold mb-4 text-center">Sign Up</h2>
                 {message && <div className="text-green-600 mb-2">{message}</div>}


### PR DESCRIPTION
## Summary
- show the Bellingham Data Futures logo in the header
- show the same sized logo on the signup page

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d72bbca8832984f9f5a7ce9a61ca