### PR TITLE
Set base font to Times New Roman

### DIFF
--- a/bellingham-frontend/src/index.css
+++ b/bellingham-frontend/src/index.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: "Times New Roman", Times, serif;
   line-height: 1.5;
   font-weight: 400;
 


### PR DESCRIPTION
## Summary
- update global styles to use "Times New Roman" font

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686bf289eb9c83299b265326192efd51