### PR TITLE
Fix contract details layout in Buy page

### DIFF
--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -86,11 +86,7 @@ const Buy = () => {
             <Header />
             <div className="flex flex-1 relative gap-6">
                 <Sidebar onLogout={handleLogout} />
-                <main
-                    className={`flex-1 p-8 overflow-auto bg-black transition-all duration-300 ${
-                        selectedContract ? "sm:mr-96" : ""
-                    }`}
-                >
+                <main className="flex-1 p-8 overflow-auto bg-black">
                     <h1 className="text-3xl font-bold mb-6">Available Contracts</h1>
                     {error && <p className="text-red-500 mb-4">{error}</p>}
                     <div className="mb-4 flex flex-wrap gap-4">
@@ -164,11 +160,12 @@ const Buy = () => {
                             ))}
                         </tbody>
                     </table>
+                    <ContractDetailsPanel
+                        inline
+                        contract={selectedContract}
+                        onClose={() => setSelectedContract(null)}
+                    />
                 </main>
-                <ContractDetailsPanel
-                    contract={selectedContract}
-                    onClose={() => setSelectedContract(null)}
-                />
             </div>
         </div>
     );

--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -1,10 +1,14 @@
 import React from "react";
 
-const ContractDetailsPanel = ({ contract, onClose }) => {
+const ContractDetailsPanel = ({ contract, onClose, inline = false }) => {
     if (!contract) return null;
 
+    const panelClasses = inline
+        ? "w-full bg-gray-900 text-white p-6 overflow-auto shadow-lg z-20 max-w-md mt-4"
+        : "absolute top-0 right-0 w-full sm:w-96 h-full bg-gray-900 text-white p-6 overflow-auto shadow-lg z-20 max-w-md";
+
     return (
-        <div className="absolute top-0 right-0 w-full sm:w-96 h-full bg-gray-900 text-white p-6 overflow-auto shadow-lg z-20 max-w-md">
+        <div className={panelClasses}>
             <button
                 className="mb-4 bg-red-600 hover:bg-red-700 px-3 py-1 rounded"
                 onClick={onClose}

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -103,6 +103,7 @@ const Reports = () => {
                         Total Value: ${totalValue.toFixed(2)}
                     </p>
                     <ContractDetailsPanel
+                        inline
                         contract={selectedContract}
                         onClose={() => setSelectedContract(null)}
                     />


### PR DESCRIPTION
## Summary
- show contract details below the list on the Buy page
- keep details below the table for the Reports page
- support inline display in `ContractDetailsPanel`

## Testing
- `npm run lint`
- `./mvnw test` *(fails: Could not resolve Spring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686a52ac75dc83299904da719fe43f71