### PR TITLE
Fix login with env fallback

### DIFF
--- a/bellingham-frontend/src/components/Account.jsx
+++ b/bellingham-frontend/src/components/Account.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
+import { apiUrl } from "../utils/api";
 import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
 
@@ -25,7 +26,7 @@ const Account = () => {
                     return;
                 }
                 const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/profile`,
+                    apiUrl("/api/profile"),
                     { headers: { Authorization: `Bearer ${token}` } }
                 );
                 setProfile(res.data);
@@ -66,7 +67,7 @@ const Account = () => {
         try {
             const token = localStorage.getItem("token");
             const res = await axios.put(
-                `${import.meta.env.VITE_API_BASE_URL}/api/profile`,
+                apiUrl("/api/profile"),
                 formData,
                 { headers: { Authorization: `Bearer ${token}` } }
             );

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import axios from "axios";
+import { apiUrl } from "../utils/api";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
@@ -21,7 +22,7 @@ const Buy = () => {
             const token = localStorage.getItem("token");
             const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
             const res = await axios.get(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${id}`,
+                apiUrl(`/api/contracts/${id}`),
                 config
             );
             setSelectedContract(res.data);
@@ -37,7 +38,7 @@ const Buy = () => {
                 const token = localStorage.getItem("token");
                 const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
                 const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/available`,
+                    apiUrl("/api/contracts/available"),
                     config
                 );
                 setContracts(res.data.content);
@@ -62,7 +63,7 @@ const Buy = () => {
             const token = localStorage.getItem("token");
             const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
             await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${contractId}/buy`,
+                apiUrl(`/api/contracts/${contractId}/buy`),
                 {},
                 config
             );
