### PR TITLE
Add contract activity tracking

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ContractActivity.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ContractActivity.java
@@ -1,0 +1,63 @@
+package com.bellingham.datafutures.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "contract_activity")
+public class ContractActivity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "contract_id")
+    private ForwardContract contract;
+
+    private LocalDateTime timestamp;
+    private String username;
+    private String action;
+
+    // Getters and setters
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public ForwardContract getContract() {
+        return contract;
+    }
+
+    public void setContract(ForwardContract contract) {
+        this.contract = contract;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+}

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/repository/ContractActivityRepository.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/repository/ContractActivityRepository.java
@@ -1,0 +1,13 @@
+package com.bellingham.datafutures.repository;
+
+import com.bellingham.datafutures.model.ContractActivity;
+import com.bellingham.datafutures.model.ForwardContract;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ContractActivityRepository extends JpaRepository<ContractActivity, Long> {
+    List<ContractActivity> findByContractOrderByTimestampAsc(ForwardContract contract);
+}


### PR DESCRIPTION
## Summary
- add `ContractActivity` entity to store change logs
- add repository for `ContractActivity`
- record activities on create, update, delete, list, purchase, close-out actions
- expose `GET /api/contracts/{id}/history` to retrieve activity list

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686be2febb4483298b77ff290663b2c3