### PR TITLE
Add view count tracking for contracts

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -65,7 +65,11 @@ public class ForwardContractController {
     @GetMapping("/{id}")
     public ResponseEntity<ForwardContract> getById(@PathVariable Long id) {
         return repository.findById(id)
-                .map(ResponseEntity::ok)
+                .map(contract -> {
+                    contract.setViewCount(contract.getViewCount() + 1);
+                    repository.save(contract);
+                    return ResponseEntity.ok(contract);
+                })
                 .orElse(ResponseEntity.notFound().<ForwardContract>build());
     }
 

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
@@ -50,6 +50,7 @@ public class ForwardContract {
     private String technicalContactEmail;
     private String technicalContactPhone;
     private String companyDescription;
+    private int viewCount;
 
     // Getters and setters
 
@@ -315,5 +316,13 @@ public class ForwardContract {
 
     public void setCompanyDescription(String companyDescription) {
         this.companyDescription = companyDescription;
+    }
+
+    public int getViewCount() {
+        return viewCount;
+    }
+
+    public void setViewCount(int viewCount) {
+        this.viewCount = viewCount;
     }
 }

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -16,6 +16,21 @@ const Buy = () => {
     const [maxPrice, setMaxPrice] = useState("");
     const [sellerFilter, setSellerFilter] = useState("");
 
+    const fetchContract = async (id) => {
+        try {
+            const token = localStorage.getItem("token");
+            const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
+            const res = await axios.get(
+                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${id}`,
+                config
+            );
+            setSelectedContract(res.data);
+        } catch (err) {
+            console.error(err);
+            setSelectedContract(null);
+        }
+    };
+
     useEffect(() => {
         const fetchContracts = async () => {
             try {
@@ -167,7 +182,7 @@ const Buy = () => {
                                 <tr
                                     key={contract.id}
                                     className="hover:bg-gray-600 cursor-pointer"
-                                    onClick={() => setSelectedContract(contract)}
+                                    onClick={() => fetchContract(contract.id)}
                                 >
                                     <td className="border p-2">{contract.title}</td>
                                     <td className="border p-2">{contract.seller}</td>

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -39,6 +39,21 @@ const Dashboard = () => {
         fetchContracts();
     }, [navigate]);
 
+    const fetchContract = async (id) => {
+        try {
+            const token = localStorage.getItem("token");
+            const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
+            const res = await axios.get(
+                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${id}`,
+                config
+            );
+            setSelectedContract(res.data);
+        } catch (err) {
+            console.error(err);
+            setSelectedContract(null);
+        }
+    };
+
     const handleLogout = () => {
         localStorage.removeItem("token");
         localStorage.removeItem("username");
@@ -64,7 +79,7 @@ const Dashboard = () => {
                         <tr
                             key={contract.id}
                             className="hover:bg-gray-600 cursor-pointer"
-                            onClick={() => setSelectedContract(contract)}
+                            onClick={() => fetchContract(contract.id)}
                         >
                             <td className="border p-2">{contract.title}</td>
                             <td className="border p-2">{contract.seller}</td>

--- a/bellingham-frontend/src/components/History.jsx
+++ b/bellingham-frontend/src/components/History.jsx
@@ -28,6 +28,21 @@ const History = () => {
         fetchHistory();
     }, []);
 
+    const fetchContract = async (id) => {
+        try {
+            const token = localStorage.getItem("token");
+            const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
+            const res = await axios.get(
+                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${id}`,
+                config
+            );
+            setSelectedContract(res.data);
+        } catch (err) {
+            console.error(err);
+            setSelectedContract(null);
+        }
+    };
+
     const handleLogout = () => {
         localStorage.removeItem("token");
         localStorage.removeItem("username");
@@ -54,7 +69,7 @@ const History = () => {
                             <tr
                                 key={c.id}
                                 className="hover:bg-gray-600 cursor-pointer"
-                                onClick={() => setSelectedContract(c)}
+                                onClick={() => fetchContract(c.id)}
                             >
                                 <td className="border p-2">{c.title}</td>
                                 <td className="border p-2">{c.seller}</td>

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -32,6 +32,21 @@ const Reports = () => {
         fetchPurchased();
     }, []);
 
+    const fetchContract = async (id) => {
+        try {
+            const token = localStorage.getItem("token");
+            const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
+            const res = await axios.get(
+                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${id}`,
+                config
+            );
+            setSelectedContract(res.data);
+        } catch (err) {
+            console.error(err);
+            setSelectedContract(null);
+        }
+    };
+
     const handleListForSale = async (id) => {
         try {
             const token = localStorage.getItem("token");
@@ -90,7 +105,7 @@ const Reports = () => {
                         <tr
                             key={contract.id}
                             className="hover:bg-gray-600 cursor-pointer"
-                            onClick={() => setSelectedContract(contract)}
+                            onClick={() => fetchContract(contract.id)}
                         >
                             <td className="border p-2">{contract.title}</td>
                             <td className="border p-2">{contract.seller}</td>

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -433,6 +433,7 @@ const Sell = () => {
                         <th className="border p-2">Ask Price</th>
                         <th className="border p-2">Delivery</th>
                         <th className="border p-2">Status</th>
+                        <th className="border p-2">Views</th>
                         <th className="border p-2">Actions</th>
                     </tr>
                 </thead>
@@ -444,6 +445,7 @@ const Sell = () => {
                             <td className="border p-2">${c.price}</td>
                             <td className="border p-2">{c.deliveryDate}</td>
                             <td className="border p-2">{c.status}</td>
+                            <td className="border p-2">{c.viewCount}</td>
                             <td className="border p-2">
                                 <button
                                     className="bg-blue-600 hover:bg-blue-700 px-2 py-1 rounded"


### PR DESCRIPTION
## Summary
- track a new `viewCount` column on `ForwardContract`
- increment contract views when a contract is fetched
- show views on seller dashboard
- update frontend to load contract details when selected

## Testing
- `./mvnw test -Dspring.profiles.active=test` *(fails: Could not resolve parent POM)*
- `npm test --silent` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885987b16f88329b9ad30644e4a7e71