### PR TITLE
Add fields for detailed contract entry

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
@@ -26,6 +26,13 @@ public class ForwardContract {
     private String termsFileName;
     @Column(columnDefinition = "TEXT")
     private String agreementText;
+    private java.time.LocalDate effectiveDate;
+    private String sellerFullName;
+    private String sellerEntityType;
+    private String sellerAddress;
+    private String buyerFullName;
+    private String buyerEntityType;
+    private String buyerAddress;
     private String status;
     private String buyerUsername;
     private String creatorUsername;
@@ -124,6 +131,62 @@ public class ForwardContract {
 
     public void setAgreementText(String agreementText) {
         this.agreementText = agreementText;
+    }
+
+    public java.time.LocalDate getEffectiveDate() {
+        return effectiveDate;
+    }
+
+    public void setEffectiveDate(java.time.LocalDate effectiveDate) {
+        this.effectiveDate = effectiveDate;
+    }
+
+    public String getSellerFullName() {
+        return sellerFullName;
+    }
+
+    public void setSellerFullName(String sellerFullName) {
+        this.sellerFullName = sellerFullName;
+    }
+
+    public String getSellerEntityType() {
+        return sellerEntityType;
+    }
+
+    public void setSellerEntityType(String sellerEntityType) {
+        this.sellerEntityType = sellerEntityType;
+    }
+
+    public String getSellerAddress() {
+        return sellerAddress;
+    }
+
+    public void setSellerAddress(String sellerAddress) {
+        this.sellerAddress = sellerAddress;
+    }
+
+    public String getBuyerFullName() {
+        return buyerFullName;
+    }
+
+    public void setBuyerFullName(String buyerFullName) {
+        this.buyerFullName = buyerFullName;
+    }
+
+    public String getBuyerEntityType() {
+        return buyerEntityType;
+    }
+
+    public void setBuyerEntityType(String buyerEntityType) {
+        this.buyerEntityType = buyerEntityType;
+    }
+
+    public String getBuyerAddress() {
+        return buyerAddress;
+    }
+
+    public void setBuyerAddress(String buyerAddress) {
+        this.buyerAddress = buyerAddress;
     }
 
     public String getStatus() {

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/service/PdfService.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/service/PdfService.java
@@ -31,8 +31,24 @@ public class PdfService {
                 stream.newLine();
                 stream.showText("Seller: " + nullSafe(contract.getSeller()));
                 stream.newLine();
+                if (contract.getEffectiveDate() != null) {
+                    stream.showText("Effective Date: " + contract.getEffectiveDate().format(DateTimeFormatter.ISO_DATE));
+                    stream.newLine();
+                }
+                stream.showText("Seller Name: " + nullSafe(contract.getSellerFullName()));
+                stream.newLine();
+                stream.showText("Seller Entity Type: " + nullSafe(contract.getSellerEntityType()));
+                stream.newLine();
+                stream.showText("Seller Address: " + nullSafe(contract.getSellerAddress()));
+                stream.newLine();
+                stream.showText("Buyer Name: " + nullSafe(contract.getBuyerFullName()));
+                stream.newLine();
+                stream.showText("Buyer Entity Type: " + nullSafe(contract.getBuyerEntityType()));
+                stream.newLine();
+                stream.showText("Buyer Address: " + nullSafe(contract.getBuyerAddress()));
+                stream.newLine();
                 String buyer = contract.getBuyerUsername() == null ? "-" : contract.getBuyerUsername();
-                stream.showText("Buyer: " + buyer);
+                stream.showText("Buyer Username: " + buyer);
                 stream.newLine();
                 stream.showText("Price: $" + contract.getPrice());
                 stream.newLine();

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -76,6 +76,13 @@ import axios from "axios";
 const Sell = () => {
     const navigate = useNavigate();
     const [form, setForm] = useState({
+        effectiveDate: "",
+        sellerFullName: "",
+        sellerEntityType: "",
+        sellerAddress: "",
+        buyerFullName: "",
+        buyerEntityType: "",
+        buyerAddress: "",
         deliveryDate: "",
         deliveryFormat: "",
         platformName: "",
@@ -128,6 +135,13 @@ const Sell = () => {
             price: parseFloat(form.price || 0),
             dataDescription: form.dataDescription,
             agreementText: form.agreementText,
+            effectiveDate: form.effectiveDate,
+            sellerFullName: form.sellerFullName,
+            sellerEntityType: form.sellerEntityType,
+            sellerAddress: form.sellerAddress,
+            buyerFullName: form.buyerFullName,
+            buyerEntityType: form.buyerEntityType,
+            buyerAddress: form.buyerAddress,
         };
         if (snippet) {
             data.termsFileName = snippet.name;
@@ -141,6 +155,13 @@ const Sell = () => {
             );
             setMessage("✅ Data contract submitted!");
             setForm({
+                effectiveDate: "",
+                sellerFullName: "",
+                sellerEntityType: "",
+                sellerAddress: "",
+                buyerFullName: "",
+                buyerEntityType: "",
+                buyerAddress: "",
                 deliveryDate: "",
                 deliveryFormat: "",
                 platformName: "",
@@ -211,6 +232,83 @@ const Sell = () => {
                 <h1 className="text-3xl font-bold mb-6">Sell Your Data Contract</h1>
                     {message && <p className="mb-4">{message}</p>}
                     <form onSubmit={handleSubmit} className="space-y-6 max-w-xl">
+                <div>
+                    <label>Effective Date</label>
+                    <input
+                        type="date"
+                        name="effectiveDate"
+                        value={form.effectiveDate}
+                        onChange={handleChange}
+                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        required
+                    />
+                </div>
+                <div>
+                    <label>Seller Full Name</label>
+                    <input
+                        type="text"
+                        name="sellerFullName"
+                        value={form.sellerFullName}
+                        onChange={handleChange}
+                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        required
+                    />
+                </div>
+                <div>
+                    <label>Seller Entity Type</label>
+                    <input
+                        type="text"
+                        name="sellerEntityType"
+                        value={form.sellerEntityType}
+                        onChange={handleChange}
+                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        required
+                    />
+                </div>
+                <div>
+                    <label>Seller Address</label>
+                    <input
+                        type="text"
+                        name="sellerAddress"
+                        value={form.sellerAddress}
+                        onChange={handleChange}
+                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        required
+                    />
+                </div>
+                <div>
+                    <label>Buyer Full Name</label>
+                    <input
+                        type="text"
+                        name="buyerFullName"
+                        value={form.buyerFullName}
+                        onChange={handleChange}
+                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        required
+                    />
+                </div>
+                <div>
+                    <label>Buyer Entity Type</label>
+                    <input
+                        type="text"
+                        name="buyerEntityType"
+                        value={form.buyerEntityType}
+                        onChange={handleChange}
+                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        required
+                    />
+                </div>
+                <div>
+                    <label>Buyer Address</label>
+                    <input
+                        type="text"
+                        name="buyerAddress"
+                        value={form.buyerAddress}
+                        onChange={handleChange}
+                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        required
+                    />
+                </div>
                 <div>
                     <label>Delivery Date</label>
                     <input


### PR DESCRIPTION
## Summary
- extend `ForwardContract` with seller/buyer details and effective date
- display the new details in PDFs
- allow sellers to input those details when creating a contract

## Testing
- `mvnw -q -DskipTests package` *(fails: could not resolve dependencies)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68859321a70c83298adff4ed14369fd7