### PR TITLE
Add searchable table to buy contracts

### DIFF
--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -12,6 +12,10 @@ const Buy = () => {
     const [contracts, setContracts] = useState([]);
     const [error, setError] = useState("");
     const [selectedContract, setSelectedContract] = useState(null);
+    const [search, setSearch] = useState("");
+    const [minPrice, setMinPrice] = useState("");
+    const [maxPrice, setMaxPrice] = useState("");
+    const [sellerFilter, setSellerFilter] = useState("");
 
     useEffect(() => {
         const fetchContracts = async () => {
@@ -61,34 +65,105 @@ const Buy = () => {
         navigate("/login");
     };
 
+    const sellers = Array.from(
+        new Set(contracts.map((c) => c.seller).filter(Boolean))
+    );
+
+    const filteredContracts = contracts.filter((contract) => {
+        const term = search.toLowerCase();
+        const matchesSearch =
+            contract.title.toLowerCase().includes(term) ||
+            (contract.seller || "").toLowerCase().includes(term);
+        const price = Number(contract.price || 0);
+        const matchesMin = !minPrice || price >= Number(minPrice);
+        const matchesMax = !maxPrice || price <= Number(maxPrice);
+        const matchesSeller = !sellerFilter || contract.seller === sellerFilter;
+        return matchesSearch && matchesMin && matchesMax && matchesSeller;
+    });
+
     return (
         <div className="flex flex-col min-h-screen font-poppins bg-black text-white">
             <Header />
             <div className="flex flex-1 relative gap-6">
                 <Sidebar onLogout={handleLogout} />
-                <main className="flex-1 p-8">
+                <main
+                    className={`flex-1 p-8 overflow-auto bg-black transition-all duration-300 ${
+                        selectedContract ? "sm:mr-96" : ""
+                    }`}
+                >
                     <h1 className="text-3xl font-bold mb-6">Available Contracts</h1>
                     {error && <p className="text-red-500 mb-4">{error}</p>}
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                        {contracts.map((contract) => (
-                            <div
-                                key={contract.id}
-                                className="bg-gray-800 p-6 rounded shadow cursor-pointer"
-                                onClick={() => setSelectedContract(contract)}
-                            >
-                                <h2 className="text-xl font-semibold mb-2">{contract.title}</h2>
-                                <p className="text-sm text-gray-400 mb-1">Category: {contract.category}</p>
-                                <p className="text-sm text-gray-400 mb-1">End Date: {contract.deliveryDate}</p>
-                                <p className="text-sm text-gray-400 mb-4">Price: ${contract.price}</p>
-                                <button
-                                    onClick={(e) => { e.stopPropagation(); handleBuy(contract.id); }}
-                                    className="bg-green-600 hover:bg-green-700 px-4 py-2 rounded text-white"
-                                >
-                                    Buy Contract
-                                </button>
-                            </div>
-                        ))}
+                    <div className="mb-4 flex flex-wrap gap-4">
+                        <input
+                            type="text"
+                            placeholder="Search by title or seller"
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
+                            className="p-2 bg-gray-800 rounded"
+                        />
+                        <input
+                            type="number"
+                            placeholder="Min Price"
+                            value={minPrice}
+                            onChange={(e) => setMinPrice(e.target.value)}
+                            className="p-2 bg-gray-800 rounded w-24"
+                        />
+                        <input
+                            type="number"
+                            placeholder="Max Price"
+                            value={maxPrice}
+                            onChange={(e) => setMaxPrice(e.target.value)}
+                            className="p-2 bg-gray-800 rounded w-24"
+                        />
+                        <select
+                            value={sellerFilter}
+                            onChange={(e) => setSellerFilter(e.target.value)}
+                            className="p-2 bg-gray-800 rounded"
+                        >
+                            <option value="">All Sellers</option>
+                            {sellers.map((s) => (
+                                <option key={s} value={s}>
+                                    {s}
+                                </option>
+                            ))}
+                        </select>
                     </div>
+                    <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+                        <thead>
+                            <tr className="bg-gray-700 text-left">
+                                <th className="border p-2">Title</th>
+                                <th className="border p-2">Seller</th>
+                                <th className="border p-2">Price</th>
+                                <th className="border p-2">Delivery</th>
+                                <th className="border p-2">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {filteredContracts.map((contract) => (
+                                <tr
+                                    key={contract.id}
+                                    className="hover:bg-gray-600 cursor-pointer"
+                                    onClick={() => setSelectedContract(contract)}
+                                >
+                                    <td className="border p-2">{contract.title}</td>
+                                    <td className="border p-2">{contract.seller}</td>
+                                    <td className="border p-2">${contract.price}</td>
+                                    <td className="border p-2">{contract.deliveryDate}</td>
+                                    <td className="border p-2">
+                                        <button
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                handleBuy(contract.id);
+                                            }}
+                                            className="bg-green-600 hover:bg-green-700 px-2 py-1 rounded"
+                                        >
+                                            Buy
+                                        </button>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
                 </main>
                 <ContractDetailsPanel
                     contract={selectedContract}


### PR DESCRIPTION
## Summary
- convert Buy contracts screen from card grid to searchable table
- add filtering by price and seller

## Testing
- `npm run lint`
- `./mvnw -q test` *(fails: could not resolve parent pom)*

------
https://chatgpt.com/codex/tasks/task_e_686a34e1eb488329a6be946edfeab0b0