### PR TITLE
Improve logo placement and table layout

### DIFF
--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -49,7 +49,7 @@ const Dashboard = () => {
         <Layout onLogout={handleLogout}>
             <main className="flex-1 p-8 overflow-auto">
                 <h2 className="text-3xl font-bold mb-6 text-white">Open Contracts</h2>
-                <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+                <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded mr-4">
                     <thead>
                     <tr className="bg-gray-700 text-left">
                         <th className="border p-2">Title</th>

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -60,10 +60,16 @@ const Login = () => {
             }}
         >
             <div className="absolute inset-0 bg-black opacity-60" />
-            <form
-                onSubmit={handleLogin}
-                className="relative z-10 bg-white bg-opacity-90 shadow-lg rounded-2xl p-8 w-96"
-            >
+            <div className="relative z-10 flex flex-col items-center">
+                <img
+                    src={LoginImage}
+                    alt="Bellingham Data Futures logo"
+                    className="h-[150px] w-[150px] mb-6"
+                />
+                <form
+                    onSubmit={handleLogin}
+                    className="bg-white bg-opacity-90 shadow-lg rounded-2xl p-8 w-96"
+                >
                 {error && <div className="text-red-600 mb-2">{error}</div>}
                 <input
                     type="text"
@@ -93,6 +99,7 @@ const Login = () => {
                     Create Account
                 </button>
             </form>
+            </div>
         </div>
     );
 };

--- a/bellingham-frontend/src/components/Logo.jsx
+++ b/bellingham-frontend/src/components/Logo.jsx
@@ -2,16 +2,15 @@ import React from "react";
 import logoImage from "../assets/login.png";
 
 const Logo = () => {
-    const style =
-        window.location.pathname === "/login"
-            ? { right: "calc(1rem + 10px)" }
-            : {};
+    const isLogin = window.location.pathname === "/login";
+    const style = isLogin ? { right: "calc(1rem + 10px)" } : {};
+    const sizeClass = isLogin ? "w-[150px] h-[150px]" : "w-[180px] h-[180px]";
 
     return (
         <img
             src={logoImage}
             alt="Logo"
-            className="fixed bottom-4 right-4 w-[150px] h-[150px] pointer-events-none"
+            className={`fixed bottom-4 right-4 ${sizeClass} pointer-events-none`}
             style={style}
         />
     );


### PR DESCRIPTION
## Summary
- tweak Logo component so it's slightly bigger outside of login
- center the logo above the login form
- give contracts table a little right margin

## Testing
- `npm run lint`
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687b8f31695c8329af378076949b9fc7