### PR TITLE
Hard-code JWT secret again

### DIFF
--- a/bellingham-datafutures/README.md
+++ b/bellingham-datafutures/README.md
@@ -4,15 +4,8 @@ This module contains the Spring Boot API used by the platform.
 
 ## Configuration
 
-The API requires a secret key for signing JSON Web Tokens. The configuration
-files reference the `JWT_SECRET` environment variable which must be provided
-when running the application:
-
-```
-jwt.secret=${JWT_SECRET:}
-```
-
-If no secret is supplied the application will fail to start.
+The API requires a secret key for signing JSON Web Tokens. The value is
+hard-coded in `JwtUtil` so no additional configuration is necessary.
 
 ## Running the application
 
@@ -29,7 +22,6 @@ spring.datasource.password=bdf_pass
 
 The following environment variables can be used to configure the runtime:
 
-- `JWT_SECRET` – secret used for signing tokens.
 - `server.port` – optional port the API listens on. Defaults to `8080`.
 
 Start the service with the Maven wrapper:

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/security/JwtUtil.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/security/JwtUtil.java
@@ -2,8 +2,6 @@ package com.bellingham.datafutures.security;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
-import jakarta.annotation.PostConstruct;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
@@ -12,24 +10,10 @@ import java.util.Date;
 @Component
 public class JwtUtil {
 
+    private static final String SECRET = "my-very-secret-key-that-should-be-long-enough";
     private static final long EXPIRATION_TIME = 864_000_00; // 1 day in milliseconds
 
-    @Value("${jwt.secret:}")
-    private String secretProperty;
-
-    private Key key;
-
-    @PostConstruct
-    public void init() {
-        String secret = (secretProperty == null || secretProperty.isEmpty())
-                ? System.getenv("JWT_SECRET")
-                : secretProperty;
-        if (secret == null || secret.isEmpty()) {
-            throw new IllegalStateException(
-                    "JWT secret not configured. Set 'jwt.secret' or JWT_SECRET.");
-        }
-        key = Keys.hmacShaKeyFor(secret.getBytes());
-    }
+    private final Key key = Keys.hmacShaKeyFor(SECRET.getBytes());
 
     public String generateToken(String username) {
         return Jwts.builder()

--- a/bellingham-datafutures/src/main/resources/application.properties
+++ b/bellingham-datafutures/src/main/resources/application.properties
@@ -8,5 +8,3 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
-# === JWT Configuration ===
-jwt.secret=${JWT_SECRET:}

--- a/bellingham-datafutures/src/main/resources/application.yml
+++ b/bellingham-datafutures/src/main/resources/application.yml
@@ -13,5 +13,4 @@ spring:
       max-request-size: 10MB
 
 jwt:
-  secret: ${JWT_SECRET:}
   expirationMs: 86400000

--- a/bellingham-datafutures/src/test/resources/application-test.properties
+++ b/bellingham-datafutures/src/test/resources/application-test.properties
@@ -4,5 +4,4 @@ spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-jwt.secret=test-secret
 logging.level.org.springframework=warn


### PR DESCRIPTION
## Summary
- keep JWT secret constant in `JwtUtil`
- remove jwt.secret properties and docs

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687d3e18e86c832998d9875b9fcbf64d