### PR TITLE
Add CI workflow with caching for modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bellingham-datafutures
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Run tests
+        run: ./mvnw test
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bellingham-frontend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: bellingham-frontend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running backend Maven tests and frontend npm tests
- cache Maven and npm dependencies for faster runs

## Testing
- `npm ci`
- `npm test`
- `./mvnw test` *(fails: Could not transfer artifact due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687d33d852c0832983c74829db5fdfc1