### PR TITLE
Center all tables

### DIFF
--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -152,7 +152,7 @@ const Buy = () => {
                             ))}
                         </select>
                     </div>
-                    <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+                    <table className="w-[90%] mx-auto table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
                         <thead>
                             <tr className="bg-gray-700 text-left">
                                 <th className="border p-2">Title</th>

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -49,7 +49,7 @@ const Dashboard = () => {
         <Layout onLogout={handleLogout}>
             <main className="flex-1 p-8 overflow-auto">
                 <h2 className="text-3xl font-bold mb-6 text-white">Open Contracts</h2>
-                <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded mr-4">
+                <table className="w-[90%] mx-auto table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
                     <thead>
                     <tr className="bg-gray-700 text-left">
                         <th className="border p-2">Title</th>

--- a/bellingham-frontend/src/components/History.jsx
+++ b/bellingham-frontend/src/components/History.jsx
@@ -39,7 +39,7 @@ const History = () => {
             <main className="flex-1 p-8">
                 <h1 className="text-3xl font-bold mb-6">Contract History</h1>
                 {error && <p className="text-red-500 mb-4">{error}</p>}
-                <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+                <table className="w-[90%] mx-auto table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
                     <thead>
                         <tr className="bg-gray-700 text-left">
                             <th className="border p-2">Title</th>

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -75,7 +75,7 @@ const Reports = () => {
             <main className="flex-1 p-8">
                 <h1 className="text-3xl font-bold mb-6">Purchased Contracts</h1>
                     {error && <p className="text-red-500 mb-4">{error}</p>}
-                    <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+                    <table className="w-[90%] mx-auto table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
                 <thead>
                     <tr className="bg-gray-700 text-left">
                         <th className="border p-2">Title</th>

--- a/bellingham-frontend/src/components/Sales.jsx
+++ b/bellingham-frontend/src/components/Sales.jsx
@@ -39,7 +39,7 @@ const Sales = () => {
             <main className="flex-1 p-8">
                 <h1 className="text-3xl font-bold mb-6">Sold Contracts</h1>
                 {error && <p className="text-red-500 mb-4">{error}</p>}
-                <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+                <table className="w-[90%] mx-auto table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
                     <thead>
                         <tr className="bg-gray-700 text-left">
                             <th className="border p-2">Title</th>

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -303,7 +303,7 @@ const Sell = () => {
 
             <h2 className="text-2xl font-bold mt-10 mb-4">My Contracts</h2>
             {error && <p className="text-red-500 mb-4">{error}</p>}
-            <table className="w-full table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+            <table className="w-[90%] mx-auto table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
                 <thead>
                     <tr className="bg-gray-700 text-left">
                         <th className="border p-2">Title</th>


### PR DESCRIPTION
## Summary
- add `mx-auto w-[90%]` to tables across pages so they don't hug the left side

## Testing
- `npm test --silent`
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6880556fbe888329bd7aa884a2d3027b