### PR TITLE
Add sliding sidebar for contract details

### DIFF
--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -1,11 +1,21 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 const ContractDetailsPanel = ({ contract, onClose, inline = false }) => {
-    if (!contract) return null;
+    const [visible, setVisible] = useState(false);
+
+    useEffect(() => {
+        if (contract) {
+            setVisible(true);
+        } else {
+            setVisible(false);
+        }
+    }, [contract]);
+
+    if (!contract && !visible) return null;
 
     const panelClasses = inline
         ? "w-full bg-gray-900 text-white p-6 overflow-auto shadow-lg z-20 max-w-md mt-4"
-        : "absolute top-0 right-0 w-full sm:w-96 h-full bg-gray-900 text-white p-6 overflow-auto shadow-lg z-20 max-w-md";
+        : `fixed top-0 right-0 w-full sm:w-1/3 h-full bg-gray-900 text-white p-6 shadow-lg z-20 transform transition-transform duration-300 flex flex-col ${visible ? "translate-x-0" : "translate-x-full"}`;
 
     const handleDownload = async () => {
         const token = localStorage.getItem("token");
@@ -25,14 +35,15 @@ const ContractDetailsPanel = ({ contract, onClose, inline = false }) => {
         window.URL.revokeObjectURL(url);
     };
 
+    const handleClose = () => {
+        setVisible(false);
+        setTimeout(() => {
+            onClose();
+        }, 300);
+    };
+
     return (
         <div className={panelClasses}>
-            <button
-                className="mb-4 bg-red-600 hover:bg-red-700 px-3 py-1 rounded"
-                onClick={onClose}
-            >
-                Close
-            </button>
             <h2 className="text-xl font-bold mb-4">{contract.title}</h2>
             <button
                 className="mb-4 bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded"
@@ -52,6 +63,12 @@ const ContractDetailsPanel = ({ contract, onClose, inline = false }) => {
                     </li>
                 ))}
             </ul>
+            <button
+                className="mt-auto bg-red-600 hover:bg-red-700 px-3 py-1 rounded self-end"
+                onClick={handleClose}
+            >
+                Close
+            </button>
         </div>
     );
 };

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -54,11 +54,7 @@ const Dashboard = () => {
                 <Sidebar onLogout={handleLogout} />
 
                 {/* Main Content */}
-                <main
-                    className={`flex-1 p-8 overflow-auto bg-black transition-all duration-300 ${
-                        selectedContract ? "sm:mr-96" : ""
-                    }`}
-                >
+                <main className="flex-1 p-8 overflow-auto bg-black">
                     <h2 className="text-3xl font-bold mb-6 text-white">Open Contracts</h2>
                     <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
                     <thead>


### PR DESCRIPTION
## Summary
- make contract details slide in from the right
- keep home screen visible underneath
- move close button to the bottom of the sidebar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ba91d24c8832993519a62dc292425