### PR TITLE
Add back buttons

### DIFF
--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -1,15 +1,26 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import logoImage from "../assets/login.png";
 
 const Header = () => {
     const username = localStorage.getItem("username");
+    const navigate = useNavigate();
+
     return (
         <header className="bg-gray-800 p-4 flex justify-between items-center">
-            <img
-                src={logoImage}
-                alt="Bellingham Data Futures logo"
-                className="h-[150px] w-[150px]"
-            />
+            <div className="flex items-center gap-4">
+                <button
+                    onClick={() => navigate(-1)}
+                    className="bg-gray-700 hover:bg-gray-600 text-white px-3 py-1 rounded"
+                >
+                    Back
+                </button>
+                <img
+                    src={logoImage}
+                    alt="Bellingham Data Futures logo"
+                    className="h-[150px] w-[150px]"
+                />
+            </div>
             {username && (
                 <span className="text-sm text-white">Logged in as: {username}</span>
             )}

--- a/bellingham-frontend/src/components/Signup.jsx
+++ b/bellingham-frontend/src/components/Signup.jsx
@@ -57,7 +57,13 @@ const Signup = () => {
     };
 
     return (
-        <div className="flex flex-col h-screen items-center justify-center bg-black text-white font-poppins">
+        <div className="relative flex flex-col h-screen items-center justify-center bg-black text-white font-poppins">
+            <button
+                onClick={() => navigate(-1)}
+                className="absolute top-4 left-4 bg-gray-700 hover:bg-gray-600 text-white px-3 py-1 rounded"
+            >
+                Back
+            </button>
             <img
                 src={logoImage}
                 alt="Bellingham Data Futures logo"


### PR DESCRIPTION
## Summary
- include a back button in the shared `Header` component
- show the back button on the Signup screen

## Testing
- `npm run lint` in `bellingham-frontend`
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686a75a66b2883299ca5522dbb7af77b