### PR TITLE
Center notification popup

### DIFF
--- a/bellingham-frontend/src/components/NotificationPopup.jsx
+++ b/bellingham-frontend/src/components/NotificationPopup.jsx
@@ -101,7 +101,7 @@ const NotificationPopup = () => {
 
     return (
         <div
-            className={`fixed bottom-4 right-4 bg-gray-800 text-white p-4 rounded shadow-lg z-50 w-80 transform transition-transform duration-300 ${visible ? "translate-y-0" : "translate-y-full"}`}
+            className={`fixed bottom-4 left-1/2 bg-gray-800 text-white p-4 rounded shadow-lg z-50 w-80 transform -translate-x-1/2 transition-transform duration-300 ${visible ? "translate-y-0" : "translate-y-full"}`}
         >
             <p className="mb-2">{notification.message}</p>
             <div className="flex gap-2 justify-end">


### PR DESCRIPTION
## Summary
- tweak `NotificationPopup` to slide in from the screen bottom center

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687bde3a2c608329ba3b1dcae8154820