### PR TITLE
Fix link color override

### DIFF
--- a/bellingham-frontend/src/index.css
+++ b/bellingham-frontend/src/index.css
@@ -19,11 +19,8 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
   text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+  color: inherit;
 }
 
 body {


### PR DESCRIPTION
## Summary
- remove hardcoded link color so sidebar navigation uses Tailwind classes

## Testing
- `npm run lint`
- `./mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686bec7542a48329b0834b133b20753c