### PR TITLE
Fix account page crash

### DIFF
--- a/bellingham-frontend/src/components/Account.jsx
+++ b/bellingham-frontend/src/components/Account.jsx
@@ -11,6 +11,12 @@ const Account = () => {
     const [formData, setFormData] = useState({});
     const navigate = useNavigate();
 
+    const handleLogout = () => {
+        localStorage.removeItem("token");
+        localStorage.removeItem("username");
+        navigate("/login");
+    };
+
     useEffect(() => {
         const fetchProfile = async () => {
             try {
@@ -79,12 +85,6 @@ const Account = () => {
             console.error(err);
             setError("Failed to save profile");
         }
-    };
-
-    const handleLogout = () => {
-        localStorage.removeItem("token");
-        localStorage.removeItem("username");
-        navigate("/login");
     };
 
     return (


### PR DESCRIPTION
## Summary
- define `handleLogout` before any early returns in `Account.jsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686806acc44c8329a62366d60e5bb586