### PR TITLE
Fix home screen contract list

### DIFF
--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -24,7 +24,7 @@ const Dashboard = () => {
                     ? { headers: { Authorization: `Bearer ${token}` } }
                     : {};
                 const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts`,
+                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/available`,
                     config
                 );
 


### PR DESCRIPTION
## Summary
- fetch only available contracts on Dashboard

## Testing
- `npm run lint`
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6867ff4ccffc83299a4daceb3a4950ed