### PR TITLE
Fix button text color

### DIFF
--- a/bellingham-frontend/src/index.css
+++ b/bellingham-frontend/src/index.css
@@ -41,6 +41,7 @@ button {
   font-weight: 500;
   font-family: inherit;
   background-color: #1a1a1a;
+  color: #fff;
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -62,5 +63,6 @@ button:focus-visible {
   }
   button {
     background-color: #f9f9f9;
+    color: #fff;
   }
 }


### PR DESCRIPTION
## Summary
- fix button styles so text always shows in white

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b8da76c44832997880795bd4db465