### PR TITLE
Remove user image upload feature

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
@@ -90,7 +90,6 @@ public class AuthController {
         user.setTechnicalContactEmail(creds.get("technicalContactEmail"));
         user.setTechnicalContactPhone(creds.get("technicalContactPhone"));
         user.setCompanyDescription(creds.get("companyDescription"));
-        user.setProfilePicture(creds.get("profilePicture"));
 
         userRepository.save(user);
         return "User registered";
@@ -118,7 +117,6 @@ public class AuthController {
         map.put("technicalContactEmail", user.getTechnicalContactEmail());
         map.put("technicalContactPhone", user.getTechnicalContactPhone());
         map.put("companyDescription", user.getCompanyDescription());
-        map.put("profilePicture", user.getProfilePicture());
         return map;
     }
 
@@ -155,8 +153,6 @@ public class AuthController {
             user.setTechnicalContactPhone(updates.get("technicalContactPhone"));
         if (updates.containsKey("companyDescription"))
             user.setCompanyDescription(updates.get("companyDescription"));
-        if (updates.containsKey("profilePicture"))
-            user.setProfilePicture(updates.get("profilePicture"));
 
         userRepository.save(user);
 
@@ -175,7 +171,6 @@ public class AuthController {
         map.put("technicalContactEmail", user.getTechnicalContactEmail());
         map.put("technicalContactPhone", user.getTechnicalContactPhone());
         map.put("companyDescription", user.getCompanyDescription());
-        map.put("profilePicture", user.getProfilePicture());
         return map;
     }
 }

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/User.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/User.java
@@ -27,9 +27,6 @@ public class User {
     private String technicalContactPhone;
     private String companyDescription;
 
-    @Lob
-    private String profilePicture;
-
     // Getters and Setters
 
     public Long getId() {
@@ -160,11 +157,4 @@ public class User {
         this.companyDescription = companyDescription;
     }
 
-    public String getProfilePicture() {
-        return profilePicture;
-    }
-
-    public void setProfilePicture(String profilePicture) {
-        this.profilePicture = profilePicture;
-    }
 }

--- a/bellingham-frontend/src/components/Account.jsx
+++ b/bellingham-frontend/src/components/Account.jsx
@@ -3,7 +3,6 @@ import axios from "axios";
 import Header from "./Header";
 import Sidebar from "./Sidebar";
 import { useNavigate } from "react-router-dom";
-import { safeSetItem } from "../utils/storage";
 
 const Account = () => {
     const [profile, setProfile] = useState(null);
@@ -15,7 +14,6 @@ const Account = () => {
     const handleLogout = () => {
         localStorage.removeItem("token");
         localStorage.removeItem("username");
-        localStorage.removeItem("profilePicture");
         navigate("/login");
     };
 
@@ -33,11 +31,6 @@ const Account = () => {
                 );
                 setProfile(res.data);
                 setFormData(res.data);
-                if (res.data.profilePicture) {
-                    if (!safeSetItem("profilePicture", res.data.profilePicture)) {
-                        console.warn("Unable to cache profile picture");
-                    }
-                }
             } catch (err) {
                 console.error(err);
                 setError("Failed to load profile");
@@ -87,11 +80,6 @@ const Account = () => {
                 { headers: { Authorization: `Bearer ${token}` } }
             );
             setProfile(res.data);
-            if (res.data.profilePicture) {
-                if (!safeSetItem("profilePicture", res.data.profilePicture)) {
-                    console.warn("Unable to cache profile picture");
-                }
-            }
             setEditing(false);
         } catch (err) {
             console.error(err);
@@ -186,23 +174,6 @@ const Account = () => {
                         onChange={handleChange}
                         placeholder="Technical Contact Phone"
                     />
-                    <input
-                        type="file"
-                        accept="image/*"
-                        onChange={(e) => {
-                            const file = e.target.files?.[0];
-                            if (!file) return;
-                            const reader = new FileReader();
-                            reader.onloadend = () => {
-                                setFormData({ ...formData, profilePicture: reader.result });
-                            };
-                            reader.readAsDataURL(file);
-                        }}
-                        className="w-full p-2 bg-gray-800 rounded"
-                    />
-                    {formData.profilePicture && (
-                        <img src={formData.profilePicture} alt="Preview" className="h-20 w-20 rounded-full" />
-                    )}
                     <textarea
                         className="w-full p-2 bg-gray-800 rounded"
                         name="companyDescription"
@@ -243,9 +214,6 @@ const Account = () => {
                     <p><strong>Technical Contact Email:</strong> {profile.technicalContactEmail}</p>
                     <p><strong>Technical Contact Phone:</strong> {profile.technicalContactPhone}</p>
                     <p><strong>Company Description:</strong> {profile.companyDescription}</p>
-                    {profile.profilePicture && (
-                        <img src={profile.profilePicture} alt="Profile" className="h-20 w-20 rounded-full" />
-                    )}
                     <button
                         onClick={() => setEditing(true)}
                         className="mt-4 bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded"

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -62,7 +62,6 @@ const Buy = () => {
     const handleLogout = () => {
         localStorage.removeItem("token");
         localStorage.removeItem("username");
-        localStorage.removeItem("profilePicture");
         navigate("/login");
     };
 

--- a/bellingham-frontend/src/components/Calendar.jsx
+++ b/bellingham-frontend/src/components/Calendar.jsx
@@ -60,7 +60,6 @@ const ContractCalendar = () => {
     const handleLogout = () => {
         localStorage.removeItem("token");
         localStorage.removeItem("username");
-        localStorage.removeItem("profilePicture");
         navigate("/login");
     };
 

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -33,7 +33,6 @@ const Dashboard = () => {
             } catch (err) {
                 console.error("Error fetching contracts", err);
                 localStorage.removeItem("token");
-                localStorage.removeItem("profilePicture");
                 navigate("/login");
             }
         };
@@ -44,7 +43,6 @@ const Dashboard = () => {
     const handleLogout = () => {
         localStorage.removeItem("token");
         localStorage.removeItem("username");
-        localStorage.removeItem("profilePicture");
         navigate("/login");
     };
 

--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -1,28 +1,9 @@
-import React, { useEffect, useState } from "react";
-import axios from "axios";
+import React from "react";
 
 import logoImage from "../assets/login.png";
 
 const Header = () => {
     const username = localStorage.getItem("username");
-    const [picture, setPicture] = useState(localStorage.getItem("profilePicture") || "");
-
-    useEffect(() => {
-        const fetchProfilePic = async () => {
-            const token = localStorage.getItem("token");
-            if (!token) return;
-            try {
-                const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/profile`,
-                    { headers: { Authorization: `Bearer ${token}` } }
-                );
-                setPicture(res.data.profilePicture || "");
-            } catch (e) {
-                console.error(e);
-            }
-        };
-        fetchProfilePic();
-    }, []);
 
     return (
         <header className="bg-gray-800 p-4 flex justify-between items-center">
@@ -35,9 +16,6 @@ const Header = () => {
             </div>
             {username && (
                 <div className="flex items-center gap-2 text-white text-sm">
-                    {picture && (
-                        <img src={picture} alt="Profile" className="h-8 w-8 rounded-full" />
-                    )}
                     <span>Logged in as: {username}</span>
                 </div>
             )}

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -29,26 +29,9 @@ const Login = () => {
             const token = res.data.id_token;
             if (token) {
                 if (!safeSetItem("token", token) || !safeSetItem("username", username)) {
-                    console.error("LocalStorage quota exceeded, clearing profile picture");
-                    localStorage.removeItem("profilePicture");
-                    if (!safeSetItem("token", token) || !safeSetItem("username", username)) {
-                        console.error("Failed to store credentials");
-                        setError("Login failed: unable to store credentials.");
-                        return;
-                    }
-                }
-                try {
-                    const profile = await axios.get(
-                        `${import.meta.env.VITE_API_BASE_URL}/api/profile`,
-                        { headers: { Authorization: `Bearer ${token}` } }
-                    );
-                    if (profile.data.profilePicture) {
-                        if (!safeSetItem("profilePicture", profile.data.profilePicture)) {
-                            console.warn("Unable to cache profile picture");
-                        }
-                    }
-                } catch (e) {
-                    console.error(e);
+                    console.error("Failed to store credentials");
+                    setError("Login failed: unable to store credentials.");
+                    return;
                 }
 
                 // Force full page reload to refresh state

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -52,7 +52,6 @@ const Reports = () => {
     const handleLogout = () => {
         localStorage.removeItem("token");
         localStorage.removeItem("username");
-        localStorage.removeItem("profilePicture");
         navigate("/login");
     };
 

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -106,7 +106,6 @@ const Sell = () => {
     const handleLogout = () => {
         localStorage.removeItem("token");
         localStorage.removeItem("username");
-        localStorage.removeItem("profilePicture");
         navigate("/login");
     };
 

--- a/bellingham-frontend/src/components/Signup.jsx
+++ b/bellingham-frontend/src/components/Signup.jsx
@@ -19,21 +19,11 @@ const Signup = () => {
         technicalContactEmail: "",
         technicalContactPhone: "",
         companyDescription: "",
-        profilePicture: "",
     });
     const [message, setMessage] = useState("");
     const [error, setError] = useState("");
     const navigate = useNavigate();
 
-    const handleFileChange = (e) => {
-        const file = e.target.files?.[0];
-        if (!file) return;
-        const reader = new FileReader();
-        reader.onloadend = () => {
-            setForm({ ...form, profilePicture: reader.result });
-        };
-        reader.readAsDataURL(file);
-    };
 
     const handleSignup = async (e) => {
         e.preventDefault();
@@ -60,7 +50,6 @@ const Signup = () => {
                 technicalContactEmail: "",
                 technicalContactPhone: "",
                 companyDescription: "",
-                profilePicture: "",
             });
         } catch (err) {
             console.error(err);
@@ -97,12 +86,6 @@ const Signup = () => {
                     placeholder="Password"
                     value={form.password}
                     onChange={(e) => setForm({ ...form, password: e.target.value })}
-                    className="w-full p-2 mb-4 border rounded-lg"
-                />
-                <input
-                    type="file"
-                    accept="image/*"
-                    onChange={handleFileChange}
                     className="w-full p-2 mb-4 border rounded-lg"
                 />
                 <input


### PR DESCRIPTION
## Summary
- remove `profilePicture` field from the backend user model and controller
- drop image upload inputs and preview code from Signup and Account pages
- simplify login, header and other components to no longer handle profile pictures
- cleanup logout handlers across components

## Testing
- `npm run lint`
- `mvnw test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686b716ee5648329a2ff0db9c25ff05c