### PR TITLE
Autofill seller info from user profile

### DIFF
--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -97,6 +97,30 @@ const Sell = () => {
     const [error, setError] = useState("");
 
     useEffect(() => {
+        const fetchProfile = async () => {
+            try {
+                const token = localStorage.getItem("token");
+                if (!token) return;
+                const res = await axios.get(
+                    `${import.meta.env.VITE_API_BASE_URL}/api/profile`,
+                    { headers: { Authorization: `Bearer ${token}` } }
+                );
+                setForm((f) => ({
+                    ...f,
+                    sellerFullName:
+                        f.sellerFullName ||
+                        res.data.legalBusinessName ||
+                        res.data.name ||
+                        "",
+                }));
+            } catch (err) {
+                console.error(err);
+            }
+        };
+        fetchProfile();
+    }, []);
+
+    useEffect(() => {
         const fetchContracts = async () => {
             try {
                 const token = localStorage.getItem("token");


### PR DESCRIPTION
## Summary
- autofill `sellerFullName` on the Sell form using account profile information

## Testing
- `./mvnw test -Dspring.profiles.active=test` *(fails: could not resolve parent POM)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6885961d4478832987cd567511a7e173