### PR TITLE
Add Settings page

### DIFF
--- a/bellingham-frontend/src/App.jsx
+++ b/bellingham-frontend/src/App.jsx
@@ -8,6 +8,7 @@ import Reports from "./components/Reports";
 import Calendar from "./components/Calendar";
 import Signup from "./components/Signup";
 import Account from "./components/Account";
+import Settings from "./components/Settings";
 import Logo from "./components/Logo";
 
 const App = () => {
@@ -37,6 +38,10 @@ const App = () => {
             <Route
                 path="/calendar"
                 element={token ? <Calendar /> : <Navigate to="/login" />}
+            />
+            <Route
+                path="/settings"
+                element={token ? <Settings /> : <Navigate to="/login" />}
             />
             <Route
                 path="/account"

--- a/bellingham-frontend/src/components/Settings.jsx
+++ b/bellingham-frontend/src/components/Settings.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+import Header from "./Header";
+import Sidebar from "./Sidebar";
+import { useNavigate } from "react-router-dom";
+
+const Settings = () => {
+    const navigate = useNavigate();
+
+    const handleLogout = () => {
+        localStorage.removeItem("token");
+        localStorage.removeItem("username");
+        navigate("/login");
+    };
+
+    return (
+        <div className="flex flex-col min-h-screen font-poppins bg-black text-white">
+            <Header />
+            <div className="flex flex-1 relative gap-6">
+                <Sidebar onLogout={handleLogout} />
+                <main className="flex-1 p-8">
+                    <h1 className="text-3xl font-bold mb-6">Settings</h1>
+                    <p>Settings page coming soon.</p>
+                </main>
+            </div>
+        </div>
+    );
+};
+
+export default Settings;

--- a/bellingham-frontend/src/components/Sidebar.jsx
+++ b/bellingham-frontend/src/components/Sidebar.jsx
@@ -47,12 +47,14 @@ const Sidebar = ({ onLogout }) => {
                 >
                     Calendar
                 </NavLink>
-                <button
-                    onClick={() => alert("Settings screen not implemented yet")}
-                    className="text-left hover:bg-gray-700 px-4 py-2 rounded text-white"
+                <NavLink
+                    to="/settings"
+                    className={({ isActive }) =>
+                        `text-left hover:bg-gray-700 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
+                    }
                 >
                     Settings
-                </button>
+                </NavLink>
                 <NavLink
                     to="/account"
                     className={({ isActive }) =>


### PR DESCRIPTION
## Summary
- create `Settings` page component
- add navigation link to Settings in `Sidebar`
- expose `/settings` route in `App`

## Testing
- `npm run lint`
- `npm run build`
- `./mvnw -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686bee1650e08329a9e89c4c8a807804