### PR TITLE
feat: add auth context and API client

### DIFF
--- a/bellingham-frontend/src/App.jsx
+++ b/bellingham-frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import Login from "./components/Login";
 import Dashboard from "./components/Dashboard";
@@ -12,9 +12,10 @@ import Account from "./components/Account";
 import Settings from "./components/Settings";
 import History from "./components/History";
 import Logo from "./components/Logo";
+import { AuthContext } from "./context/AuthContext";
 
 const App = () => {
-    const token = localStorage.getItem("token");
+    const { token } = useContext(AuthContext);
 
     return (
         <>

--- a/bellingham-frontend/src/__tests__/AuthContext.test.jsx
+++ b/bellingham-frontend/src/__tests__/AuthContext.test.jsx
@@ -1,0 +1,31 @@
+/* eslint-env jest */
+/* global test, expect, beforeEach */
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { AuthProvider, AuthContext } from '../context/AuthContext';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('login and logout update context and localStorage', () => {
+  const { result } = renderHook(() => React.useContext(AuthContext), {
+    wrapper: AuthProvider,
+  });
+
+  act(() => {
+    result.current.login('abc', 'user');
+  });
+  expect(result.current.token).toBe('abc');
+  expect(result.current.username).toBe('user');
+  expect(localStorage.getItem('token')).toBe('abc');
+  expect(localStorage.getItem('username')).toBe('user');
+
+  act(() => {
+    result.current.logout();
+  });
+  expect(result.current.token).toBe(null);
+  expect(result.current.username).toBe(null);
+  expect(localStorage.getItem('token')).toBe(null);
+  expect(localStorage.getItem('username')).toBe(null);
+});

--- a/bellingham-frontend/src/__tests__/Login.test.jsx
+++ b/bellingham-frontend/src/__tests__/Login.test.jsx
@@ -1,9 +1,16 @@
+/* eslint-env jest */
+/* global test, expect */
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Login from '../components/Login';
+import { AuthProvider } from '../context/AuthContext';
 
 test('renders username and password fields', () => {
-  render(<Login />);
+  render(
+    <AuthProvider>
+      <Login />
+    </AuthProvider>
+  );
   expect(screen.getByPlaceholderText(/Username/i)).toBeInTheDocument();
   expect(screen.getByPlaceholderText(/Password/i)).toBeInTheDocument();
 });

--- a/bellingham-frontend/src/__tests__/Logo.test.jsx
+++ b/bellingham-frontend/src/__tests__/Logo.test.jsx
@@ -1,3 +1,5 @@
+/* eslint-env jest */
+/* global test, expect */
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Logo from '../components/Logo';

--- a/bellingham-frontend/src/__tests__/api.test.js
+++ b/bellingham-frontend/src/__tests__/api.test.js
@@ -1,0 +1,23 @@
+/* eslint-env jest */
+/* global test, expect */
+import api from '../utils/api';
+
+test('attaches auth header when token exists', async () => {
+  localStorage.setItem('token', 'testtoken');
+  await api.get('/test', {
+    adapter: (config) => {
+      expect(config.headers.Authorization).toBe('Bearer testtoken');
+      return Promise.resolve({ data: {}, status: 200, statusText: 'OK', headers: {}, config });
+    },
+  });
+});
+
+test('does not attach auth header when token missing', async () => {
+  localStorage.removeItem('token');
+  await api.get('/test', {
+    adapter: (config) => {
+      expect(config.headers.Authorization).toBeUndefined();
+      return Promise.resolve({ data: {}, status: 200, statusText: 'OK', headers: {}, config });
+    },
+  });
+});

--- a/bellingham-frontend/src/components/Account.jsx
+++ b/bellingham-frontend/src/components/Account.jsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from "react";
-import axios from "axios";
+import React, { useEffect, useState, useContext } from "react";
 import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
+import api from "../utils/api";
+import { AuthContext } from "../context/AuthContext";
 
 const Account = () => {
     const [profile, setProfile] = useState(null);
@@ -10,24 +11,21 @@ const Account = () => {
     const [formData, setFormData] = useState({});
     const navigate = useNavigate();
 
+    const { token, logout } = useContext(AuthContext);
+
     const handleLogout = () => {
-        localStorage.removeItem("token");
-        localStorage.removeItem("username");
+        logout();
         navigate("/login");
     };
 
     useEffect(() => {
         const fetchProfile = async () => {
             try {
-                const token = localStorage.getItem("token");
                 if (!token) {
                     navigate("/login");
                     return;
                 }
-                const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/profile`,
-                    { headers: { Authorization: `Bearer ${token}` } }
-                );
+                const res = await api.get(`/api/profile`);
                 setProfile(res.data);
                 setFormData(res.data);
             } catch (err) {
@@ -36,7 +34,7 @@ const Account = () => {
             }
         };
         fetchProfile();
-    }, [navigate]);
+    }, [navigate, token]);
 
     if (error) {
         return (
@@ -64,12 +62,7 @@ const Account = () => {
 
     const handleSave = async () => {
         try {
-            const token = localStorage.getItem("token");
-            const res = await axios.put(
-                `${import.meta.env.VITE_API_BASE_URL}/api/profile`,
-                formData,
-                { headers: { Authorization: `Bearer ${token}` } }
-            );
+            const res = await api.put(`/api/profile`, formData);
             setProfile(res.data);
             setEditing(false);
         } catch (err) {

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -1,7 +1,8 @@
 // src/components/Buy.jsx
 
-import React, { useEffect, useState } from "react";
-import axios from "axios";
+import React, { useEffect, useState, useContext } from "react";
+import api from "../utils/api";
+import { AuthContext } from "../context/AuthContext";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
@@ -16,15 +17,12 @@ const Buy = () => {
     const [maxPrice, setMaxPrice] = useState("");
     const [sellerFilter, setSellerFilter] = useState("");
 
+    const { token, logout } = useContext(AuthContext);
+
     useEffect(() => {
         const fetchContracts = async () => {
             try {
-                const token = localStorage.getItem("token");
-                const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
-                const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/available`,
-                    config
-                );
+                const res = await api.get(`/api/contracts/available`);
                 setContracts(res.data.content);
             } catch (err) {
                 console.error(err);
@@ -44,13 +42,7 @@ const Buy = () => {
 
     const handleBuy = async (contractId) => {
         try {
-            const token = localStorage.getItem("token");
-            const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
-            await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${contractId}/buy`,
-                {},
-                config
-            );
+            await api.post(`/api/contracts/${contractId}/buy`);
             alert("Contract purchased successfully!");
         } catch (err) {
             console.error(err);
@@ -62,7 +54,6 @@ const Buy = () => {
         const price = prompt("Enter your bid price");
         if (!price) return;
 
-        const token = localStorage.getItem("token");
         if (!token) {
             alert("You must sign in to place a bid.");
             navigate("/login");
@@ -70,12 +61,7 @@ const Buy = () => {
         }
 
         try {
-            const config = { headers: { Authorization: `Bearer ${token}` } };
-            await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${contractId}/bids`,
-                { amount: parseFloat(price) },
-                config
-            );
+            await api.post(`/api/contracts/${contractId}/bids`, { amount: parseFloat(price) });
             alert("Bid submitted!");
         } catch (err) {
             console.error(err);
@@ -91,8 +77,7 @@ const Buy = () => {
     };
 
     const handleLogout = () => {
-        localStorage.removeItem("token");
-        localStorage.removeItem("username");
+        logout();
         navigate("/login");
     };
 

--- a/bellingham-frontend/src/components/Calendar.jsx
+++ b/bellingham-frontend/src/components/Calendar.jsx
@@ -1,24 +1,22 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import Calendar from "react-calendar";
 import 'react-calendar/dist/Calendar.css';
-import axios from "axios";
 import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
+import api from "../utils/api";
+import { AuthContext } from "../context/AuthContext";
 
 const ContractCalendar = () => {
     const navigate = useNavigate();
     const [contracts, setContracts] = useState([]);
     const [selectedDate, setSelectedDate] = useState(new Date());
 
+    const { logout } = useContext(AuthContext);
+
     useEffect(() => {
         const fetchContracts = async () => {
             try {
-                const token = localStorage.getItem("token");
-                const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
-                const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/purchased`,
-                    config
-                );
+                const res = await api.get(`/api/contracts/purchased`);
                 setContracts(res.data.content);
             } catch (err) {
                 console.error(err);
@@ -57,8 +55,7 @@ const ContractCalendar = () => {
     const events = eventsByDate[formattedSelected] || [];
 
     const handleLogout = () => {
-        localStorage.removeItem("token");
-        localStorage.removeItem("username");
+        logout();
         navigate("/login");
     };
 

--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from "react";
-import axios from "axios";
+import React, { useEffect, useState, useContext } from "react";
 import BidChart from "./BidChart";
+import api from "../utils/api";
+import { AuthContext } from "../context/AuthContext";
 
 const ContractDetailsPanel = ({
     contract,
@@ -10,21 +11,24 @@ const ContractDetailsPanel = ({
 }) => {
     const [visible, setVisible] = useState(false);
     const [bids, setBids] = useState([]);
+    const { token } = useContext(AuthContext);
 
     useEffect(() => {
         if (contract) {
             setVisible(true);
-            const token = localStorage.getItem("token");
-            const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
-            axios
-                .get(`${import.meta.env.VITE_API_BASE_URL}/api/contracts/${contract.id}/bids`, config)
-                .then((res) => setBids(res.data))
-                .catch(() => setBids([]));
+            if (token) {
+                api
+                    .get(`/api/contracts/${contract.id}/bids`)
+                    .then((res) => setBids(res.data))
+                    .catch(() => setBids([]));
+            } else {
+                setBids([]);
+            }
         } else {
             setVisible(false);
             setBids([]);
         }
-    }, [contract]);
+    }, [contract, token]);
 
     if (!contract && !visible) return null;
 
@@ -33,15 +37,8 @@ const ContractDetailsPanel = ({
         : `fixed top-0 right-0 w-full sm:w-1/3 h-full bg-gray-900 text-white p-6 shadow-lg z-20 transform transition-transform duration-300 flex flex-col ${visible ? "translate-x-0" : "translate-x-full"}`;
 
     const handleDownload = async () => {
-        const token = localStorage.getItem("token");
-        const res = await fetch(
-            `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${contract.id}/pdf`,
-            {
-                headers: token ? { Authorization: `Bearer ${token}` } : {},
-            }
-        );
-        if (!res.ok) return;
-        const blob = await res.blob();
+        const res = await api.get(`/api/contracts/${contract.id}/pdf`, { responseType: "blob" });
+        const blob = res.data;
         const url = window.URL.createObjectURL(blob);
         const a = document.createElement("a");
         a.href = url;

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -1,47 +1,40 @@
 // src/components/Dashboard.jsx
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
-import axios from "axios";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import Layout from "./Layout";
+import api from "../utils/api";
+import { AuthContext } from "../context/AuthContext";
 
 const Dashboard = () => {
     const [contracts, setContracts] = useState([]);
     const [selectedContract, setSelectedContract] = useState(null);
     const navigate = useNavigate();
 
+    const { token, logout } = useContext(AuthContext);
+
     useEffect(() => {
         const fetchContracts = async () => {
             try {
-                const token = localStorage.getItem("token");
                 if (!token) {
                     navigate("/login");
                     return;
                 }
-
-                const config = token
-                    ? { headers: { Authorization: `Bearer ${token}` } }
-                    : {};
-                const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/available`,
-                    config
-                );
-
+                const res = await api.get(`/api/contracts/available`);
                 setContracts(res.data.content);
             } catch (err) {
                 console.error("Error fetching contracts", err);
-                localStorage.removeItem("token");
+                logout();
                 navigate("/login");
             }
         };
 
         fetchContracts();
-    }, [navigate]);
+    }, [navigate, token, logout]);
 
     const handleLogout = () => {
-        localStorage.removeItem("token");
-        localStorage.removeItem("username");
+        logout();
         navigate("/login");
     };
 

--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useContext } from "react";
 
 import logoImage from "../assets/login.png";
+import { AuthContext } from "../context/AuthContext";
 
 const Header = () => {
-    const username = localStorage.getItem("username");
+    const { username } = useContext(AuthContext);
 
     return (
         <header className="bg-gray-800 p-4 flex justify-between items-center border-b border-gray-700">

--- a/bellingham-frontend/src/components/History.jsx
+++ b/bellingham-frontend/src/components/History.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from "react";
-import axios from "axios";
+import React, { useEffect, useState, useContext } from "react";
 import Layout from "./Layout";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import { useNavigate } from "react-router-dom";
+import api from "../utils/api";
+import { AuthContext } from "../context/AuthContext";
 
 const History = () => {
     const navigate = useNavigate();
@@ -10,15 +11,12 @@ const History = () => {
     const [error, setError] = useState("");
     const [selectedContract, setSelectedContract] = useState(null);
 
+    const { logout } = useContext(AuthContext);
+
     useEffect(() => {
         const fetchHistory = async () => {
             try {
-                const token = localStorage.getItem("token");
-                const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
-                const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/history`,
-                    config
-                );
+                const res = await api.get(`/api/contracts/history`);
                 setContracts(res.data.content);
             } catch (err) {
                 console.error(err);
@@ -29,8 +27,7 @@ const History = () => {
     }, []);
 
     const handleLogout = () => {
-        localStorage.removeItem("token");
-        localStorage.removeItem("username");
+        logout();
         navigate("/login");
     };
 

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -1,9 +1,9 @@
 // src/components/Login.jsx
 
-import React, { useState } from "react";
-import axios from "axios";
+import React, { useState, useContext } from "react";
 import LoginImage from "../assets/login.png";
-import { safeSetItem } from "../utils/storage";
+import api from "../utils/api";
+import { AuthContext } from "../context/AuthContext";
 
 const Login = () => {
     const [username, setUsername] = useState("");
@@ -11,30 +11,17 @@ const Login = () => {
     const [error, setError] = useState("");
 
 
+    const { login } = useContext(AuthContext);
+
     const handleLogin = async (e) => {
         e.preventDefault();
-        setError(""); // Clear previous errors
+        setError("");
 
         try {
-            const res = await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/authenticate`,
-                {
-                username,
-                password,
-                }
-            );
-
-            console.log("✅ Login API success:", res.data);
-
+            const res = await api.post(`/api/authenticate`, { username, password });
             const token = res.data.id_token;
             if (token) {
-                if (!safeSetItem("token", token) || !safeSetItem("username", username)) {
-                    console.error("Failed to store credentials");
-                    setError("Login failed: unable to store credentials.");
-                    return;
-                }
-
-                // Force full page reload to refresh state
+                login(token, username);
                 window.location.href = "/";
             } else {
                 setError("Login failed: No token received.");

--- a/bellingham-frontend/src/components/NotificationPopup.jsx
+++ b/bellingham-frontend/src/components/NotificationPopup.jsx
@@ -1,16 +1,17 @@
-import React, { useEffect, useState } from "react";
-import axios from "axios";
+import React, { useEffect, useState, useContext } from "react";
+import api from "../utils/api";
+import { AuthContext } from "../context/AuthContext";
 
 const NotificationPopup = () => {
     const [notification, setNotification] = useState(null);
     const [visible, setVisible] = useState(false);
 
+    const { token } = useContext(AuthContext);
+
     const fetchNotifications = async () => {
-        const token = localStorage.getItem("token");
         if (!token) return;
-        const config = { headers: { Authorization: `Bearer ${token}` } };
         try {
-            const res = await axios.get(`${import.meta.env.VITE_API_BASE_URL}/api/notifications`, config);
+            const res = await api.get(`/api/notifications`);
             const unread = res.data.find((n) => !n.readFlag);
             if (unread && (!notification || unread.id !== notification.id)) {
                 setNotification(unread);
@@ -33,11 +34,9 @@ const NotificationPopup = () => {
     }, [notification]);
 
     const markRead = async (id) => {
-        const token = localStorage.getItem("token");
         if (!token) return;
-        const config = { headers: { Authorization: `Bearer ${token}` } };
         try {
-            await axios.post(`${import.meta.env.VITE_API_BASE_URL}/api/notifications/${id}/read`, {}, config);
+            await api.post(`/api/notifications/${id}/read`);
         } catch (err) {
             console.error("Failed to mark notification read", err);
         }
@@ -53,14 +52,9 @@ const NotificationPopup = () => {
 
     const handleAccept = async () => {
         if (!notification) return;
-        const token = localStorage.getItem("token");
-        if (!token) return;
-        const config = { headers: { Authorization: `Bearer ${token}` } };
         try {
-            await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${notification.contractId}/bids/${notification.bidId}/accept`,
-                {},
-                config
+            await api.post(
+                `/api/contracts/${notification.contractId}/bids/${notification.bidId}/accept`
             );
             await markRead(notification.id);
             setVisible(false);
@@ -74,14 +68,9 @@ const NotificationPopup = () => {
 
     const handleDecline = async () => {
         if (!notification) return;
-        const token = localStorage.getItem("token");
-        if (!token) return;
-        const config = { headers: { Authorization: `Bearer ${token}` } };
         try {
-            await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${notification.contractId}/bids/${notification.bidId}/reject`,
-                {},
-                config
+            await api.post(
+                `/api/contracts/${notification.contractId}/bids/${notification.bidId}/reject`
             );
             await markRead(notification.id);
             setVisible(false);

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from "react";
-import axios from "axios";
+import React, { useEffect, useState, useContext } from "react";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
+import api from "../utils/api";
+import { AuthContext } from "../context/AuthContext";
 
 const Reports = () => {
     const navigate = useNavigate();
@@ -15,15 +16,12 @@ const Reports = () => {
         0
     );
 
+    const { logout } = useContext(AuthContext);
+
     useEffect(() => {
         const fetchPurchased = async () => {
             try {
-                const token = localStorage.getItem("token");
-                const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
-                const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/purchased`,
-                    config
-                );
+                const res = await api.get(`/api/contracts/purchased`);
                 setContracts(res.data.content);
             } catch {
                 setError("Failed to load purchased contracts.");
@@ -34,13 +32,7 @@ const Reports = () => {
 
     const handleListForSale = async (id) => {
         try {
-            const token = localStorage.getItem("token");
-            const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
-            await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${id}/list`,
-                {},
-                config
-            );
+            await api.post(`/api/contracts/${id}/list`);
             setContracts((prev) => prev.filter((c) => c.id !== id));
         } catch (err) {
             console.error(err);
@@ -50,13 +42,7 @@ const Reports = () => {
 
     const handleCloseout = async (id) => {
         try {
-            const token = localStorage.getItem("token");
-            const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
-            await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${id}/closeout`,
-                {},
-                config
-            );
+            await api.post(`/api/contracts/${id}/closeout`);
             setContracts((prev) => prev.filter((c) => c.id !== id));
         } catch (err) {
             console.error(err);
@@ -65,8 +51,7 @@ const Reports = () => {
     };
 
     const handleLogout = () => {
-        localStorage.removeItem("token");
-        localStorage.removeItem("username");
+        logout();
         navigate("/login");
     };
 

--- a/bellingham-frontend/src/components/Sales.jsx
+++ b/bellingham-frontend/src/components/Sales.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from "react";
-import axios from "axios";
+import React, { useEffect, useState, useContext } from "react";
 import Layout from "./Layout";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import { useNavigate } from "react-router-dom";
+import api from "../utils/api";
+import { AuthContext } from "../context/AuthContext";
 
 const Sales = () => {
     const navigate = useNavigate();
@@ -10,15 +11,12 @@ const Sales = () => {
     const [error, setError] = useState("");
     const [selectedContract, setSelectedContract] = useState(null);
 
+    const { logout } = useContext(AuthContext);
+
     useEffect(() => {
         const fetchSales = async () => {
             try {
-                const token = localStorage.getItem("token");
-                const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
-                const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/sold`,
-                    config
-                );
+                const res = await api.get(`/api/contracts/sold`);
                 setContracts(res.data.content);
             } catch (err) {
                 console.error(err);
@@ -29,8 +27,7 @@ const Sales = () => {
     }, []);
 
     const handleLogout = () => {
-        localStorage.removeItem("token");
-        localStorage.removeItem("username");
+        logout();
         navigate("/login");
     };
 

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -1,6 +1,8 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
+import api from "../utils/api";
+import { AuthContext } from "../context/AuthContext";
 
 const defaultAgreement = `Forward Data Sale Agreement (England & Wales Law)
 
@@ -71,10 +73,10 @@ IN WITNESS WHEREOF, the Parties have executed this Forward Data Sale Agreement a
  _Date: _____________________ _
  </div>
  </div>`;
-import axios from "axios";
 
 const Sell = () => {
     const navigate = useNavigate();
+    const { logout } = useContext(AuthContext);
     const [form, setForm] = useState({
         effectiveDate: "",
         sellerFullName: "",
@@ -99,12 +101,7 @@ const Sell = () => {
     useEffect(() => {
         const fetchContracts = async () => {
             try {
-                const token = localStorage.getItem("token");
-                const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
-                const res = await axios.get(
-                    `${import.meta.env.VITE_API_BASE_URL}/api/contracts/my`,
-                    config
-                );
+                const res = await api.get(`/api/contracts/my`);
                 setContracts(res.data.content);
             } catch (err) {
                 console.error(err);
@@ -124,8 +121,6 @@ const Sell = () => {
 
     const handleSubmit = async (e) => {
         e.preventDefault();
-        const token = localStorage.getItem("token");
-        const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
 
         const data = {
             title: form.title,
@@ -148,11 +143,7 @@ const Sell = () => {
         }
 
         try {
-            await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts`,
-                data,
-                config
-            );
+            await api.post(`/api/contracts`, data);
             setMessage("✅ Data contract submitted!");
             setForm({
                 effectiveDate: "",
@@ -178,18 +169,12 @@ const Sell = () => {
     };
 
     const handleLogout = () => {
-        localStorage.removeItem("token");
-        localStorage.removeItem("username");
+        logout();
         navigate("/login");
     };
 
     const fetchBids = async (contractId) => {
-        const token = localStorage.getItem("token");
-        const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
-        const res = await axios.get(
-            `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${contractId}/bids`,
-            config
-        );
+        const res = await api.get(`/api/contracts/${contractId}/bids`);
         return res.data;
     };
 
@@ -212,13 +197,7 @@ const Sell = () => {
 
     const handleAcceptBid = async (contractId, bidId) => {
         try {
-            const token = localStorage.getItem("token");
-            const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
-            await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/contracts/${contractId}/bids/${bidId}/accept`,
-                {},
-                config
-            );
+            await api.post(`/api/contracts/${contractId}/bids/${bidId}/accept`);
             alert("Bid accepted");
         } catch (err) {
             console.error(err);

--- a/bellingham-frontend/src/components/Settings.jsx
+++ b/bellingham-frontend/src/components/Settings.jsx
@@ -1,13 +1,15 @@
-import React from "react";
+import React, { useContext } from "react";
 import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
+import { AuthContext } from "../context/AuthContext";
 
 const Settings = () => {
     const navigate = useNavigate();
 
+    const { logout } = useContext(AuthContext);
+
     const handleLogout = () => {
-        localStorage.removeItem("token");
-        localStorage.removeItem("username");
+        logout();
         navigate("/login");
     };
 

--- a/bellingham-frontend/src/components/Signup.jsx
+++ b/bellingham-frontend/src/components/Signup.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
-import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import Header from "./Header";
+import api from "../utils/api";
 
 const Signup = () => {
     const [form, setForm] = useState({
@@ -30,10 +30,7 @@ const Signup = () => {
         setError("");
         setMessage("");
         try {
-            await axios.post(
-                `${import.meta.env.VITE_API_BASE_URL}/api/register`,
-                form
-            );
+            await api.post(`/api/register`, form);
             setMessage("Registration successful. Please log in.");
             setForm({
                 username: "",

--- a/bellingham-frontend/src/context/AuthContext.jsx
+++ b/bellingham-frontend/src/context/AuthContext.jsx
@@ -1,0 +1,30 @@
+import React, { createContext, useState } from 'react';
+
+export const AuthContext = createContext({ token: null, username: null, login: () => {}, logout: () => {} });
+
+export const AuthProvider = ({ children }) => {
+  const [token, setToken] = useState(() => localStorage.getItem('token'));
+  const [username, setUsername] = useState(() => localStorage.getItem('username'));
+
+  const login = (newToken, newUsername) => {
+    localStorage.setItem('token', newToken);
+    localStorage.setItem('username', newUsername);
+    setToken(newToken);
+    setUsername(newUsername);
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('username');
+    setToken(null);
+    setUsername(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, username, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export default AuthContext;

--- a/bellingham-frontend/src/main.jsx
+++ b/bellingham-frontend/src/main.jsx
@@ -3,11 +3,14 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
+import { AuthProvider } from "./context/AuthContext";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
     <React.StrictMode>
         <BrowserRouter>
-            <App />
+            <AuthProvider>
+                <App />
+            </AuthProvider>
         </BrowserRouter>
-    </React.StrictMode>
+    </React.StrictMode>,
 );

--- a/bellingham-frontend/src/utils/api.js
+++ b/bellingham-frontend/src/utils/api.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+});
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export default api;


### PR DESCRIPTION
## Summary
- add AuthContext to manage token and username across the app
- create reusable Axios instance that auto-attaches auth header
- refactor components to use context and API client; add unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2d5c7916c8329b112472687c89631