### PR TITLE
Fix login with large profile images

### DIFF
--- a/bellingham-frontend/src/components/Account.jsx
+++ b/bellingham-frontend/src/components/Account.jsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import Header from "./Header";
 import Sidebar from "./Sidebar";
 import { useNavigate } from "react-router-dom";
+import { safeSetItem } from "../utils/storage";
 
 const Account = () => {
     const [profile, setProfile] = useState(null);
@@ -33,7 +34,15 @@ const Account = () => {
                 setProfile(res.data);
                 setFormData(res.data);
                 if (res.data.profilePicture) {
-                    localStorage.setItem("profilePicture", res.data.profilePicture);
+                    if (
+                        !safeSetItem(
+                            "profilePicture",
+                            res.data.profilePicture,
+                            { maxLength: 1_000_000 }
+                        )
+                    ) {
+                        console.warn("Unable to cache profile picture");
+                    }
                 }
             } catch (err) {
                 console.error(err);
@@ -85,7 +94,15 @@ const Account = () => {
             );
             setProfile(res.data);
             if (res.data.profilePicture) {
-                localStorage.setItem("profilePicture", res.data.profilePicture);
+                if (
+                    !safeSetItem(
+                        "profilePicture",
+                        res.data.profilePicture,
+                        { maxLength: 1_000_000 }
+                    )
+                ) {
+                    console.warn("Unable to cache profile picture");
+                }
             }
             setEditing(false);
         } catch (err) {

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import axios from "axios";
 import LoginImage from "../assets/login.png";
+import { safeSetItem } from "../utils/storage";
 
 const Login = () => {
     const [username, setUsername] = useState("");
@@ -27,17 +28,11 @@ const Login = () => {
 
             const token = res.data.id_token;
             if (token) {
-                try {
-                    localStorage.setItem("token", token);
-                    localStorage.setItem("username", username);
-                } catch (e) {
-                    console.error("LocalStorage quota exceeded, clearing profile picture", e);
+                if (!safeSetItem("token", token) || !safeSetItem("username", username)) {
+                    console.error("LocalStorage quota exceeded, clearing profile picture");
                     localStorage.removeItem("profilePicture");
-                    try {
-                        localStorage.setItem("token", token);
-                        localStorage.setItem("username", username);
-                    } catch (e2) {
-                        console.error("Failed to store credentials", e2);
+                    if (!safeSetItem("token", token) || !safeSetItem("username", username)) {
+                        console.error("Failed to store credentials");
                         setError("Login failed: unable to store credentials.");
                         return;
                     }
@@ -48,7 +43,13 @@ const Login = () => {
                         { headers: { Authorization: `Bearer ${token}` } }
                     );
                     if (profile.data.profilePicture) {
-                        localStorage.setItem("profilePicture", profile.data.profilePicture);
+                        if (!safeSetItem(
+                                "profilePicture",
+                                profile.data.profilePicture,
+                                { maxLength: 1_000_000 }
+                            )) {
+                            console.warn("Unable to cache profile picture");
+                        }
                     }
                 } catch (e) {
                     console.error(e);

--- a/bellingham-frontend/src/utils/storage.js
+++ b/bellingham-frontend/src/utils/storage.js
@@ -1,0 +1,22 @@
+export function safeSetItem(key, value, { maxLength = 5_000_000 } = {}) {
+  try {
+    if (typeof value === 'string' && value.length > maxLength) {
+      console.warn(`Value for ${key} exceeds ${maxLength} characters; skipping`);
+      return false;
+    }
+    localStorage.setItem(key, value);
+    return true;
+  } catch (e) {
+    console.error('Failed to store', key, e);
+    return false;
+  }
+}
+
+export function safeGetItem(key) {
+  try {
+    return localStorage.getItem(key);
+  } catch (e) {
+    console.error('Failed to read', key, e);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- limit size for profile pictures stored in LocalStorage
- warn when skipping large profile images
- apply size limit in login and account update flows

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686aced0c8f08329a6f650edc7baff86