### PR TITLE
Fix JWT secret placeholder

### DIFF
--- a/bellingham-datafutures/README.md
+++ b/bellingham-datafutures/README.md
@@ -9,7 +9,7 @@ files reference the `JWT_SECRET` environment variable which must be provided
 when running the application:
 
 ```
-jwt.secret=${JWT_SECRET}
+jwt.secret=${JWT_SECRET:}
 ```
 
 If no secret is supplied the application will fail to start.

--- a/bellingham-datafutures/src/main/resources/application.properties
+++ b/bellingham-datafutures/src/main/resources/application.properties
@@ -9,4 +9,4 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
 # === JWT Configuration ===
-jwt.secret=${JWT_SECRET}
+jwt.secret=${JWT_SECRET:}

--- a/bellingham-datafutures/src/main/resources/application.yml
+++ b/bellingham-datafutures/src/main/resources/application.yml
@@ -13,5 +13,5 @@ spring:
       max-request-size: 10MB
 
 jwt:
-  secret: ${JWT_SECRET}
+  secret: ${JWT_SECRET:}
   expirationMs: 86400000


### PR DESCRIPTION
## Summary
- allow missing `JWT_SECRET` env var by providing empty default
- update docs accordingly

## Testing
- `./mvnw test -Dspring.profiles.active=test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687d3bcad17c832991f2124237692cf6