### PR TITLE
Fix buy button style

### DIFF
--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -179,7 +179,7 @@ const Buy = () => {
                                                 e.stopPropagation();
                                                 handleBuy(contract.id);
                                             }}
-                                            className="bg-green-600 hover:bg-green-700 px-2 py-1 rounded"
+                                            className="bg-green-500 hover:bg-green-600 text-white px-2 py-1 rounded"
                                         >
                                             Buy
                                         </button>
@@ -188,7 +188,7 @@ const Buy = () => {
                                                 e.stopPropagation();
                                                 handleBid(contract.id);
                                             }}
-                                            className="bg-blue-600 hover:bg-blue-700 px-2 py-1 rounded"
+                                            className="bg-blue-500 hover:bg-blue-600 text-white px-2 py-1 rounded"
                                         >
                                             Bid
                                         </button>


### PR DESCRIPTION
## Summary
- tweak colors for Buy and Bid buttons to lighten them and keep text white

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68790b28b1d883298e50baa5676f8308