### PR TITLE
Update login logo placement

### DIFF
--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -4,7 +4,6 @@ import React, { useState } from "react";
 import axios from "axios";
 import LoginImage from "../assets/login.png";
 import { safeSetItem } from "../utils/storage";
-import Header from "./Header";
 
 const Login = () => {
     const [username, setUsername] = useState("");
@@ -51,23 +50,17 @@ const Login = () => {
     };
 
     return (
-        <div className="flex flex-col min-h-screen">
-            <Header />
-            <div
-                className="relative flex flex-col items-center justify-center flex-1"
-                style={{
-                    backgroundImage: `url(${LoginImage})`,
-                    backgroundSize: "150px",
-                    backgroundRepeat: "no-repeat",
-                    backgroundPosition: "bottom right",
-                }}
-            >
-                <div className="absolute inset-0 bg-black opacity-60" />
-                <div className="relative z-10 flex flex-col items-center">
-                    <form
-                        onSubmit={handleLogin}
-                        className="bg-white bg-opacity-90 shadow-lg rounded-2xl p-8 w-96"
-                    >
+        <div className="flex flex-col min-h-screen items-center justify-center">
+            <div className="flex flex-col items-center justify-center">
+                <img
+                    src={LoginImage}
+                    alt="Bellingham Data Futures logo"
+                    className="h-32 w-32 mb-4"
+                />
+                <form
+                    onSubmit={handleLogin}
+                    className="bg-white bg-opacity-90 shadow-lg rounded-2xl p-8 w-96 flex flex-col items-center"
+                >
                 {error && <div className="text-red-600 mb-2">{error}</div>}
                 <input
                     type="text"
@@ -97,10 +90,9 @@ const Login = () => {
                     Create Account
                 </button>
             </form>
-                </div>
-            </div>
         </div>
-    );
+    </div>
+        );
 };
 
 export default Login;


### PR DESCRIPTION
## Summary
- simplify Login component imports
- remove the header and background image from the login page
- display a single centered logo directly above the login form

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687be18bd2c0832994ce5c763525a002