### PR TITLE
Add calendar for contract dates

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -127,6 +127,7 @@ public class ForwardContractController {
                     String username = org.springframework.security.core.context.SecurityContextHolder
                             .getContext().getAuthentication().getName();
                     contract.setBuyerUsername(username);
+                    contract.setPurchaseDate(LocalDate.now());
                     ForwardContract saved = repository.save(contract);
                     return ResponseEntity.ok(saved);
                 })
@@ -141,6 +142,7 @@ public class ForwardContractController {
                     userRepository.findByUsername(username).ifPresent(user -> fillSellerDetails(contract, user));
                     contract.setStatus("Available");
                     contract.setBuyerUsername(null);
+                    contract.setPurchaseDate(null);
                     ForwardContract saved = repository.save(contract);
                     return ResponseEntity.ok(saved);
                 })

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
@@ -21,6 +21,7 @@ public class ForwardContract {
     private String agreementText;
     private String status;
     private String buyerUsername;
+    private LocalDate purchaseDate;
 
     private String legalBusinessName;
     private String name;
@@ -115,6 +116,14 @@ public class ForwardContract {
 
     public void setBuyerUsername(String buyerUsername) {
         this.buyerUsername = buyerUsername;
+    }
+
+    public LocalDate getPurchaseDate() {
+        return purchaseDate;
+    }
+
+    public void setPurchaseDate(LocalDate purchaseDate) {
+        this.purchaseDate = purchaseDate;
     }
 
     public String getLegalBusinessName() {

--- a/bellingham-frontend/package-lock.json
+++ b/bellingham-frontend/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.8.4",
         "chart.js": "^4.4.9",
         "react": "^19.0.0",
+        "react-calendar": "^6.0.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
@@ -1703,7 +1704,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
       "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1737,6 +1738,15 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-2.0.2.tgz",
+      "integrity": "sha512-Do66mSlSNifFFuo3l9gNKfRMSFi26CRuQMsDJuuKO/ekrDWuTTtE4ZQxoFCUOG+NgxnpSeBq/k5TY8ZseEzLpA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
       }
     },
     "node_modules/acorn": {
@@ -1991,6 +2001,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2065,7 +2084,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2626,6 +2645,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-user-locale": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-3.0.0.tgz",
+      "integrity": "sha512-iJfHSmdYV39UUBw7Jq6GJzeJxUr4U+S03qdhVuDsR9gCEnfbqLy9gYDJFBJQL1riqolFUKQvx36mEkp2iGgJ3g==",
+      "license": "MIT",
+      "dependencies": {
+        "memoize": "^10.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2801,7 +2832,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3150,6 +3180,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3179,6 +3221,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/memoize": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/memoize/-/memoize-10.1.0.tgz",
+      "integrity": "sha512-MMbFhJzh4Jlg/poq1si90XRlTZRDHVqdlz2mPyGJ6kqMpyHUyVpDd5gpFAvVehW64+RA1eKE9Yt8aSLY7w2Kgg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/memoize?sponsor=1"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -3198,6 +3255,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -3461,6 +3530,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-calendar": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-6.0.0.tgz",
+      "integrity": "sha512-6wqaki3Us0DNDjZDr0DYIzhSFprNoy4FdPT9Pjy5aD2hJJVjtJwmdMT9VmrTUo949nlk35BOxehThxX62RkuRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wojtekmaj/date-utils": "^2.0.2",
+        "clsx": "^2.0.0",
+        "get-user-locale": "^3.0.0",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-chartjs-2": {
@@ -3850,6 +3944,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/which": {

--- a/bellingham-frontend/package.json
+++ b/bellingham-frontend/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.8.4",
     "chart.js": "^4.4.9",
     "react": "^19.0.0",
+    "react-calendar": "^6.0.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",

--- a/bellingham-frontend/src/App.jsx
+++ b/bellingham-frontend/src/App.jsx
@@ -5,6 +5,7 @@ import Dashboard from "./components/Dashboard";
 import Buy from "./components/Buy";
 import Sell from "./components/Sell";
 import Reports from "./components/Reports";
+import Calendar from "./components/Calendar";
 import Signup from "./components/Signup";
 import Account from "./components/Account";
 import Logo from "./components/Logo";
@@ -32,6 +33,10 @@ const App = () => {
             <Route
                 path="/reports"
                 element={token ? <Reports /> : <Navigate to="/login" />}
+            />
+            <Route
+                path="/calendar"
+                element={token ? <Calendar /> : <Navigate to="/login" />}
             />
             <Route
                 path="/account"

--- a/bellingham-frontend/src/components/Calendar.jsx
+++ b/bellingham-frontend/src/components/Calendar.jsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from "react";
+import Calendar from "react-calendar";
+import 'react-calendar/dist/Calendar.css';
+import axios from "axios";
+import Header from "./Header";
+import Sidebar from "./Sidebar";
+import { useNavigate } from "react-router-dom";
+
+const ContractCalendar = () => {
+    const navigate = useNavigate();
+    const [contracts, setContracts] = useState([]);
+    const [selectedDate, setSelectedDate] = useState(new Date());
+
+    useEffect(() => {
+        const fetchContracts = async () => {
+            try {
+                const token = localStorage.getItem("token");
+                const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
+                const res = await axios.get(
+                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/purchased`,
+                    config
+                );
+                setContracts(res.data);
+            } catch (err) {
+                console.error(err);
+                navigate("/login");
+            }
+        };
+        fetchContracts();
+    }, [navigate]);
+
+    const eventsByDate = contracts.reduce((acc, contract) => {
+        if (contract.purchaseDate) {
+            const key = contract.purchaseDate;
+            if (!acc[key]) acc[key] = [];
+            acc[key].push({ type: "Bought", title: contract.title });
+        }
+        if (contract.deliveryDate) {
+            const key = contract.deliveryDate;
+            if (!acc[key]) acc[key] = [];
+            acc[key].push({ type: "Ends", title: contract.title });
+        }
+        return acc;
+    }, {});
+
+    const tileContent = ({ date, view }) => {
+        if (view === 'month') {
+            const key = date.toISOString().split('T')[0];
+            const events = eventsByDate[key];
+            if (events && events.length > 0) {
+                return <div className="mt-1 w-2 h-2 bg-blue-500 rounded-full mx-auto"/>;
+            }
+        }
+        return null;
+    };
+
+    const formattedSelected = selectedDate.toISOString().split('T')[0];
+    const events = eventsByDate[formattedSelected] || [];
+
+    const handleLogout = () => {
+        localStorage.removeItem("token");
+        localStorage.removeItem("username");
+        navigate("/login");
+    };
+
+    return (
+        <div className="flex flex-col min-h-screen font-poppins bg-black text-white">
+            <Header />
+            <div className="flex flex-1 gap-6 relative">
+                <Sidebar onLogout={handleLogout} />
+                <main className="flex-1 p-8 overflow-auto">
+                    <h1 className="text-3xl font-bold mb-6">Contract Calendar</h1>
+                    <Calendar
+                        onChange={setSelectedDate}
+                        value={selectedDate}
+                        tileContent={tileContent}
+                    />
+                    <div className="mt-6">
+                        <h2 className="text-xl font-semibold mb-2">Events on {formattedSelected}</h2>
+                        {events.length === 0 && <p>No events.</p>}
+                        <ul className="space-y-1">
+                            {events.map((ev, idx) => (
+                                <li key={idx} className="text-sm">
+                                    {ev.type}: {ev.title}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                </main>
+            </div>
+        </div>
+    );
+};
+
+export default ContractCalendar;

--- a/bellingham-frontend/src/components/Sidebar.jsx
+++ b/bellingham-frontend/src/components/Sidebar.jsx
@@ -31,6 +31,12 @@ const Sidebar = ({ onLogout }) => {
                     Reports
                 </button>
                 <button
+                    onClick={() => navigate("/calendar")}
+                    className="text-left hover:bg-gray-700 px-4 py-2 rounded"
+                >
+                    Calendar
+                </button>
+                <button
                     onClick={() => alert("Settings screen not implemented yet")}
                     className="text-left hover:bg-gray-700 px-4 py-2 rounded"
                 >


### PR DESCRIPTION
## Summary
- add purchaseDate tracking on forward contracts
- set purchaseDate when buying and clear when relisting
- add React Calendar tab and route
- show contract buy & end dates on a calendar

## Testing
- `npm run lint`
- `npm run build`
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686a36abf52c8329ae8df5aee791bbaf