### PR TITLE
Fix contract arrays

### DIFF
--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -26,7 +26,7 @@ const Buy = () => {
                     `${import.meta.env.VITE_API_BASE_URL}/api/contracts/available`,
                     config
                 );
-                setContracts(res.data);
+                setContracts(res.data.content);
             } catch (err) {
                 console.error(err);
                 if (err.response) {

--- a/bellingham-frontend/src/components/Calendar.jsx
+++ b/bellingham-frontend/src/components/Calendar.jsx
@@ -20,7 +20,7 @@ const ContractCalendar = () => {
                     `${import.meta.env.VITE_API_BASE_URL}/api/contracts/purchased`,
                     config
                 );
-                setContracts(res.data);
+                setContracts(res.data.content);
             } catch (err) {
                 console.error(err);
                 navigate("/login");

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -29,7 +29,7 @@ const Dashboard = () => {
                     config
                 );
 
-                setContracts(res.data);
+                setContracts(res.data.content);
             } catch (err) {
                 console.error("Error fetching contracts", err);
                 localStorage.removeItem("token");

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -25,7 +25,7 @@ const Reports = () => {
                     `${import.meta.env.VITE_API_BASE_URL}/api/contracts/purchased`,
                     config
                 );
-                setContracts(res.data);
+                setContracts(res.data.content);
             } catch {
                 setError("Failed to load purchased contracts.");
             }


### PR DESCRIPTION
## Summary
- fix contract fetching to use `Page.content` instead of the entire response

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686b92419090832988bfa35b6d63406a