### PR TITLE
Add sales contract view

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -143,6 +143,15 @@ public class ForwardContractController {
         return repository.findByCreatorUsername(username, pageable);
     }
 
+    @GetMapping("/sold")
+    public Page<ForwardContract> getSoldContracts(@RequestParam(defaultValue = "0") int page,
+                                                  @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        String username = org.springframework.security.core.context.SecurityContextHolder
+                .getContext().getAuthentication().getName();
+        return repository.findByCreatorUsernameAndBuyerUsernameIsNotNull(username, pageable);
+    }
+
     @PutMapping("/{id}")
     public ResponseEntity<ForwardContract> update(@PathVariable Long id, @RequestBody ForwardContract updated) {
         return repository.findById(id)

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/repository/ForwardContractRepository.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/repository/ForwardContractRepository.java
@@ -14,5 +14,7 @@ public interface ForwardContractRepository extends JpaRepository<ForwardContract
     Page<ForwardContract> findByStatusAndBuyerUsername(String status, String buyerUsername, Pageable pageable);
     List<ForwardContract> findByBuyerUsername(String buyerUsername);
     Page<ForwardContract> findByCreatorUsername(String creatorUsername, Pageable pageable);
+
+    Page<ForwardContract> findByCreatorUsernameAndBuyerUsernameIsNotNull(String creatorUsername, Pageable pageable);
 }
 

--- a/bellingham-frontend/src/App.jsx
+++ b/bellingham-frontend/src/App.jsx
@@ -5,6 +5,7 @@ import Dashboard from "./components/Dashboard";
 import Buy from "./components/Buy";
 import Sell from "./components/Sell";
 import Reports from "./components/Reports";
+import Sales from "./components/Sales";
 import Calendar from "./components/Calendar";
 import Signup from "./components/Signup";
 import Account from "./components/Account";
@@ -34,6 +35,10 @@ const App = () => {
             <Route
                 path="/reports"
                 element={token ? <Reports /> : <Navigate to="/login" />}
+            />
+            <Route
+                path="/sales"
+                element={token ? <Sales /> : <Navigate to="/login" />}
             />
             <Route
                 path="/calendar"

--- a/bellingham-frontend/src/components/Sales.jsx
+++ b/bellingham-frontend/src/components/Sales.jsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import Layout from "./Layout";
+import ContractDetailsPanel from "./ContractDetailsPanel";
+import { useNavigate } from "react-router-dom";
+
+const Sales = () => {
+    const navigate = useNavigate();
+    const [contracts, setContracts] = useState([]);
+    const [error, setError] = useState("");
+    const [selectedContract, setSelectedContract] = useState(null);
+
+    useEffect(() => {
+        const fetchSales = async () => {
+            try {
+                const token = localStorage.getItem("token");
+                const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
+                const res = await axios.get(
+                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/sold`,
+                    config
+                );
+                setContracts(res.data.content);
+            } catch (err) {
+                console.error(err);
+                setError("Failed to load sold contracts.");
+            }
+        };
+        fetchSales();
+    }, []);
+
+    const handleLogout = () => {
+        localStorage.removeItem("token");
+        localStorage.removeItem("username");
+        navigate("/login");
+    };
+
+    return (
+        <Layout onLogout={handleLogout}>
+            <main className="flex-1 p-8">
+                <h1 className="text-3xl font-bold mb-6">Sold Contracts</h1>
+                {error && <p className="text-red-500 mb-4">{error}</p>}
+                <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+                    <thead>
+                        <tr className="bg-gray-700 text-left">
+                            <th className="border p-2">Title</th>
+                            <th className="border p-2">Buyer</th>
+                            <th className="border p-2">Price</th>
+                            <th className="border p-2">Delivery Date</th>
+                            <th className="border p-2">Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {contracts.map((c) => (
+                            <tr
+                                key={c.id}
+                                className="hover:bg-gray-600 cursor-pointer"
+                                onClick={() => setSelectedContract(c)}
+                            >
+                                <td className="border p-2">{c.title}</td>
+                                <td className="border p-2">{c.buyerUsername}</td>
+                                <td className="border p-2">${c.price}</td>
+                                <td className="border p-2">{c.deliveryDate}</td>
+                                <td className="border p-2">{c.status}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+                <ContractDetailsPanel
+                    inline
+                    contract={selectedContract}
+                    onClose={() => setSelectedContract(null)}
+                />
+            </main>
+        </Layout>
+    );
+};
+
+export default Sales;

--- a/bellingham-frontend/src/components/Sidebar.jsx
+++ b/bellingham-frontend/src/components/Sidebar.jsx
@@ -40,6 +40,14 @@ const Sidebar = ({ onLogout }) => {
                     Reports
                 </NavLink>
                 <NavLink
+                    to="/sales"
+                    className={({ isActive }) =>
+                        `text-left hover:bg-gray-700 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
+                    }
+                >
+                    Sales
+                </NavLink>
+                <NavLink
                     to="/calendar"
                     className={({ isActive }) =>
                         `text-left hover:bg-gray-700 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`


### PR DESCRIPTION
## Summary
- expose endpoint to list sold contracts
- add repository method for sold contracts
- implement Sales page in frontend
- add Sales link to sidebar and route

## Testing
- `npm test`
- `./mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687d462f15ec8329a6cf56caf7704a79