### PR TITLE
feat: add semantic color classes

### DIFF
--- a/bellingham-frontend/eslint.config.js
+++ b/bellingham-frontend/eslint.config.js
@@ -9,7 +9,7 @@ export default [
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: { ...globals.browser, ...globals.vitest },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/bellingham-frontend/src/__tests__/Login.test.jsx
+++ b/bellingham-frontend/src/__tests__/Login.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-env vitest */
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Login from '../components/Login';

--- a/bellingham-frontend/src/__tests__/Logo.test.jsx
+++ b/bellingham-frontend/src/__tests__/Logo.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-env vitest */
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Logo from '../components/Logo';

--- a/bellingham-frontend/src/components/Account.jsx
+++ b/bellingham-frontend/src/components/Account.jsx
@@ -86,84 +86,84 @@ const Account = () => {
                         <div className="space-y-2">
                     <p><strong>Username:</strong> {profile.username}</p>
                     <input
-                        className="w-full p-2 bg-gray-800 rounded"
+                        className="w-full p-2 bg-surface rounded"
                         name="legalBusinessName"
                         value={formData.legalBusinessName || ""}
                         onChange={handleChange}
                         placeholder="Legal Business Name"
                     />
                     <input
-                        className="w-full p-2 bg-gray-800 rounded"
+                        className="w-full p-2 bg-surface rounded"
                         name="name"
                         value={formData.name || ""}
                         onChange={handleChange}
                         placeholder="Name"
                     />
                     <input
-                        className="w-full p-2 bg-gray-800 rounded"
+                        className="w-full p-2 bg-surface rounded"
                         name="countryOfIncorporation"
                         value={formData.countryOfIncorporation || ""}
                         onChange={handleChange}
                         placeholder="Country of Incorporation"
                     />
                     <input
-                        className="w-full p-2 bg-gray-800 rounded"
+                        className="w-full p-2 bg-surface rounded"
                         name="taxId"
                         value={formData.taxId || ""}
                         onChange={handleChange}
                         placeholder="Tax ID"
                     />
                     <input
-                        className="w-full p-2 bg-gray-800 rounded"
+                        className="w-full p-2 bg-surface rounded"
                         name="companyRegistrationNumber"
                         value={formData.companyRegistrationNumber || ""}
                         onChange={handleChange}
                         placeholder="Company Registration Number"
                     />
                     <input
-                        className="w-full p-2 bg-gray-800 rounded"
+                        className="w-full p-2 bg-surface rounded"
                         name="primaryContactName"
                         value={formData.primaryContactName || ""}
                         onChange={handleChange}
                         placeholder="Primary Contact Name"
                     />
                     <input
-                        className="w-full p-2 bg-gray-800 rounded"
+                        className="w-full p-2 bg-surface rounded"
                         name="primaryContactEmail"
                         value={formData.primaryContactEmail || ""}
                         onChange={handleChange}
                         placeholder="Primary Contact Email"
                     />
                     <input
-                        className="w-full p-2 bg-gray-800 rounded"
+                        className="w-full p-2 bg-surface rounded"
                         name="primaryContactPhone"
                         value={formData.primaryContactPhone || ""}
                         onChange={handleChange}
                         placeholder="Primary Contact Phone"
                     />
                     <input
-                        className="w-full p-2 bg-gray-800 rounded"
+                        className="w-full p-2 bg-surface rounded"
                         name="technicalContactName"
                         value={formData.technicalContactName || ""}
                         onChange={handleChange}
                         placeholder="Technical Contact Name"
                     />
                     <input
-                        className="w-full p-2 bg-gray-800 rounded"
+                        className="w-full p-2 bg-surface rounded"
                         name="technicalContactEmail"
                         value={formData.technicalContactEmail || ""}
                         onChange={handleChange}
                         placeholder="Technical Contact Email"
                     />
                     <input
-                        className="w-full p-2 bg-gray-800 rounded"
+                        className="w-full p-2 bg-surface rounded"
                         name="technicalContactPhone"
                         value={formData.technicalContactPhone || ""}
                         onChange={handleChange}
                         placeholder="Technical Contact Phone"
                     />
                     <textarea
-                        className="w-full p-2 bg-gray-800 rounded"
+                        className="w-full p-2 bg-surface rounded"
                         name="companyDescription"
                         value={formData.companyDescription || ""}
                         onChange={handleChange}
@@ -172,7 +172,7 @@ const Account = () => {
                     <div className="space-x-2 mt-4">
                         <button
                             onClick={handleSave}
-                            className="bg-green-600 hover:bg-green-700 px-4 py-2 rounded"
+                            className="bg-success hover:bg-success-dark px-4 py-2 rounded"
                         >
                             Save
                         </button>
@@ -181,7 +181,7 @@ const Account = () => {
                                 setEditing(false);
                                 setFormData(profile);
                             }}
-                            className="bg-gray-600 hover:bg-gray-700 px-4 py-2 rounded"
+                            className="bg-surface-tertiary hover:bg-surface-secondary px-4 py-2 rounded"
                         >
                             Cancel
                         </button>
@@ -204,7 +204,7 @@ const Account = () => {
                     <p><strong>Company Description:</strong> {profile.companyDescription}</p>
                     <button
                         onClick={() => setEditing(true)}
-                        className="mt-4 bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded"
+                        className="mt-4 bg-primary hover:bg-primary-dark px-4 py-2 rounded"
                     >
                         Edit
                     </button>

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -123,26 +123,26 @@ const Buy = () => {
                             placeholder="Search by title or seller"
                             value={search}
                             onChange={(e) => setSearch(e.target.value)}
-                            className="p-2 bg-gray-800 rounded"
+                            className="p-2 bg-surface rounded"
                         />
                         <input
                             type="number"
                             placeholder="Min Price"
                             value={minPrice}
                             onChange={(e) => setMinPrice(e.target.value)}
-                            className="p-2 bg-gray-800 rounded w-24"
+                            className="p-2 bg-surface rounded w-24"
                         />
                         <input
                             type="number"
                             placeholder="Max Price"
                             value={maxPrice}
                             onChange={(e) => setMaxPrice(e.target.value)}
-                            className="p-2 bg-gray-800 rounded w-24"
+                            className="p-2 bg-surface rounded w-24"
                         />
                         <select
                             value={sellerFilter}
                             onChange={(e) => setSellerFilter(e.target.value)}
-                            className="p-2 bg-gray-800 rounded"
+                            className="p-2 bg-surface rounded"
                         >
                             <option value="">All Sellers</option>
                             {sellers.map((s) => (
@@ -152,9 +152,9 @@ const Buy = () => {
                             ))}
                         </select>
                     </div>
-                    <table className="w-[90%] mx-auto table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+                    <table className="w-[90%] mx-auto table-auto border border-collapse border-border bg-surface text-contrast shadow rounded">
                         <thead>
-                            <tr className="bg-gray-700 text-left">
+                            <tr className="bg-surface-secondary text-left">
                                 <th className="border p-2">Title</th>
                                 <th className="border p-2">Seller</th>
                                 <th className="border p-2">Ask Price</th>
@@ -166,7 +166,7 @@ const Buy = () => {
                             {filteredContracts.map((contract) => (
                                 <tr
                                     key={contract.id}
-                                    className="hover:bg-gray-600 cursor-pointer"
+                                    className="hover:bg-surface-tertiary cursor-pointer"
                                     onClick={() => setSelectedContract(contract)}
                                 >
                                     <td className="border p-2">{contract.title}</td>
@@ -179,7 +179,7 @@ const Buy = () => {
                                                 e.stopPropagation();
                                                 handleBuy(contract.id);
                                             }}
-                                            className="bg-green-500 hover:bg-green-600 text-white px-2 py-1 rounded"
+                                            className="bg-success hover:bg-success-dark text-contrast px-2 py-1 rounded"
                                         >
                                             Buy
                                         </button>
@@ -188,7 +188,7 @@ const Buy = () => {
                                                 e.stopPropagation();
                                                 handleBid(contract.id);
                                             }}
-                                            className="bg-blue-500 hover:bg-blue-600 text-white px-2 py-1 rounded"
+                                            className="bg-primary-light hover:bg-primary text-contrast px-2 py-1 rounded"
                                         >
                                             Bid
                                         </button>

--- a/bellingham-frontend/src/components/Calendar.jsx
+++ b/bellingham-frontend/src/components/Calendar.jsx
@@ -47,7 +47,7 @@ const ContractCalendar = () => {
             const key = date.toISOString().split('T')[0];
             const events = eventsByDate[key];
             if (events && events.length > 0) {
-                return <div className="mt-1 w-2 h-2 bg-blue-500 rounded-full mx-auto"/>;
+                return <div className="mt-1 w-2 h-2 bg-primary-light rounded-full mx-auto"/>;
             }
         }
         return null;

--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -29,8 +29,8 @@ const ContractDetailsPanel = ({
     if (!contract && !visible) return null;
 
     const panelClasses = inline
-        ? `${inlineWidth} bg-gray-900 text-white p-6 overflow-auto shadow-lg z-20 mt-4 transform transition-transform duration-300 flex flex-col ${visible ? "translate-x-0" : "translate-x-full"}`
-        : `fixed top-0 right-0 w-full sm:w-1/3 h-full bg-gray-900 text-white p-6 shadow-lg z-20 transform transition-transform duration-300 flex flex-col ${visible ? "translate-x-0" : "translate-x-full"}`;
+        ? `${inlineWidth} bg-base text-contrast p-6 overflow-auto shadow-lg z-20 mt-4 transform transition-transform duration-300 flex flex-col ${visible ? "translate-x-0" : "translate-x-full"}`
+        : `fixed top-0 right-0 w-full sm:w-1/3 h-full bg-base text-contrast p-6 shadow-lg z-20 transform transition-transform duration-300 flex flex-col ${visible ? "translate-x-0" : "translate-x-full"}`;
 
     const handleDownload = async () => {
         const token = localStorage.getItem("token");
@@ -61,7 +61,7 @@ const ContractDetailsPanel = ({
         <div className={panelClasses}>
             <h2 className="text-xl font-bold mb-4">{contract.title}</h2>
             <button
-                className="mb-4 bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded"
+                className="mb-4 bg-primary hover:bg-primary-dark px-3 py-1 rounded"
                 onClick={handleDownload}
             >
                 Download PDF
@@ -92,7 +92,7 @@ const ContractDetailsPanel = ({
                 </div>
             )}
             <button
-                className="mt-auto bg-red-600 hover:bg-red-700 px-3 py-1 rounded self-end"
+                className="mt-auto bg-danger hover:bg-danger-dark px-3 py-1 rounded self-end"
                 onClick={handleClose}
             >
                 Close

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -48,10 +48,10 @@ const Dashboard = () => {
     return (
         <Layout onLogout={handleLogout}>
             <main className="flex-1 p-8 overflow-auto">
-                <h2 className="text-3xl font-bold mb-6 text-white">Open Contracts</h2>
-                <table className="w-[90%] mx-auto table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+                <h2 className="text-3xl font-bold mb-6 text-contrast">Open Contracts</h2>
+                <table className="w-[90%] mx-auto table-auto border border-collapse border-border bg-surface text-contrast shadow rounded">
                     <thead>
-                    <tr className="bg-gray-700 text-left">
+                    <tr className="bg-surface-secondary text-left">
                         <th className="border p-2">Title</th>
                         <th className="border p-2">Seller</th>
                         <th className="border p-2">Ask Price</th>
@@ -63,7 +63,7 @@ const Dashboard = () => {
                     {contracts.map((contract) => (
                         <tr
                             key={contract.id}
-                            className="hover:bg-gray-600 cursor-pointer"
+                            className="hover:bg-surface-tertiary cursor-pointer"
                             onClick={() => setSelectedContract(contract)}
                         >
                             <td className="border p-2">{contract.title}</td>

--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -6,7 +6,7 @@ const Header = () => {
     const username = localStorage.getItem("username");
 
     return (
-        <header className="bg-gray-800 p-4 flex justify-between items-center border-b border-gray-700">
+        <header className="bg-surface p-4 flex justify-between items-center border-b border-border">
             <div className="flex items-center gap-4">
                 <img
                     src={logoImage}
@@ -15,7 +15,7 @@ const Header = () => {
                 />
             </div>
             {username && (
-                <div className="flex items-center gap-2 text-white text-sm">
+                <div className="flex items-center gap-2 text-contrast text-sm">
                     <span>Logged in as: {username}</span>
                 </div>
             )}

--- a/bellingham-frontend/src/components/History.jsx
+++ b/bellingham-frontend/src/components/History.jsx
@@ -39,9 +39,9 @@ const History = () => {
             <main className="flex-1 p-8">
                 <h1 className="text-3xl font-bold mb-6">Contract History</h1>
                 {error && <p className="text-red-500 mb-4">{error}</p>}
-                <table className="w-[90%] mx-auto table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+                <table className="w-[90%] mx-auto table-auto border border-collapse border-border bg-surface text-contrast shadow rounded">
                     <thead>
-                        <tr className="bg-gray-700 text-left">
+                        <tr className="bg-surface-secondary text-left">
                             <th className="border p-2">Title</th>
                             <th className="border p-2">Seller</th>
                             <th className="border p-2">Buyer</th>
@@ -53,7 +53,7 @@ const History = () => {
                         {contracts.map((c) => (
                             <tr
                                 key={c.id}
-                                className="hover:bg-gray-600 cursor-pointer"
+                                className="hover:bg-surface-tertiary cursor-pointer"
                                 onClick={() => setSelectedContract(c)}
                             >
                                 <td className="border p-2">{c.title}</td>

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -78,7 +78,7 @@ const Login = () => {
                 />
                 <button
                     type="submit"
-                    className="w-full bg-blue-600 text-white p-2 rounded-lg hover:bg-blue-700"
+                    className="w-full bg-primary text-contrast p-2 rounded-lg hover:bg-primary-dark"
                 >
                     Sign In
                 </button>

--- a/bellingham-frontend/src/components/NotificationPopup.jsx
+++ b/bellingham-frontend/src/components/NotificationPopup.jsx
@@ -107,11 +107,11 @@ const NotificationPopup = () => {
             <div className="flex gap-2 justify-end">
                 {showBidActions && (
                     <>
-                        <button className="bg-green-600 px-2 py-1 rounded" onClick={handleAccept}>Accept</button>
-                        <button className="bg-red-600 px-2 py-1 rounded" onClick={handleDecline}>Decline</button>
+                        <button className="bg-success px-2 py-1 rounded" onClick={handleAccept}>Accept</button>
+                        <button className="bg-danger px-2 py-1 rounded" onClick={handleDecline}>Decline</button>
                     </>
                 )}
-                <button className="bg-gray-600 px-2 py-1 rounded" onClick={handleClose}>Dismiss</button>
+                <button className="bg-surface-tertiary px-2 py-1 rounded" onClick={handleClose}>Dismiss</button>
             </div>
         </div>
     );

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -75,9 +75,9 @@ const Reports = () => {
             <main className="flex-1 p-8">
                 <h1 className="text-3xl font-bold mb-6">Purchased Contracts</h1>
                     {error && <p className="text-red-500 mb-4">{error}</p>}
-                    <table className="w-[90%] mx-auto table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+                    <table className="w-[90%] mx-auto table-auto border border-collapse border-border bg-surface text-contrast shadow rounded">
                 <thead>
-                    <tr className="bg-gray-700 text-left">
+                    <tr className="bg-surface-secondary text-left">
                         <th className="border p-2">Title</th>
                         <th className="border p-2">Seller</th>
                         <th className="border p-2">Ask Price</th>
@@ -89,7 +89,7 @@ const Reports = () => {
                     {contracts.map((contract) => (
                         <tr
                             key={contract.id}
-                            className="hover:bg-gray-600 cursor-pointer"
+                            className="hover:bg-surface-tertiary cursor-pointer"
                             onClick={() => setSelectedContract(contract)}
                         >
                             <td className="border p-2">{contract.title}</td>
@@ -102,7 +102,7 @@ const Reports = () => {
                                         e.stopPropagation();
                                         handleListForSale(contract.id);
                                     }}
-                                    className="bg-blue-600 hover:bg-blue-700 px-2 py-1 rounded"
+                                    className="bg-primary hover:bg-primary-dark px-2 py-1 rounded"
                                 >
                                     List for Sale
                                 </button>
@@ -111,7 +111,7 @@ const Reports = () => {
                                         e.stopPropagation();
                                         handleCloseout(contract.id);
                                     }}
-                                    className="ml-2 bg-red-600 hover:bg-red-700 px-2 py-1 rounded"
+                                    className="ml-2 bg-danger hover:bg-danger-dark px-2 py-1 rounded"
                                 >
                                     Closeout
                                 </button>

--- a/bellingham-frontend/src/components/Sales.jsx
+++ b/bellingham-frontend/src/components/Sales.jsx
@@ -39,9 +39,9 @@ const Sales = () => {
             <main className="flex-1 p-8">
                 <h1 className="text-3xl font-bold mb-6">Sold Contracts</h1>
                 {error && <p className="text-red-500 mb-4">{error}</p>}
-                <table className="w-[90%] mx-auto table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+                <table className="w-[90%] mx-auto table-auto border border-collapse border-border bg-surface text-contrast shadow rounded">
                     <thead>
-                        <tr className="bg-gray-700 text-left">
+                        <tr className="bg-surface-secondary text-left">
                             <th className="border p-2">Title</th>
                             <th className="border p-2">Buyer</th>
                             <th className="border p-2">Price</th>
@@ -53,7 +53,7 @@ const Sales = () => {
                         {contracts.map((c) => (
                             <tr
                                 key={c.id}
-                                className="hover:bg-gray-600 cursor-pointer"
+                                className="hover:bg-surface-tertiary cursor-pointer"
                                 onClick={() => setSelectedContract(c)}
                             >
                                 <td className="border p-2">{c.title}</td>

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -239,7 +239,7 @@ const Sell = () => {
                         name="effectiveDate"
                         value={form.effectiveDate}
                         onChange={handleChange}
-                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        className="w-full p-2 mt-1 bg-surface rounded"
                         required
                     />
                 </div>
@@ -250,7 +250,7 @@ const Sell = () => {
                         name="sellerFullName"
                         value={form.sellerFullName}
                         onChange={handleChange}
-                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        className="w-full p-2 mt-1 bg-surface rounded"
                         required
                     />
                 </div>
@@ -261,7 +261,7 @@ const Sell = () => {
                         name="sellerEntityType"
                         value={form.sellerEntityType}
                         onChange={handleChange}
-                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        className="w-full p-2 mt-1 bg-surface rounded"
                         required
                     />
                 </div>
@@ -272,7 +272,7 @@ const Sell = () => {
                         name="sellerAddress"
                         value={form.sellerAddress}
                         onChange={handleChange}
-                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        className="w-full p-2 mt-1 bg-surface rounded"
                         required
                     />
                 </div>
@@ -283,7 +283,7 @@ const Sell = () => {
                         name="buyerFullName"
                         value={form.buyerFullName}
                         onChange={handleChange}
-                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        className="w-full p-2 mt-1 bg-surface rounded"
                         required
                     />
                 </div>
@@ -294,7 +294,7 @@ const Sell = () => {
                         name="buyerEntityType"
                         value={form.buyerEntityType}
                         onChange={handleChange}
-                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        className="w-full p-2 mt-1 bg-surface rounded"
                         required
                     />
                 </div>
@@ -305,7 +305,7 @@ const Sell = () => {
                         name="buyerAddress"
                         value={form.buyerAddress}
                         onChange={handleChange}
-                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        className="w-full p-2 mt-1 bg-surface rounded"
                         required
                     />
                 </div>
@@ -316,7 +316,7 @@ const Sell = () => {
                         name="deliveryDate"
                         value={form.deliveryDate}
                         onChange={handleChange}
-                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        className="w-full p-2 mt-1 bg-surface rounded"
                         required
                     />
                 </div>
@@ -327,7 +327,7 @@ const Sell = () => {
                         name="title"
                         value={form.title}
                         onChange={handleChange}
-                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        className="w-full p-2 mt-1 bg-surface rounded"
                         required
                     />
                 </div>
@@ -338,7 +338,7 @@ const Sell = () => {
                         name="price"
                         value={form.price}
                         onChange={handleChange}
-                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        className="w-full p-2 mt-1 bg-surface rounded"
                         required
                     />
                 </div>
@@ -349,7 +349,7 @@ const Sell = () => {
                         name="dataDescription"
                         value={form.dataDescription}
                         onChange={handleChange}
-                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        className="w-full p-2 mt-1 bg-surface rounded"
                         required
                     />
                 </div>
@@ -360,7 +360,7 @@ const Sell = () => {
                         name="deliveryFormat"
                         value={form.deliveryFormat}
                         onChange={handleChange}
-                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        className="w-full p-2 mt-1 bg-surface rounded"
                         required
                     />
                 </div>
@@ -371,7 +371,7 @@ const Sell = () => {
                         name="platformName"
                         value={form.platformName}
                         onChange={handleChange}
-                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        className="w-full p-2 mt-1 bg-surface rounded"
                         required
                     />
                 </div>
@@ -381,7 +381,7 @@ const Sell = () => {
                         name="agreementText"
                         value={form.agreementText}
                         onChange={handleChange}
-                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        className="w-full p-2 mt-1 bg-surface rounded"
                         rows="10"
                     />
                 </div>
@@ -390,20 +390,20 @@ const Sell = () => {
                     <input
                         type="file"
                         onChange={handleFileChange}
-                        className="w-full p-2 mt-1 bg-gray-800 rounded"
+                        className="w-full p-2 mt-1 bg-surface rounded"
                         accept=".csv,.json,.txt"
                     />
                 </div>
-                <button type="submit" className="bg-green-600 hover:bg-green-700 px-4 py-2 rounded">
+                <button type="submit" className="bg-success hover:bg-success-dark px-4 py-2 rounded">
                     Submit Contract
                 </button>
             </form>
 
             <h2 className="text-2xl font-bold mt-10 mb-4">My Contracts</h2>
             {error && <p className="text-red-500 mb-4">{error}</p>}
-            <table className="w-[90%] mx-auto table-auto border border-collapse border-gray-700 bg-gray-800 text-white shadow rounded">
+            <table className="w-[90%] mx-auto table-auto border border-collapse border-border bg-surface text-contrast shadow rounded">
                 <thead>
-                    <tr className="bg-gray-700 text-left">
+                    <tr className="bg-surface-secondary text-left">
                         <th className="border p-2">Title</th>
                         <th className="border p-2">Buyer</th>
                         <th className="border p-2">Ask Price</th>
@@ -414,7 +414,7 @@ const Sell = () => {
                 </thead>
                 <tbody>
                     {contracts.map((c) => (
-                        <tr key={c.id} className="hover:bg-gray-600">
+                        <tr key={c.id} className="hover:bg-surface-tertiary">
                             <td className="border p-2">{c.title}</td>
                             <td className="border p-2">{c.buyerUsername || "-"}</td>
                             <td className="border p-2">${c.price}</td>
@@ -422,7 +422,7 @@ const Sell = () => {
                             <td className="border p-2">{c.status}</td>
                             <td className="border p-2">
                                 <button
-                                    className="bg-blue-600 hover:bg-blue-700 px-2 py-1 rounded"
+                                    className="bg-primary hover:bg-primary-dark px-2 py-1 rounded"
                                     onClick={() => handleViewBids(c)}
                                 >
                                     View Bids

--- a/bellingham-frontend/src/components/Sidebar.jsx
+++ b/bellingham-frontend/src/components/Sidebar.jsx
@@ -4,13 +4,13 @@ import { NavLink, useNavigate } from "react-router-dom";
 const Sidebar = ({ onLogout }) => {
     const navigate = useNavigate();
     return (
-        <aside className="w-64 bg-gray-900 p-6 flex flex-col justify-between border-r border-gray-700">
+        <aside className="w-64 bg-base p-6 flex flex-col justify-between border-r border-border">
             <nav className="flex flex-col space-y-4">
                 <NavLink
                     to="/"
                     end
                     className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
+                        `text-left hover:bg-success px-4 py-2 rounded text-contrast ${isActive ? "bg-surface-secondary" : ""}`
                     }
                 >
                     Home
@@ -18,7 +18,7 @@ const Sidebar = ({ onLogout }) => {
                 <NavLink
                     to="/buy"
                     className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
+                        `text-left hover:bg-success px-4 py-2 rounded text-contrast ${isActive ? "bg-surface-secondary" : ""}`
                     }
                 >
                     Buy
@@ -26,7 +26,7 @@ const Sidebar = ({ onLogout }) => {
                 <NavLink
                     to="/sell"
                     className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
+                        `text-left hover:bg-success px-4 py-2 rounded text-contrast ${isActive ? "bg-surface-secondary" : ""}`
                     }
                 >
                     Sell
@@ -34,7 +34,7 @@ const Sidebar = ({ onLogout }) => {
                 <NavLink
                     to="/reports"
                     className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
+                        `text-left hover:bg-success px-4 py-2 rounded text-contrast ${isActive ? "bg-surface-secondary" : ""}`
                     }
                 >
                     Reports
@@ -42,7 +42,7 @@ const Sidebar = ({ onLogout }) => {
                 <NavLink
                     to="/sales"
                     className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
+                        `text-left hover:bg-success px-4 py-2 rounded text-contrast ${isActive ? "bg-surface-secondary" : ""}`
                     }
                 >
                     Sales
@@ -50,7 +50,7 @@ const Sidebar = ({ onLogout }) => {
                 <NavLink
                     to="/calendar"
                     className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
+                        `text-left hover:bg-success px-4 py-2 rounded text-contrast ${isActive ? "bg-surface-secondary" : ""}`
                     }
                 >
                     Calendar
@@ -58,7 +58,7 @@ const Sidebar = ({ onLogout }) => {
                 <NavLink
                     to="/history"
                     className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
+                        `text-left hover:bg-success px-4 py-2 rounded text-contrast ${isActive ? "bg-surface-secondary" : ""}`
                     }
                 >
                     History
@@ -66,7 +66,7 @@ const Sidebar = ({ onLogout }) => {
                 <NavLink
                     to="/settings"
                     className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
+                        `text-left hover:bg-success px-4 py-2 rounded text-contrast ${isActive ? "bg-surface-secondary" : ""}`
                     }
                 >
                     Settings
@@ -74,7 +74,7 @@ const Sidebar = ({ onLogout }) => {
                 <NavLink
                     to="/account"
                     className={({ isActive }) =>
-                        `text-left hover:bg-green-600 px-4 py-2 rounded text-white ${isActive ? "bg-gray-700" : ""}`
+                        `text-left hover:bg-success px-4 py-2 rounded text-contrast ${isActive ? "bg-surface-secondary" : ""}`
                     }
                 >
                     Account
@@ -83,14 +83,14 @@ const Sidebar = ({ onLogout }) => {
             <div className="mt-6 flex flex-col space-y-2">
                 <button
                     onClick={() => navigate(-1)}
-                    className="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded text-left text-white"
+                    className="bg-surface-secondary hover:bg-surface-tertiary px-4 py-2 rounded text-left text-contrast"
                 >
                     Back
                 </button>
                 {onLogout && (
                     <button
                         onClick={onLogout}
-                        className="bg-red-600 hover:bg-red-700 px-4 py-2 rounded text-white"
+                        className="bg-danger hover:bg-danger-dark px-4 py-2 rounded text-contrast"
                     >
                         Log Out
                     </button>

--- a/bellingham-frontend/src/components/Signup.jsx
+++ b/bellingham-frontend/src/components/Signup.jsx
@@ -63,7 +63,7 @@ const Signup = () => {
             <div className="relative flex flex-col flex-1 items-center justify-center">
                 <button
                     onClick={() => navigate(-1)}
-                    className="absolute top-4 left-4 bg-gray-700 hover:bg-gray-600 text-white px-3 py-1 rounded"
+                    className="absolute top-4 left-4 bg-surface-secondary hover:bg-surface-tertiary text-contrast px-3 py-1 rounded"
                 >
                     Back
                 </button>
@@ -169,7 +169,7 @@ const Signup = () => {
                     onChange={(e) => setForm({ ...form, companyDescription: e.target.value })}
                     className="w-1/2 p-2 mb-6 border rounded-lg"
                 />
-                <button type="submit" className="w-1/2 bg-blue-600 text-white p-2 rounded-lg hover:bg-blue-700">
+                <button type="submit" className="w-1/2 bg-primary text-contrast p-2 rounded-lg hover:bg-primary-dark">
                     Register
                 </button>
                 <button

--- a/bellingham-frontend/tailwind.config.js
+++ b/bellingham-frontend/tailwind.config.js
@@ -6,10 +6,27 @@ export default {
   theme: {
     extend: {
       colors: {
-        base: '#000',
+        base: '#111827',
         contrast: '#fff',
-        primary: '#1d4ed8',
-        secondary: '#3b82f6',
+        surface: {
+          DEFAULT: '#1f2937',
+          secondary: '#374151',
+          tertiary: '#4b5563'
+        },
+        border: '#374151',
+        primary: {
+          light: '#3b82f6',
+          DEFAULT: '#2563eb',
+          dark: '#1d4ed8'
+        },
+        success: {
+          DEFAULT: '#16a34a',
+          dark: '#15803d'
+        },
+        danger: {
+          DEFAULT: '#dc2626',
+          dark: '#b91c1c'
+        },
         accent: '#ef4444'
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
- add semantic color palette to tailwind config
- refactor frontend components to use `bg-surface`, `text-contrast`, and other semantic classes
- configure ESLint for vitest and fix test env comments

## Testing
- `npm test`
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68a2d5c839e48329876cd2d91184d197