### PR TITLE
Add notification popup for bid actions

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/Notification.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/Notification.java
@@ -13,6 +13,8 @@ public class Notification {
     private String message;
     private LocalDateTime timestamp;
     private boolean readFlag = false;
+    private Long contractId;
+    private Long bidId;
 
     public Long getId() {
         return id;
@@ -52,5 +54,21 @@ public class Notification {
 
     public void setReadFlag(boolean readFlag) {
         this.readFlag = readFlag;
+    }
+
+    public Long getContractId() {
+        return contractId;
+    }
+
+    public void setContractId(Long contractId) {
+        this.contractId = contractId;
+    }
+
+    public Long getBidId() {
+        return bidId;
+    }
+
+    public void setBidId(Long bidId) {
+        this.bidId = bidId;
     }
 }

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/service/NotificationService.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/service/NotificationService.java
@@ -16,10 +16,16 @@ public class NotificationService {
     }
 
     public void notifyUser(String username, String message) {
+        notifyUser(username, message, null, null);
+    }
+
+    public void notifyUser(String username, String message, Long contractId, Long bidId) {
         Notification n = new Notification();
         n.setUsername(username);
         n.setMessage(message);
         n.setTimestamp(LocalDateTime.now());
+        n.setContractId(contractId);
+        n.setBidId(bidId);
         repository.save(n);
     }
 

--- a/bellingham-frontend/src/components/Layout.jsx
+++ b/bellingham-frontend/src/components/Layout.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Header from "./Header";
 import Sidebar from "./Sidebar";
+import NotificationPopup from "./NotificationPopup";
 
 const Layout = ({ children, onLogout }) => (
     <div className="flex flex-col min-h-screen font-sans bg-base text-contrast">
@@ -8,6 +9,7 @@ const Layout = ({ children, onLogout }) => (
         <div className="flex flex-1 relative gap-6">
             <Sidebar onLogout={onLogout} />
             {children}
+            <NotificationPopup />
         </div>
     </div>
 );


### PR DESCRIPTION
## Summary
- extend backend `Notification` with contract and bid identifiers
- overload `NotificationService.notifyUser` to accept IDs
- include contract and bid IDs when saving notifications
- add endpoint to reject a bid
- display new `NotificationPopup` in Layout with accept/decline actions

## Testing
- `./mvnw test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687bd03e303083298cbed889e4b5c1b6