@@ -87,7 +88,7 @@ const Buy = () => {
         try {
             const config = { headers: { Authorization: `Bearer ${token}` } };
             await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${contractId}/bids`,
+                apiUrl(`/api/contracts/${contractId}/bids`),
                 { amount: parseFloat(price) },
                 config
             );

--- a/bellingham-frontend/src/components/Calendar.jsx
+++ b/bellingham-frontend/src/components/Calendar.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import Calendar from "react-calendar";
 import 'react-calendar/dist/Calendar.css';
 import axios from "axios";
+import { apiUrl } from "../utils/api";
 import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
 
@@ -16,7 +17,7 @@ const ContractCalendar = () => {
                 const token = localStorage.getItem("token");
                 const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
                 const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/purchased`,
+                    apiUrl("/api/contracts/purchased"),
                     config
                 );
                 setContracts(res.data.content);

--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
+import { apiUrl } from "../utils/api";
 import BidChart from "./BidChart";
 
 const ContractDetailsPanel = ({
@@ -17,7 +18,7 @@ const ContractDetailsPanel = ({
             const token = localStorage.getItem("token");
             const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
             axios
-                .get(`${import.meta.env.VITE_API_BASE_URL}/api/contracts/${contract.id}/bids`, config)
+                .get(apiUrl(`/api/contracts/${contract.id}/bids`), config)
                 .then((res) => setBids(res.data))
                 .catch(() => setBids([]));
         } else {
@@ -35,7 +36,7 @@ const ContractDetailsPanel = ({
     const handleDownload = async () => {
         const token = localStorage.getItem("token");
         const res = await fetch(
-            `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${contract.id}/pdf`,
+            apiUrl(`/api/contracts/${contract.id}/pdf`),
             {
                 headers: token ? { Authorization: `Bearer ${token}` } : {},
             }

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
+import { apiUrl } from "../utils/api";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import Layout from "./Layout";
 
@@ -24,7 +25,7 @@ const Dashboard = () => {
                     ? { headers: { Authorization: `Bearer ${token}` } }
                     : {};
                 const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/available`,
+                    apiUrl("/api/contracts/available"),
                     config
                 );
 
@@ -44,7 +45,7 @@ const Dashboard = () => {
             const token = localStorage.getItem("token");
             const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
             const res = await axios.get(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${id}`,
+                apiUrl(`/api/contracts/${id}`),
                 config
             );
             setSelectedContract(res.data);

--- a/bellingham-frontend/src/components/History.jsx
+++ b/bellingham-frontend/src/components/History.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
+import { apiUrl } from "../utils/api";
 import Layout from "./Layout";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import { useNavigate } from "react-router-dom";
@@ -16,7 +17,7 @@ const History = () => {
                 const token = localStorage.getItem("token");
                 const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
                 const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/history`,
+                    apiUrl("/api/contracts/history"),
                     config
                 );
                 setContracts(res.data.content);
@@ -33,7 +34,7 @@ const History = () => {
             const token = localStorage.getItem("token");
             const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
             const res = await axios.get(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${id}`,
+                apiUrl(`/api/contracts/${id}`),
                 config
             );
             setSelectedContract(res.data);

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import axios from "axios";
 import LoginImage from "../assets/login.png";
 import { safeSetItem } from "../utils/storage";
+import { apiUrl } from "../utils/api";
 
 const Login = () => {
     const [username, setUsername] = useState("");
@@ -17,7 +18,7 @@ const Login = () => {
 
         try {
             const res = await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/authenticate`,
+                apiUrl("/api/authenticate"),
                 {
                 username,
                 password,

--- a/bellingham-frontend/src/components/NotificationPopup.jsx
+++ b/bellingham-frontend/src/components/NotificationPopup.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
+import { apiUrl } from "../utils/api";
 
 const NotificationPopup = () => {
     const [notification, setNotification] = useState(null);
@@ -10,7 +11,7 @@ const NotificationPopup = () => {
         if (!token) return;
         const config = { headers: { Authorization: `Bearer ${token}` } };
         try {
-            const res = await axios.get(`${import.meta.env.VITE_API_BASE_URL}/api/notifications`, config);
+            const res = await axios.get(apiUrl("/api/notifications"), config);
             const unread = res.data.find((n) => !n.readFlag);
             if (unread && (!notification || unread.id !== notification.id)) {
                 setNotification(unread);
@@ -37,7 +38,7 @@ const NotificationPopup = () => {
         if (!token) return;
         const config = { headers: { Authorization: `Bearer ${token}` } };
         try {
-            await axios.post(`${import.meta.env.VITE_API_BASE_URL}/api/notifications/${id}/read`, {}, config);
+            await axios.post(apiUrl(`/api/notifications/${id}/read`), {}, config);
         } catch (err) {
             console.error("Failed to mark notification read", err);
         }
@@ -58,7 +59,7 @@ const NotificationPopup = () => {
         const config = { headers: { Authorization: `Bearer ${token}` } };
         try {
             await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${notification.contractId}/bids/${notification.bidId}/accept`,
+                apiUrl(`/api/contracts/${notification.contractId}/bids/${notification.bidId}/accept`),
                 {},
                 config
             );
@@ -79,7 +80,7 @@ const NotificationPopup = () => {
         const config = { headers: { Authorization: `Bearer ${token}` } };
         try {
             await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${notification.contractId}/bids/${notification.bidId}/reject`,
+                apiUrl(`/api/contracts/${notification.contractId}/bids/${notification.bidId}/reject`),
                 {},
                 config
             );

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
+import { apiUrl } from "../utils/api";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
@@ -21,7 +22,7 @@ const Reports = () => {
                 const token = localStorage.getItem("token");
                 const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
                 const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/purchased`,
+                    apiUrl("/api/contracts/purchased"),
                     config
                 );
                 setContracts(res.data.content);
@@ -37,7 +38,7 @@ const Reports = () => {
             const token = localStorage.getItem("token");
             const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
             const res = await axios.get(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${id}`,
+                apiUrl(`/api/contracts/${id}`),
                 config
             );
             setSelectedContract(res.data);
@@ -52,7 +53,7 @@ const Reports = () => {
             const token = localStorage.getItem("token");
             const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
             await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${id}/list`,
+                apiUrl(`/api/contracts/${id}/list`),
                 {},
                 config
             );
@@ -68,7 +69,7 @@ const Reports = () => {
             const token = localStorage.getItem("token");
             const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
             await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${id}/closeout`,
+                apiUrl(`/api/contracts/${id}/closeout`),
                 {},
                 config
             );

--- a/bellingham-frontend/src/components/Sales.jsx
+++ b/bellingham-frontend/src/components/Sales.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
+import { apiUrl } from "../utils/api";
 import Layout from "./Layout";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import { useNavigate } from "react-router-dom";
@@ -16,7 +17,7 @@ const Sales = () => {
                 const token = localStorage.getItem("token");
                 const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
                 const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/sold`,
+                    apiUrl("/api/contracts/sold"),
                     config
                 );
                 setContracts(res.data.content);

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -72,6 +72,7 @@ IN WITNESS WHEREOF, the Parties have executed this Forward Data Sale Agreement a
  </div>
  </div>`;
 import axios from "axios";
+import { apiUrl } from "../utils/api";
 
 const Sell = () => {
     const navigate = useNavigate();
@@ -102,7 +103,7 @@ const Sell = () => {
                 const token = localStorage.getItem("token");
                 if (!token) return;
                 const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/profile`,
+                    apiUrl("/api/profile"),
                     { headers: { Authorization: `Bearer ${token}` } }
                 );
                 setForm((f) => ({
@@ -126,7 +127,7 @@ const Sell = () => {
                 const token = localStorage.getItem("token");
                 const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
                 const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/my`,
+                    apiUrl("/api/contracts/my"),
                     config
                 );
                 setContracts(res.data.content);
@@ -173,7 +174,7 @@ const Sell = () => {
 
         try {
             await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts`,
+                apiUrl("/api/contracts"),
                 data,
                 config
             );
@@ -211,7 +212,7 @@ const Sell = () => {
         const token = localStorage.getItem("token");
         const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
         const res = await axios.get(
-            `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${contractId}/bids`,
+            apiUrl(`/api/contracts/${contractId}/bids`),
             config
         );
         return res.data;
@@ -239,7 +240,7 @@ const Sell = () => {
             const token = localStorage.getItem("token");
             const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
             await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${contractId}/bids/${bidId}/accept`,
+                apiUrl(`/api/contracts/${contractId}/bids/${bidId}/accept`),
                 {},
                 config
             );

--- a/bellingham-frontend/src/components/Signup.jsx
+++ b/bellingham-frontend/src/components/Signup.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import axios from "axios";
+import { apiUrl } from "../utils/api";
 import { useNavigate } from "react-router-dom";
 import Header from "./Header";
 
@@ -31,7 +32,7 @@ const Signup = () => {
         setMessage("");
         try {
             await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/register`,
+                apiUrl("/api/register"),
                 form
             );
             setMessage("Registration successful. Please log in.");

--- a/bellingham-frontend/src/utils/api.js
+++ b/bellingham-frontend/src/utils/api.js
@@ -1,0 +1,10 @@
+export function apiUrl(path) {
+  const base = import.meta.env.VITE_API_BASE_URL;
+  if (base && base.trim() !== '') {
+    if (path.startsWith('/')) {
+      return base + path;
+    }
+    return `${base}/${path}`;
+  }
+  return path.startsWith('/') ? path : `/${path}`;
+}


### PR DESCRIPTION
## Summary
- add `apiUrl` helper with fallback to relative path
- update components to use `apiUrl` so login works without `.env`

## Testing
- `npm test --silent`
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68859a4887b88329b5045587a10bb1e3