### PR TITLE
Standardize logo sizes

### DIFF
--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -8,7 +8,7 @@ const Header = () => {
             <img
                 src={logoImage}
                 alt="Bellingham Data Futures logo"
-                className="h-8"
+                className="h-[150px] w-[150px]"
             />
             {username && (
                 <span className="text-sm text-white">Logged in as: {username}</span>

--- a/bellingham-frontend/src/components/Logo.jsx
+++ b/bellingham-frontend/src/components/Logo.jsx
@@ -11,7 +11,7 @@ const Logo = () => {
         <img
             src={logoImage}
             alt="Logo"
-            className="fixed bottom-4 right-4 w-24 h-24 pointer-events-none"
+            className="fixed bottom-4 right-4 w-[150px] h-[150px] pointer-events-none"
             style={style}
         />
     );

--- a/bellingham-frontend/src/components/Signup.jsx
+++ b/bellingham-frontend/src/components/Signup.jsx
@@ -61,7 +61,7 @@ const Signup = () => {
             <img
                 src={logoImage}
                 alt="Bellingham Data Futures logo"
-                className="h-12 mb-6"
+                className="h-[150px] w-[150px] mb-6"
             />
             <form onSubmit={handleSignup} className="bg-white shadow-lg rounded-2xl p-8 w-96">
                 <h2 className="text-2xl font-bold mb-4 text-center">Sign Up</h2>


### PR DESCRIPTION
## Summary
- enlarge header logo
- enlarge signup logo
- enlarge floating logo so they're all the same size as login

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c599923c8329b0e10fef91d594ef