### PR TITLE
Fix dashboard slide panel covering content

### DIFF
--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useState } from "react";
 
-const ContractDetailsPanel = ({ contract, onClose, inline = false }) => {
+const ContractDetailsPanel = ({
+    contract,
+    onClose,
+    inline = false,
+    inlineWidth = "w-full max-w-md",
+}) => {
     const [visible, setVisible] = useState(false);
 
     useEffect(() => {
@@ -14,7 +19,7 @@ const ContractDetailsPanel = ({ contract, onClose, inline = false }) => {
     if (!contract && !visible) return null;
 
     const panelClasses = inline
-        ? "w-full bg-gray-900 text-white p-6 overflow-auto shadow-lg z-20 max-w-md mt-4"
+        ? `${inlineWidth} bg-gray-900 text-white p-6 overflow-auto shadow-lg z-20 mt-4 transform transition-transform duration-300 flex flex-col ${visible ? "translate-x-0" : "translate-x-full"}`
         : `fixed top-0 right-0 w-full sm:w-1/3 h-full bg-gray-900 text-white p-6 shadow-lg z-20 transform transition-transform duration-300 flex flex-col ${visible ? "translate-x-0" : "translate-x-full"}`;
 
     const handleDownload = async () => {

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -84,6 +84,8 @@ const Dashboard = () => {
                     </table>
                 </main>
                 <ContractDetailsPanel
+                    inline
+                    inlineWidth="w-full sm:w-1/3"
                     contract={selectedContract}
                     onClose={() => setSelectedContract(null)}
                 />


### PR DESCRIPTION
## Summary
- adjust `ContractDetailsPanel` to support configurable width when used inline
- show the panel inline on the dashboard so main content isn't covered

## Testing
- `npm run lint`
- `npm run build`
- `npm run test` *(fails: Missing script)*
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686baa8b1e608329b3eb4d4b16558159