### PR TITLE
Implement profile pictures

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
@@ -89,6 +89,7 @@ public class AuthController {
         user.setTechnicalContactEmail(creds.get("technicalContactEmail"));
         user.setTechnicalContactPhone(creds.get("technicalContactPhone"));
         user.setCompanyDescription(creds.get("companyDescription"));
+        user.setProfilePicture(creds.get("profilePicture"));
 
         userRepository.save(user);
         return "User registered";
@@ -116,6 +117,7 @@ public class AuthController {
         map.put("technicalContactEmail", user.getTechnicalContactEmail());
         map.put("technicalContactPhone", user.getTechnicalContactPhone());
         map.put("companyDescription", user.getCompanyDescription());
+        map.put("profilePicture", user.getProfilePicture());
         return map;
     }
 
@@ -152,6 +154,8 @@ public class AuthController {
             user.setTechnicalContactPhone(updates.get("technicalContactPhone"));
         if (updates.containsKey("companyDescription"))
             user.setCompanyDescription(updates.get("companyDescription"));
+        if (updates.containsKey("profilePicture"))
+            user.setProfilePicture(updates.get("profilePicture"));
 
         userRepository.save(user);
 
@@ -170,6 +174,7 @@ public class AuthController {
         map.put("technicalContactEmail", user.getTechnicalContactEmail());
         map.put("technicalContactPhone", user.getTechnicalContactPhone());
         map.put("companyDescription", user.getCompanyDescription());
+        map.put("profilePicture", user.getProfilePicture());
         return map;
     }
 }

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/User.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/User.java
@@ -27,6 +27,9 @@ public class User {
     private String technicalContactPhone;
     private String companyDescription;
 
+    @Lob
+    private String profilePicture;
+
     // Getters and Setters
 
     public Long getId() {
@@ -155,5 +158,13 @@ public class User {
 
     public void setCompanyDescription(String companyDescription) {
         this.companyDescription = companyDescription;
+    }
+
+    public String getProfilePicture() {
+        return profilePicture;
+    }
+
+    public void setProfilePicture(String profilePicture) {
+        this.profilePicture = profilePicture;
     }
 }

--- a/bellingham-frontend/src/components/Account.jsx
+++ b/bellingham-frontend/src/components/Account.jsx
@@ -31,6 +31,9 @@ const Account = () => {
                 );
                 setProfile(res.data);
                 setFormData(res.data);
+                if (res.data.profilePicture) {
+                    localStorage.setItem("profilePicture", res.data.profilePicture);
+                }
             } catch (err) {
                 console.error(err);
                 setError("Failed to load profile");
@@ -80,6 +83,9 @@ const Account = () => {
                 { headers: { Authorization: `Bearer ${token}` } }
             );
             setProfile(res.data);
+            if (res.data.profilePicture) {
+                localStorage.setItem("profilePicture", res.data.profilePicture);
+            }
             setEditing(false);
         } catch (err) {
             console.error(err);
@@ -174,6 +180,23 @@ const Account = () => {
                         onChange={handleChange}
                         placeholder="Technical Contact Phone"
                     />
+                    <input
+                        type="file"
+                        accept="image/*"
+                        onChange={(e) => {
+                            const file = e.target.files?.[0];
+                            if (!file) return;
+                            const reader = new FileReader();
+                            reader.onloadend = () => {
+                                setFormData({ ...formData, profilePicture: reader.result });
+                            };
+                            reader.readAsDataURL(file);
+                        }}
+                        className="w-full p-2 bg-gray-800 rounded"
+                    />
+                    {formData.profilePicture && (
+                        <img src={formData.profilePicture} alt="Preview" className="h-20 w-20 rounded-full" />
+                    )}
                     <textarea
                         className="w-full p-2 bg-gray-800 rounded"
                         name="companyDescription"
@@ -214,6 +237,9 @@ const Account = () => {
                     <p><strong>Technical Contact Email:</strong> {profile.technicalContactEmail}</p>
                     <p><strong>Technical Contact Phone:</strong> {profile.technicalContactPhone}</p>
                     <p><strong>Company Description:</strong> {profile.companyDescription}</p>
+                    {profile.profilePicture && (
+                        <img src={profile.profilePicture} alt="Profile" className="h-20 w-20 rounded-full" />
+                    )}
                     <button
                         onClick={() => setEditing(true)}
                         className="mt-4 bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded"

--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -1,9 +1,28 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import axios from "axios";
 
 import logoImage from "../assets/login.png";
 
 const Header = () => {
     const username = localStorage.getItem("username");
+    const [picture, setPicture] = useState(localStorage.getItem("profilePicture") || "");
+
+    useEffect(() => {
+        const fetchProfilePic = async () => {
+            const token = localStorage.getItem("token");
+            if (!token) return;
+            try {
+                const res = await axios.get(
+                    `${import.meta.env.VITE_API_BASE_URL}/api/profile`,
+                    { headers: { Authorization: `Bearer ${token}` } }
+                );
+                setPicture(res.data.profilePicture || "");
+            } catch (e) {
+                console.error(e);
+            }
+        };
+        fetchProfilePic();
+    }, []);
 
     return (
         <header className="bg-gray-800 p-4 flex justify-between items-center">
@@ -15,7 +34,12 @@ const Header = () => {
                 />
             </div>
             {username && (
-                <span className="text-sm text-white">Logged in as: {username}</span>
+                <div className="flex items-center gap-2 text-white text-sm">
+                    {picture && (
+                        <img src={picture} alt="Profile" className="h-8 w-8 rounded-full" />
+                    )}
+                    <span>Logged in as: {username}</span>
+                </div>
             )}
         </header>
     );

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -29,6 +29,17 @@ const Login = () => {
             if (token) {
                 localStorage.setItem("token", token);
                 localStorage.setItem("username", username);
+                try {
+                    const profile = await axios.get(
+                        `${import.meta.env.VITE_API_BASE_URL}/api/profile`,
+                        { headers: { Authorization: `Bearer ${token}` } }
+                    );
+                    if (profile.data.profilePicture) {
+                        localStorage.setItem("profilePicture", profile.data.profilePicture);
+                    }
+                } catch (e) {
+                    console.error(e);
+                }
 
                 // Force full page reload to refresh state
                 window.location.href = "/";

--- a/bellingham-frontend/src/components/Signup.jsx
+++ b/bellingham-frontend/src/components/Signup.jsx
@@ -19,10 +19,21 @@ const Signup = () => {
         technicalContactEmail: "",
         technicalContactPhone: "",
         companyDescription: "",
+        profilePicture: "",
     });
     const [message, setMessage] = useState("");
     const [error, setError] = useState("");
     const navigate = useNavigate();
+
+    const handleFileChange = (e) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onloadend = () => {
+            setForm({ ...form, profilePicture: reader.result });
+        };
+        reader.readAsDataURL(file);
+    };
 
     const handleSignup = async (e) => {
         e.preventDefault();
@@ -49,6 +60,7 @@ const Signup = () => {
                 technicalContactEmail: "",
                 technicalContactPhone: "",
                 companyDescription: "",
+                profilePicture: "",
             });
         } catch (err) {
             console.error(err);
@@ -85,6 +97,12 @@ const Signup = () => {
                     placeholder="Password"
                     value={form.password}
                     onChange={(e) => setForm({ ...form, password: e.target.value })}
+                    className="w-full p-2 mb-4 border rounded-lg"
+                />
+                <input
+                    type="file"
+                    accept="image/*"
+                    onChange={handleFileChange}
                     className="w-full p-2 mb-4 border rounded-lg"
                 />
                 <input


### PR DESCRIPTION
## Summary
- allow storing profile picture in database
- expose profile picture through register and profile APIs
- load profile picture in header and account views
- support profile image upload on signup and account pages

## Testing
- `./mvnw -q test` *(fails: could not resolve dependencies)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_686a9e22103083298ad780187298133b