### PR TITLE
Refactor sidebar links to use config and add tests

### DIFF
--- a/bellingham-frontend/eslint.config.js
+++ b/bellingham-frontend/eslint.config.js
@@ -9,7 +9,7 @@ export default [
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: { ...globals.browser, ...globals.jest },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/bellingham-frontend/src/__tests__/Sidebar.test.jsx
+++ b/bellingham-frontend/src/__tests__/Sidebar.test.jsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import Sidebar from '../components/Sidebar';
+import navItems from '../config/navItems';
+
+test('renders navigation links from configuration', () => {
+    render(
+        <MemoryRouter>
+            <Sidebar />
+        </MemoryRouter>
+    );
+    navItems.forEach((item) => {
+        expect(screen.getByText(item.label)).toBeInTheDocument();
+    });
+});
+
+test('highlights the active link', () => {
+    render(
+        <MemoryRouter initialEntries={['/sell']}>
+            <Sidebar />
+        </MemoryRouter>
+    );
+    expect(screen.getByText('Sell')).toHaveClass('bg-gray-700');
+    expect(screen.getByText('Home')).not.toHaveClass('bg-gray-700');
+});

--- a/bellingham-frontend/src/components/Sidebar.jsx
+++ b/bellingham-frontend/src/components/Sidebar.jsx
@@ -1,84 +1,24 @@
 import React from "react";
 import { NavLink, useNavigate } from "react-router-dom";
+import navItems from "../config/navItems";
 
 const Sidebar = ({ onLogout }) => {
     const navigate = useNavigate();
     return (
         <aside className="w-64 bg-gray-900 p-6 flex flex-col justify-between border-r border-gray-700">
             <nav className="flex flex-col space-y-4">
-                <NavLink
-                    to="/"
-                    end
-                    className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
-                    }
-                >
-                    Home
-                </NavLink>
-                <NavLink
-                    to="/buy"
-                    className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
-                    }
-                >
-                    Buy
-                </NavLink>
-                <NavLink
-                    to="/sell"
-                    className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
-                    }
-                >
-                    Sell
-                </NavLink>
-                <NavLink
-                    to="/reports"
-                    className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
-                    }
-                >
-                    Reports
-                </NavLink>
-                <NavLink
-                    to="/sales"
-                    className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
-                    }
-                >
-                    Sales
-                </NavLink>
-                <NavLink
-                    to="/calendar"
-                    className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
-                    }
-                >
-                    Calendar
-                </NavLink>
-                <NavLink
-                    to="/history"
-                    className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
-                    }
-                >
-                    History
-                </NavLink>
-                <NavLink
-                    to="/settings"
-                    className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
-                    }
-                >
-                    Settings
-                </NavLink>
-                <NavLink
-                    to="/account"
-                    className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
-                    }
-                >
-                    Account
-                </NavLink>
+                {navItems.map(({ path, label }) => (
+                    <NavLink
+                        key={path}
+                        to={path}
+                        end={path === "/"}
+                        className={({ isActive }) =>
+                            `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
+                        }
+                    >
+                        {label}
+                    </NavLink>
+                ))}
             </nav>
             <div className="mt-6 flex flex-col space-y-2">
                 <button

--- a/bellingham-frontend/src/config/navItems.js
+++ b/bellingham-frontend/src/config/navItems.js
@@ -1,0 +1,13 @@
+const navItems = [
+    { path: "/", label: "Home" },
+    { path: "/buy", label: "Buy" },
+    { path: "/sell", label: "Sell" },
+    { path: "/reports", label: "Reports" },
+    { path: "/sales", label: "Sales" },
+    { path: "/calendar", label: "Calendar" },
+    { path: "/history", label: "History" },
+    { path: "/settings", label: "Settings" },
+    { path: "/account", label: "Account" },
+];
+
+export default navItems;


### PR DESCRIPTION
## Summary
- centralize sidebar navigation items in `navItems` config
- render sidebar links from config and keep active styling
- test sidebar links and active highlighting
- allow ESLint to recognize testing globals

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2d5a12bd88329a4982cf0b5a861ad