### PR TITLE
Implement contract history feature

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -350,6 +350,19 @@ public class ForwardContractController {
                 .orElse(ResponseEntity.notFound().<ForwardContract>build());
     }
 
+    @GetMapping("/history")
+    public Page<ForwardContract> getHistory(@RequestParam(defaultValue = "0") int page,
+                                            @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        return repository.findByStatusAndBuyerUsernameOrStatusAndCreatorUsername(
+                "Closed",
+                username,
+                "Closed",
+                username,
+                pageable);
+    }
+
     @GetMapping("/{id}/history")
     public ResponseEntity<java.util.List<ContractActivity>> getHistory(@PathVariable Long id) {
         return repository.findById(id)

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/repository/ForwardContractRepository.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/repository/ForwardContractRepository.java
@@ -16,5 +16,12 @@ public interface ForwardContractRepository extends JpaRepository<ForwardContract
     Page<ForwardContract> findByCreatorUsername(String creatorUsername, Pageable pageable);
 
     Page<ForwardContract> findByCreatorUsernameAndBuyerUsernameIsNotNull(String creatorUsername, Pageable pageable);
+
+    Page<ForwardContract> findByStatusAndBuyerUsernameOrStatusAndCreatorUsername(
+            String status1,
+            String buyerUsername,
+            String status2,
+            String creatorUsername,
+            Pageable pageable);
 }
 

--- a/bellingham-frontend/src/App.jsx
+++ b/bellingham-frontend/src/App.jsx
@@ -10,6 +10,7 @@ import Calendar from "./components/Calendar";
 import Signup from "./components/Signup";
 import Account from "./components/Account";
 import Settings from "./components/Settings";
+import History from "./components/History";
 import Logo from "./components/Logo";
 
 const App = () => {
@@ -51,6 +52,10 @@ const App = () => {
             <Route
                 path="/account"
                 element={token ? <Account /> : <Navigate to="/login" />}
+            />
+            <Route
+                path="/history"
+                element={token ? <History /> : <Navigate to="/login" />}
             />
         </Routes>
         <Logo />

--- a/bellingham-frontend/src/components/History.jsx
+++ b/bellingham-frontend/src/components/History.jsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import Layout from "./Layout";
+import ContractDetailsPanel from "./ContractDetailsPanel";
+import { useNavigate } from "react-router-dom";
+
+const History = () => {
+    const navigate = useNavigate();
+    const [contracts, setContracts] = useState([]);
+    const [error, setError] = useState("");
+    const [selectedContract, setSelectedContract] = useState(null);
+
+    useEffect(() => {
+        const fetchHistory = async () => {
+            try {
+                const token = localStorage.getItem("token");
+                const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
+                const res = await axios.get(
+                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/history`,
+                    config
+                );
+                setContracts(res.data.content);
+            } catch (err) {
+                console.error(err);
+                setError("Failed to load contract history.");
+            }
+        };
+        fetchHistory();
+    }, []);
+
+    const handleLogout = () => {
+        localStorage.removeItem("token");
+        localStorage.removeItem("username");
+        navigate("/login");
+    };
+
+    return (
+        <Layout onLogout={handleLogout}>
+            <main className="flex-1 p-8">
+                <h1 className="text-3xl font-bold mb-6">Contract History</h1>
+                {error && <p className="text-red-500 mb-4">{error}</p>}
+                <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+                    <thead>
+                        <tr className="bg-gray-700 text-left">
+                            <th className="border p-2">Title</th>
+                            <th className="border p-2">Seller</th>
+                            <th className="border p-2">Buyer</th>
+                            <th className="border p-2">Price</th>
+                            <th className="border p-2">Delivery</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {contracts.map((c) => (
+                            <tr
+                                key={c.id}
+                                className="hover:bg-gray-600 cursor-pointer"
+                                onClick={() => setSelectedContract(c)}
+                            >
+                                <td className="border p-2">{c.title}</td>
+                                <td className="border p-2">{c.seller}</td>
+                                <td className="border p-2">{c.buyerUsername || "-"}</td>
+                                <td className="border p-2">${c.price}</td>
+                                <td className="border p-2">{c.deliveryDate}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+                <ContractDetailsPanel
+                    inline
+                    contract={selectedContract}
+                    onClose={() => setSelectedContract(null)}
+                />
+            </main>
+        </Layout>
+    );
+};
+
+export default History;

--- a/bellingham-frontend/src/components/Sidebar.jsx
+++ b/bellingham-frontend/src/components/Sidebar.jsx
@@ -56,6 +56,14 @@ const Sidebar = ({ onLogout }) => {
                     Calendar
                 </NavLink>
                 <NavLink
+                    to="/history"
+                    className={({ isActive }) =>
+                        `text-left hover:bg-gray-700 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
+                    }
+                >
+                    History
+                </NavLink>
+                <NavLink
                     to="/settings"
                     className={({ isActive }) =>
                         `text-left hover:bg-gray-700 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`


### PR DESCRIPTION
## Summary
- add repository helper to fetch closed contracts for either buyer or seller
- expose `/api/contracts/history` endpoint
- create `History` page in frontend
- link history page in router and sidebar

## Testing
- `npm test --silent`
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68804dd8dd3c832980b4c1c72080948c