### PR TITLE
Add persistent navigation sidebar

### DIFF
--- a/bellingham-frontend/src/components/Account.jsx
+++ b/bellingham-frontend/src/components/Account.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
 import Header from "./Header";
+import Sidebar from "./Sidebar";
 import { useNavigate } from "react-router-dom";
 
 const Account = () => {
@@ -34,18 +35,28 @@ const Account = () => {
 
     if (error) {
         return (
-            <div className="p-8 bg-black min-h-screen text-white font-poppins">
+            <div className="flex flex-col min-h-screen font-poppins bg-black text-white">
                 <Header />
-                <p className="text-red-500">{error}</p>
+                <div className="flex flex-1">
+                    <Sidebar onLogout={handleLogout} />
+                    <main className="flex-1 p-8">
+                        <p className="text-red-500">{error}</p>
+                    </main>
+                </div>
             </div>
         );
     }
 
     if (!profile) {
         return (
-            <div className="p-8 bg-black min-h-screen text-white font-poppins">
+            <div className="flex flex-col min-h-screen font-poppins bg-black text-white">
                 <Header />
-                <p>Loading...</p>
+                <div className="flex flex-1">
+                    <Sidebar onLogout={handleLogout} />
+                    <main className="flex-1 p-8">
+                        <p>Loading...</p>
+                    </main>
+                </div>
             </div>
         );
     }
@@ -70,12 +81,21 @@ const Account = () => {
         }
     };
 
+    const handleLogout = () => {
+        localStorage.removeItem("token");
+        localStorage.removeItem("username");
+        navigate("/login");
+    };
+
     return (
-        <div className="p-8 bg-black min-h-screen text-white font-poppins">
+        <div className="flex flex-col min-h-screen font-poppins bg-black text-white">
             <Header />
-            <h1 className="text-3xl font-bold mb-6">Account Details</h1>
-            {editing ? (
-                <div className="space-y-2">
+            <div className="flex flex-1 relative gap-6">
+                <Sidebar onLogout={handleLogout} />
+                <main className="flex-1 p-8">
+                    <h1 className="text-3xl font-bold mb-6">Account Details</h1>
+                    {editing ? (
+                        <div className="space-y-2">
                     <p><strong>Username:</strong> {profile.username}</p>
                     <input
                         className="w-full p-2 bg-gray-800 rounded"
@@ -202,6 +222,8 @@ const Account = () => {
                     </button>
                 </div>
             )}
+                </main>
+            </div>
         </div>
     );
 };

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -4,8 +4,11 @@ import React, { useEffect, useState } from "react";
 import axios from "axios";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import Header from "./Header";
+import Sidebar from "./Sidebar";
+import { useNavigate } from "react-router-dom";
 
 const Buy = () => {
+    const navigate = useNavigate();
     const [contracts, setContracts] = useState([]);
     const [error, setError] = useState("");
     const [selectedContract, setSelectedContract] = useState(null);
@@ -52,35 +55,46 @@ const Buy = () => {
         }
     };
 
+    const handleLogout = () => {
+        localStorage.removeItem("token");
+        localStorage.removeItem("username");
+        navigate("/login");
+    };
+
     return (
-        <div className="relative p-8 text-white bg-black min-h-screen font-poppins">
+        <div className="flex flex-col min-h-screen font-poppins bg-black text-white">
             <Header />
-            <h1 className="text-3xl font-bold mb-6">Available Contracts</h1>
-            {error && <p className="text-red-500 mb-4">{error}</p>}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {contracts.map((contract) => (
-                    <div
-                        key={contract.id}
-                        className="bg-gray-800 p-6 rounded shadow cursor-pointer"
-                        onClick={() => setSelectedContract(contract)}
-                    >
-                        <h2 className="text-xl font-semibold mb-2">{contract.title}</h2>
-                        <p className="text-sm text-gray-400 mb-1">Category: {contract.category}</p>
-                        <p className="text-sm text-gray-400 mb-1">End Date: {contract.deliveryDate}</p>
-                        <p className="text-sm text-gray-400 mb-4">Price: ${contract.price}</p>
-                        <button
-                            onClick={(e) => { e.stopPropagation(); handleBuy(contract.id); }}
-                            className="bg-green-600 hover:bg-green-700 px-4 py-2 rounded text-white"
-                        >
-                            Buy Contract
-                        </button>
+            <div className="flex flex-1 relative gap-6">
+                <Sidebar onLogout={handleLogout} />
+                <main className="flex-1 p-8">
+                    <h1 className="text-3xl font-bold mb-6">Available Contracts</h1>
+                    {error && <p className="text-red-500 mb-4">{error}</p>}
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {contracts.map((contract) => (
+                            <div
+                                key={contract.id}
+                                className="bg-gray-800 p-6 rounded shadow cursor-pointer"
+                                onClick={() => setSelectedContract(contract)}
+                            >
+                                <h2 className="text-xl font-semibold mb-2">{contract.title}</h2>
+                                <p className="text-sm text-gray-400 mb-1">Category: {contract.category}</p>
+                                <p className="text-sm text-gray-400 mb-1">End Date: {contract.deliveryDate}</p>
+                                <p className="text-sm text-gray-400 mb-4">Price: ${contract.price}</p>
+                                <button
+                                    onClick={(e) => { e.stopPropagation(); handleBuy(contract.id); }}
+                                    className="bg-green-600 hover:bg-green-700 px-4 py-2 rounded text-white"
+                                >
+                                    Buy Contract
+                                </button>
+                            </div>
+                        ))}
                     </div>
-                ))}
+                </main>
+                <ContractDetailsPanel
+                    contract={selectedContract}
+                    onClose={() => setSelectedContract(null)}
+                />
             </div>
-            <ContractDetailsPanel
-                contract={selectedContract}
-                onClose={() => setSelectedContract(null)}
-            />
         </div>
     );
 };

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import Header from "./Header";
+import Sidebar from "./Sidebar";
 
 const Dashboard = () => {
     const [contracts, setContracts] = useState([]);
@@ -50,52 +51,7 @@ const Dashboard = () => {
             <Header />
             <div className="flex flex-1 relative gap-6">
                 {/* Sidebar */}
-                <aside className="w-64 bg-gray-900 p-6 flex flex-col justify-between">
-                    <nav className="flex flex-col space-y-4">
-                        <button
-                            onClick={() => navigate("/")}
-                            className="text-left hover:bg-gray-700 px-4 py-2 rounded"
-                        >
-                            Home
-                        </button>
-                        <button
-                            onClick={() => navigate("/buy")}
-                            className="text-left hover:bg-gray-700 px-4 py-2 rounded"
-                        >
-                            Buy
-                        </button>
-                        <button
-                            onClick={() => navigate("/sell")}
-                            className="text-left hover:bg-gray-700 px-4 py-2 rounded"
-                        >
-                            Sell
-                        </button>
-                        <button
-                            onClick={() => navigate("/reports")}
-                            className="text-left hover:bg-gray-700 px-4 py-2 rounded"
-                        >
-                            Reports
-                        </button>
-                        <button
-                            onClick={() => alert("Settings screen not implemented yet")}
-                            className="text-left hover:bg-gray-700 px-4 py-2 rounded"
-                        >
-                            Settings
-                        </button>
-                        <button
-                            onClick={() => navigate("/account")}
-                            className="text-left hover:bg-gray-700 px-4 py-2 rounded"
-                        >
-                            Account
-                        </button>
-                    </nav>
-                    <button
-                        onClick={handleLogout}
-                        className="mt-6 bg-red-600 hover:bg-red-700 px-4 py-2 rounded text-white"
-                    >
-                        Log Out
-                    </button>
-                </aside>
+                <Sidebar onLogout={handleLogout} />
 
                 {/* Main Content */}
                 <main

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -2,8 +2,11 @@ import React, { useEffect, useState } from "react";
 import axios from "axios";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import Header from "./Header";
+import Sidebar from "./Sidebar";
+import { useNavigate } from "react-router-dom";
 
 const Reports = () => {
+    const navigate = useNavigate();
     const [contracts, setContracts] = useState([]);
     const [error, setError] = useState("");
     const [selectedContract, setSelectedContract] = useState(null);
@@ -46,12 +49,21 @@ const Reports = () => {
         }
     };
 
+    const handleLogout = () => {
+        localStorage.removeItem("token");
+        localStorage.removeItem("username");
+        navigate("/login");
+    };
+
     return (
-        <div className="relative p-8 text-white bg-black min-h-screen font-poppins">
+        <div className="flex flex-col min-h-screen font-poppins bg-black text-white">
             <Header />
-            <h1 className="text-3xl font-bold mb-6">Purchased Contracts</h1>
-            {error && <p className="text-red-500 mb-4">{error}</p>}
-            <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+            <div className="flex flex-1 relative gap-6">
+                <Sidebar onLogout={handleLogout} />
+                <main className="flex-1 p-8">
+                    <h1 className="text-3xl font-bold mb-6">Purchased Contracts</h1>
+                    {error && <p className="text-red-500 mb-4">{error}</p>}
+                    <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
                 <thead>
                     <tr className="bg-gray-700 text-left">
                         <th className="border p-2">Title</th>
@@ -87,13 +99,15 @@ const Reports = () => {
                     ))}
                 </tbody>
             </table>
-            <p className="mt-4 text-lg font-semibold">
-                Total Value: ${totalValue.toFixed(2)}
-            </p>
-            <ContractDetailsPanel
-                contract={selectedContract}
-                onClose={() => setSelectedContract(null)}
-            />
+                    <p className="mt-4 text-lg font-semibold">
+                        Total Value: ${totalValue.toFixed(2)}
+                    </p>
+                    <ContractDetailsPanel
+                        contract={selectedContract}
+                        onClose={() => setSelectedContract(null)}
+                    />
+                </main>
+            </div>
         </div>
     );
 };

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 import Header from "./Header";
+import Sidebar from "./Sidebar";
+import { useNavigate } from "react-router-dom";
 
 const defaultAgreement = `DATA PURCHASE AGREEMENT
 
@@ -45,6 +47,7 @@ Buyer: [Buyer’s Full Legal Name], a [Entity Type] with a principal place of bu
 import axios from "axios";
 
 const Sell = () => {
+    const navigate = useNavigate();
     const [form, setForm] = useState({
         deliveryDate: "",
         title: "",
@@ -100,12 +103,21 @@ const Sell = () => {
         }
     };
 
+    const handleLogout = () => {
+        localStorage.removeItem("token");
+        localStorage.removeItem("username");
+        navigate("/login");
+    };
+
     return (
-        <div className="p-8 bg-black min-h-screen text-white font-poppins">
+        <div className="flex flex-col min-h-screen font-poppins bg-black text-white">
             <Header />
-            <h1 className="text-3xl font-bold mb-6">Sell Your Data Contract</h1>
-            {message && <p className="mb-4">{message}</p>}
-            <form onSubmit={handleSubmit} className="space-y-6 max-w-xl">
+            <div className="flex flex-1 relative gap-6">
+                <Sidebar onLogout={handleLogout} />
+                <main className="flex-1 p-8">
+                    <h1 className="text-3xl font-bold mb-6">Sell Your Data Contract</h1>
+                    {message && <p className="mb-4">{message}</p>}
+                    <form onSubmit={handleSubmit} className="space-y-6 max-w-xl">
                 <div>
                     <label>Delivery Date</label>
                     <input
@@ -173,6 +185,8 @@ const Sell = () => {
                     Submit Contract
                 </button>
             </form>
+                </main>
+            </div>
         </div>
     );
 };

--- a/bellingham-frontend/src/components/Sidebar.jsx
+++ b/bellingham-frontend/src/components/Sidebar.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+const Sidebar = ({ onLogout }) => {
+    const navigate = useNavigate();
+    return (
+        <aside className="w-64 bg-gray-900 p-6 flex flex-col justify-between">
+            <nav className="flex flex-col space-y-4">
+                <button
+                    onClick={() => navigate("/")}
+                    className="text-left hover:bg-gray-700 px-4 py-2 rounded"
+                >
+                    Home
+                </button>
+                <button
+                    onClick={() => navigate("/buy")}
+                    className="text-left hover:bg-gray-700 px-4 py-2 rounded"
+                >
+                    Buy
+                </button>
+                <button
+                    onClick={() => navigate("/sell")}
+                    className="text-left hover:bg-gray-700 px-4 py-2 rounded"
+                >
+                    Sell
+                </button>
+                <button
+                    onClick={() => navigate("/reports")}
+                    className="text-left hover:bg-gray-700 px-4 py-2 rounded"
+                >
+                    Reports
+                </button>
+                <button
+                    onClick={() => alert("Settings screen not implemented yet")}
+                    className="text-left hover:bg-gray-700 px-4 py-2 rounded"
+                >
+                    Settings
+                </button>
+                <button
+                    onClick={() => navigate("/account")}
+                    className="text-left hover:bg-gray-700 px-4 py-2 rounded"
+                >
+                    Account
+                </button>
+            </nav>
+            {onLogout && (
+                <button
+                    onClick={onLogout}
+                    className="mt-6 bg-red-600 hover:bg-red-700 px-4 py-2 rounded text-white"
+                >
+                    Log Out
+                </button>
+            )}
+        </aside>
+    );
+};
+
+export default Sidebar;


### PR DESCRIPTION
## Summary
- create `Sidebar` navigation component
- reuse new `Sidebar` in Dashboard, Buy, Sell, Reports and Account pages
- update early return states to include navigation bar

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686804a7f2d0832985f9f035e7421731