### PR TITLE
Add bid chart to contract details panel

### DIFF
--- a/bellingham-frontend/src/components/BidChart.jsx
+++ b/bellingham-frontend/src/components/BidChart.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    BarElement,
+    Tooltip,
+    Legend,
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+const BidChart = ({ bids = [] }) => {
+    if (!bids.length) return null;
+
+    const data = {
+        labels: bids.map((b) => b.bidderUsername),
+        datasets: [
+            {
+                label: 'Bid Amount',
+                data: bids.map((b) => b.amount),
+                backgroundColor: 'rgba(37,99,235,0.6)', // tailwind blue-600
+            },
+        ],
+    };
+
+    const options = {
+        plugins: {
+            legend: { display: false },
+        },
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+            y: { beginAtZero: true },
+        },
+    };
+
+    return (
+        <div className="h-64 mt-4">
+            <Bar data={data} options={options} />
+        </div>
+    );
+};
+
+export default BidChart;

--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
+import BidChart from "./BidChart";
 
 const ContractDetailsPanel = ({
     contract,
@@ -87,6 +88,7 @@ const ContractDetailsPanel = ({
                             </li>
                         ))}
                     </ul>
+                    <BidChart bids={bids} />
                 </div>
             )}
             <button


### PR DESCRIPTION
## Summary
- create a new `BidChart` component using `react-chartjs-2`
- show bid chart in `ContractDetailsPanel` when bids are present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68858fa27ca08329af1eaf769bf3f857