### PR TITLE
Add bidder notifications for bid status

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -246,6 +246,13 @@ public class ForwardContractController {
         bid.setStatus("Accepted");
         bidRepository.save(bid);
 
+        // notify the bidder that their bid was accepted
+        String bidder = bid.getBidderUsername();
+        if (bidder != null && !bidder.isEmpty()) {
+            String msg = "Your bid on contract " + contract.getTitle() + " was accepted";
+            notificationService.notifyUser(bidder, msg, contract.getId(), bid.getId());
+        }
+
         bidRepository.findByContractOrderByTimestampAsc(contract).forEach(b -> {
             if (!b.getId().equals(bidId)) {
                 b.setStatus("Rejected");
@@ -275,6 +282,13 @@ public class ForwardContractController {
         }
         bid.setStatus("Rejected");
         bidRepository.save(bid);
+
+        // notify the bidder that their bid was declined
+        String bidder = bid.getBidderUsername();
+        if (bidder != null && !bidder.isEmpty()) {
+            String msg = "Your bid on contract " + contract.getTitle() + " was declined";
+            notificationService.notifyUser(bidder, msg, contract.getId(), bid.getId());
+        }
         logActivity(contract, username, "Rejected bid");
         return ResponseEntity.ok().build();
     }

--- a/bellingham-frontend/src/components/NotificationPopup.jsx
+++ b/bellingham-frontend/src/components/NotificationPopup.jsx
@@ -94,14 +94,23 @@ const NotificationPopup = () => {
 
     if (!notification) return null;
 
+    const showBidActions =
+        notification.bidId &&
+        notification.contractId &&
+        notification.message.toLowerCase().includes("new bid");
+
     return (
         <div
             className={`fixed bottom-4 right-4 bg-gray-800 text-white p-4 rounded shadow-lg z-50 w-80 transform transition-transform duration-300 ${visible ? "translate-y-0" : "translate-y-full"}`}
         >
             <p className="mb-2">{notification.message}</p>
             <div className="flex gap-2 justify-end">
-                <button className="bg-green-600 px-2 py-1 rounded" onClick={handleAccept}>Accept</button>
-                <button className="bg-red-600 px-2 py-1 rounded" onClick={handleDecline}>Decline</button>
+                {showBidActions && (
+                    <>
+                        <button className="bg-green-600 px-2 py-1 rounded" onClick={handleAccept}>Accept</button>
+                        <button className="bg-red-600 px-2 py-1 rounded" onClick={handleDecline}>Decline</button>
+                    </>
+                )}
                 <button className="bg-gray-600 px-2 py-1 rounded" onClick={handleClose}>Dismiss</button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- notify bidders when their bids are accepted or declined
- hide accept/decline buttons for informational notifications

## Testing
- `./mvnw test` *(fails: Could not resolve dependencies)*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_687bda13ae5883299c07b66ca99477b1