### PR TITLE
Use environment variable for JWT secrets

### DIFF
--- a/bellingham-datafutures/README.md
+++ b/bellingham-datafutures/README.md
@@ -4,15 +4,15 @@ This module contains the Spring Boot API used by the platform.
 
 ## Configuration
 
-The API requires a secret key for signing JSON Web Tokens. Provide the key via
-`jwt.secret` in `application.properties` or set an environment variable named
-`JWT_SECRET` when running the application.
+The API requires a secret key for signing JSON Web Tokens. The configuration
+files reference the `JWT_SECRET` environment variable which must be provided
+when running the application:
 
 ```
-jwt.secret=your-strong-secret
+jwt.secret=${JWT_SECRET}
 ```
 
-If the property is missing the application will fail to start.
+If no secret is supplied the application will fail to start.
 
 ## Running the application
 
@@ -29,8 +29,7 @@ spring.datasource.password=bdf_pass
 
 The following environment variables can be used to configure the runtime:
 
-- `JWT_SECRET` – secret used for signing tokens (required if
-  `jwt.secret` is not set).
+- `JWT_SECRET` – secret used for signing tokens.
 - `server.port` – optional port the API listens on. Defaults to `8080`.
 
 Start the service with the Maven wrapper:

--- a/bellingham-datafutures/src/main/resources/application.properties
+++ b/bellingham-datafutures/src/main/resources/application.properties
@@ -9,4 +9,4 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
 # === JWT Configuration ===
-jwt.secret=z2hukfvv09fnaVJxRn_gJKCragUK6L-1v3XfHEKaaSU
+jwt.secret=${JWT_SECRET}

--- a/bellingham-datafutures/src/main/resources/application.yml
+++ b/bellingham-datafutures/src/main/resources/application.yml
@@ -13,5 +13,5 @@ spring:
       max-request-size: 10MB
 
 jwt:
-  secret: my-jwt-secret-key
+  secret: ${JWT_SECRET}
   expirationMs: 86400000


### PR DESCRIPTION
## Summary
- reference `JWT_SECRET` env var in backend configuration
- document the new placeholder format

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687d3893a1c08329ab625d06b348aee6