### PR TITLE
Implement contract closeout feature

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
@@ -26,6 +26,7 @@ public class ForwardContract {
     private String agreementText;
     private String status;
     private String buyerUsername;
+    private String creatorUsername;
     private LocalDate purchaseDate;
 
     private String legalBusinessName;
@@ -121,6 +122,14 @@ public class ForwardContract {
 
     public void setBuyerUsername(String buyerUsername) {
         this.buyerUsername = buyerUsername;
+    }
+
+    public String getCreatorUsername() {
+        return creatorUsername;
+    }
+
+    public void setCreatorUsername(String creatorUsername) {
+        this.creatorUsername = creatorUsername;
     }
 
     public LocalDate getPurchaseDate() {

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -49,6 +49,22 @@ const Reports = () => {
         }
     };
 
+    const handleCloseout = async (id) => {
+        try {
+            const token = localStorage.getItem("token");
+            const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
+            await axios.post(
+                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${id}/closeout`,
+                {},
+                config
+            );
+            setContracts((prev) => prev.filter((c) => c.id !== id));
+        } catch (err) {
+            console.error(err);
+            alert("Failed to closeout contract.");
+        }
+    };
+
     const handleLogout = () => {
         localStorage.removeItem("token");
         localStorage.removeItem("username");
@@ -93,6 +109,15 @@ const Reports = () => {
                                     className="bg-blue-600 hover:bg-blue-700 px-2 py-1 rounded"
                                 >
                                     List for Sale
+                                </button>
+                                <button
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        handleCloseout(contract.id);
+                                    }}
+                                    className="ml-2 bg-red-600 hover:bg-red-700 px-2 py-1 rounded"
+                                >
+                                    Closeout
                                 </button>
                             </td>
                         </tr>


### PR DESCRIPTION
## Summary
- track the user who created each contract
- allow sellers or buyers to close out a contract via `/closeout`
- add button in Reports page to close out purchased contracts

## Testing
- `npm run lint`
- `mvn -q -DskipTests=true package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686be11fd0848329a294fbe8ecb12a82