### PR TITLE
Fix login CORS

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RestController
+@CrossOrigin(origins = "http://localhost:5173", allowCredentials = "true")
 @RequestMapping("/api")
 public class AuthController {
 


### PR DESCRIPTION
## Summary
- allow cross origin on authentication routes so the frontend can log in

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_686acd7c4d5c8329a457e89fe33193ac