### PR TITLE
Add PDF contract download

### DIFF
--- a/bellingham-datafutures/pom.xml
+++ b/bellingham-datafutures/pom.xml
@@ -92,6 +92,13 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- PDF generation -->
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.30</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -4,6 +4,7 @@ import com.bellingham.datafutures.model.ForwardContract;
 import com.bellingham.datafutures.repository.ForwardContractRepository;
 import com.bellingham.datafutures.repository.UserRepository;
 import com.bellingham.datafutures.model.User;
+import com.bellingham.datafutures.service.PdfService;
 import java.time.LocalDate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,9 @@ public class ForwardContractController {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private PdfService pdfService;
 
     private void updateExpiredContracts() {
         LocalDate today = LocalDate.now();
@@ -53,6 +57,26 @@ public class ForwardContractController {
         return repository.findById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().<ForwardContract>build());
+    }
+
+    @GetMapping("/{id}/pdf")
+    public ResponseEntity<byte[]> downloadPdf(@PathVariable Long id) {
+        return repository.findById(id)
+                .map(contract -> {
+                    try {
+                        byte[] bytes = pdfService.generateContractPdf(contract);
+                        org.springframework.http.HttpHeaders headers = new org.springframework.http.HttpHeaders();
+                        headers.setContentType(org.springframework.http.MediaType.APPLICATION_PDF);
+                        headers.setContentDisposition(org.springframework.http.ContentDisposition
+                                .attachment()
+                                .filename("contract-" + id + ".pdf")
+                                .build());
+                        return new org.springframework.http.ResponseEntity<>(bytes, headers, org.springframework.http.HttpStatus.OK);
+                    } catch (java.io.IOException e) {
+                        return org.springframework.http.ResponseEntity.internalServerError().<byte[]>build();
+                    }
+                })
+                .orElse(org.springframework.http.ResponseEntity.notFound().<byte[]>build());
     }
 
     @PostMapping

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/service/PdfService.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/service/PdfService.java
@@ -1,0 +1,79 @@
+package com.bellingham.datafutures.service;
+
+import com.bellingham.datafutures.model.ForwardContract;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.format.DateTimeFormatter;
+
+@Service
+public class PdfService {
+
+    public byte[] generateContractPdf(ForwardContract contract) throws IOException {
+        try (PDDocument document = new PDDocument()) {
+            PDPage page = new PDPage();
+            document.addPage(page);
+
+            try (PDPageContentStream stream = new PDPageContentStream(document, page)) {
+                stream.setLeading(14.5f);
+                stream.beginText();
+                stream.setFont(PDType1Font.HELVETICA_BOLD, 16);
+                stream.newLineAtOffset(50, 750);
+                stream.showText("Data Purchase Agreement");
+                stream.newLine();
+                stream.setFont(PDType1Font.HELVETICA, 12);
+                stream.showText("Title: " + nullSafe(contract.getTitle()));
+                stream.newLine();
+                stream.showText("Seller: " + nullSafe(contract.getSeller()));
+                stream.newLine();
+                String buyer = contract.getBuyerUsername() == null ? "-" : contract.getBuyerUsername();
+                stream.showText("Buyer: " + buyer);
+                stream.newLine();
+                stream.showText("Price: $" + contract.getPrice());
+                stream.newLine();
+                if (contract.getDeliveryDate() != null) {
+                    String date = contract.getDeliveryDate().format(DateTimeFormatter.ISO_DATE);
+                    stream.showText("Delivery Date: " + date);
+                    stream.newLine();
+                }
+                stream.showText("Status: " + nullSafe(contract.getStatus()));
+                stream.newLine();
+                stream.newLine();
+                stream.showText("Data Description:");
+                stream.newLine();
+                stream.setFont(PDType1Font.HELVETICA, 11);
+                stream.showText(nullSafe(contract.getDataDescription()));
+                stream.newLine();
+                stream.newLine();
+                stream.setFont(PDType1Font.HELVETICA_BOLD, 12);
+                stream.showText("Agreement Text:");
+                stream.setFont(PDType1Font.HELVETICA, 11);
+                stream.newLine();
+                for (String line : splitLines(contract.getAgreementText())) {
+                    stream.showText(line);
+                    stream.newLine();
+                }
+                stream.endText();
+            }
+
+            try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+                document.save(out);
+                return out.toByteArray();
+            }
+        }
+    }
+
+    private String[] splitLines(String text) {
+        if (text == null) return new String[]{""};
+        return text.split("\r?\n");
+    }
+
+    private String nullSafe(String str) {
+        return str == null ? "" : str;
+    }
+}

--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -7,6 +7,24 @@ const ContractDetailsPanel = ({ contract, onClose, inline = false }) => {
         ? "w-full bg-gray-900 text-white p-6 overflow-auto shadow-lg z-20 max-w-md mt-4"
         : "absolute top-0 right-0 w-full sm:w-96 h-full bg-gray-900 text-white p-6 overflow-auto shadow-lg z-20 max-w-md";
 
+    const handleDownload = async () => {
+        const token = localStorage.getItem("token");
+        const res = await fetch(
+            `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${contract.id}/pdf`,
+            {
+                headers: token ? { Authorization: `Bearer ${token}` } : {},
+            }
+        );
+        if (!res.ok) return;
+        const blob = await res.blob();
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `contract-${contract.id}.pdf`;
+        a.click();
+        window.URL.revokeObjectURL(url);
+    };
+
     return (
         <div className={panelClasses}>
             <button
@@ -16,6 +34,12 @@ const ContractDetailsPanel = ({ contract, onClose, inline = false }) => {
                 Close
             </button>
             <h2 className="text-xl font-bold mb-4">{contract.title}</h2>
+            <button
+                className="mb-4 bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded"
+                onClick={handleDownload}
+            >
+                Download PDF
+            </button>
             <ul className="space-y-1">
                 {Object.entries(contract).map(([key, value]) => (
                     <li key={key}>


### PR DESCRIPTION
## Summary
- add PdfService for generating PDF files
- expose new `/api/contracts/{id}/pdf` endpoint
- include pdfbox dependency
- allow frontend to download contract PDF
- fix ResponseEntity generics

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686b73c6be8c83298513964b695fbd0b