### PR TITLE
docs: clarify default login and env variable

### DIFF
--- a/bellingham-datafutures/README.md
+++ b/bellingham-datafutures/README.md
@@ -37,6 +37,12 @@ Or build a runnable jar and execute it manually:
 java -jar target/datafutures-0.0.1-SNAPSHOT.jar
 ```
 
+### Default credentials
+
+When the application starts it automatically creates a user with the
+credentials `admin`/`admin` if one does not already exist. Use this
+account to sign in or register additional users via the API.
+
 ## Running tests
 
 Unit tests use an in-memory H2 database defined in

--- a/bellingham-frontend/README.md
+++ b/bellingham-frontend/README.md
@@ -28,6 +28,9 @@ cp .env.example .env
 
 For local development the default value is `http://localhost:8080`.
 
+After editing `.env` you need to restart the dev server (`npm run dev`)
+so Vite picks up the new value.
+
 To create a production build:
 
 ```bash


### PR DESCRIPTION
## Summary
- document automatic admin account in backend README
- remind developers to restart the Vite dev server after updating `.env`

## Testing
- `npm test --silent`
- `./mvnw -q test -Dspring.profiles.active=test` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68859f53766c8329a10d7e52c8248ab0