### PR TITLE
Add controller and service tests

### DIFF
--- a/bellingham-datafutures/README.md
+++ b/bellingham-datafutures/README.md
@@ -48,8 +48,10 @@ java -jar target/datafutures-0.0.1-SNAPSHOT.jar
 
 ## Running tests
 
-Execute the unit tests using Maven:
+Unit tests use an in-memory H2 database defined in
+`src/test/resources/application-test.properties`. Run them with the
+`test` Spring profile:
 
 ```bash
-./mvnw test
+./mvnw test -Dspring.profiles.active=test
 ```

--- a/bellingham-datafutures/pom.xml
+++ b/bellingham-datafutures/pom.xml
@@ -93,6 +93,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- In-memory database for tests -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- PDF generation -->
         <dependency>
             <groupId>org.apache.pdfbox</groupId>

--- a/bellingham-datafutures/src/test/java/com/bellingham/datafutures/ForwardContractControllerTest.java
+++ b/bellingham-datafutures/src/test/java/com/bellingham/datafutures/ForwardContractControllerTest.java
@@ -1,0 +1,60 @@
+package com.bellingham.datafutures;
+
+import com.bellingham.datafutures.controller.ForwardContractController;
+import com.bellingham.datafutures.model.ForwardContract;
+import com.bellingham.datafutures.repository.BidRepository;
+import com.bellingham.datafutures.repository.ContractActivityRepository;
+import com.bellingham.datafutures.repository.ForwardContractRepository;
+import com.bellingham.datafutures.repository.UserRepository;
+import com.bellingham.datafutures.service.NotificationService;
+import com.bellingham.datafutures.service.PdfService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ForwardContractController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ForwardContractControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ForwardContractRepository repository;
+    @MockBean
+    private UserRepository userRepository;
+    @MockBean
+    private PdfService pdfService;
+    @MockBean
+    private ContractActivityRepository activityRepository;
+    @MockBean
+    private BidRepository bidRepository;
+    @MockBean
+    private NotificationService notificationService;
+
+    @Test
+    void getAvailableContractsReturnsPage() throws Exception {
+        ForwardContract contract = new ForwardContract();
+        contract.setId(1L);
+        contract.setTitle("Test Contract");
+        given(repository.findByStatus(eq("Available"), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(contract)));
+
+        mockMvc.perform(get("/api/contracts/available"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].title").value("Test Contract"));
+    }
+}

--- a/bellingham-datafutures/src/test/java/com/bellingham/datafutures/NotificationControllerTest.java
+++ b/bellingham-datafutures/src/test/java/com/bellingham/datafutures/NotificationControllerTest.java
@@ -1,0 +1,58 @@
+package com.bellingham.datafutures;
+
+import com.bellingham.datafutures.controller.NotificationController;
+import com.bellingham.datafutures.model.Notification;
+import com.bellingham.datafutures.service.NotificationService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NotificationController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class NotificationControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private NotificationService notificationService;
+
+    @Test
+    void getNotificationsReturnsResults() throws Exception {
+        Notification n = new Notification();
+        n.setId(1L);
+        n.setUsername("user");
+        n.setMessage("hello");
+        n.setTimestamp(LocalDateTime.now());
+        given(notificationService.getNotifications("user"))
+                .willReturn(List.of(n));
+
+        mockMvc.perform(get("/api/notifications")
+                        .with(SecurityMockMvcRequestPostProcessors.user("user")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].message").value("hello"));
+    }
+
+    @Test
+    void markReadCallsService() throws Exception {
+        mockMvc.perform(post("/api/notifications/5/read")
+                        .with(SecurityMockMvcRequestPostProcessors.user("user")))
+                .andExpect(status().isOk());
+
+        verify(notificationService).markRead(5L);
+    }
+}

--- a/bellingham-datafutures/src/test/java/com/bellingham/datafutures/NotificationServiceTest.java
+++ b/bellingham-datafutures/src/test/java/com/bellingham/datafutures/NotificationServiceTest.java
@@ -1,0 +1,53 @@
+package com.bellingham.datafutures;
+
+import com.bellingham.datafutures.model.Notification;
+import com.bellingham.datafutures.repository.NotificationRepository;
+import com.bellingham.datafutures.service.NotificationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(NotificationService.class)
+@ActiveProfiles("test")
+class NotificationServiceTest {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Test
+    void notifyUserPersistsNotification() {
+        notificationService.notifyUser("alice", "hello");
+
+        List<Notification> all = notificationRepository.findAll();
+        assertThat(all).hasSize(1);
+        Notification n = all.get(0);
+        assertThat(n.getUsername()).isEqualTo("alice");
+        assertThat(n.getMessage()).isEqualTo("hello");
+        assertThat(n.isReadFlag()).isFalse();
+    }
+
+    @Test
+    void markReadUpdatesFlag() {
+        Notification n = new Notification();
+        n.setUsername("bob");
+        n.setMessage("msg");
+        n.setTimestamp(LocalDateTime.now());
+        notificationRepository.save(n);
+
+        notificationService.markRead(n.getId());
+
+        Notification updated = notificationRepository.findById(n.getId()).orElseThrow();
+        assertThat(updated.isReadFlag()).isTrue();
+    }
+}

--- a/bellingham-datafutures/src/test/resources/application-test.properties
+++ b/bellingham-datafutures/src/test/resources/application-test.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+jwt.secret=test-secret
+logging.level.org.springframework=warn


### PR DESCRIPTION
## Summary
- create controller tests with MockMvc
- create service tests using `@DataJpaTest`
- provide in-memory DB settings for tests
- update backend README with testing instructions

## Testing
- `./mvnw test -Dspring.profiles.active=test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687d129a653c8329b55922a3be299f5b