### PR TITLE
feat: add digital signature flow

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -3,6 +3,7 @@ package com.bellingham.datafutures.controller;
 import com.bellingham.datafutures.model.ForwardContract;
 import com.bellingham.datafutures.model.ContractActivity;
 import com.bellingham.datafutures.model.Bid;
+import com.bellingham.datafutures.model.SignatureRequest;
 import com.bellingham.datafutures.repository.BidRepository;
 import com.bellingham.datafutures.repository.ContractActivityRepository;
 import com.bellingham.datafutures.repository.ForwardContractRepository;
@@ -178,7 +179,7 @@ public class ForwardContractController {
     }
 
     @PostMapping("/{id}/buy")
-    public ResponseEntity<ForwardContract> buy(@PathVariable Long id) {
+    public ResponseEntity<ForwardContract> buy(@PathVariable Long id, @RequestBody SignatureRequest signature) {
         return repository.findById(id)
                 .map(contract -> {
                     if (!"Available".equalsIgnoreCase(contract.getStatus())) {
@@ -189,6 +190,7 @@ public class ForwardContractController {
                             .getContext().getAuthentication().getName();
                     contract.setBuyerUsername(username);
                     contract.setPurchaseDate(LocalDate.now());
+                    contract.setBuyerSignature(signature.getSignature());
                     ForwardContract saved = repository.save(contract);
                     logActivity(saved, username, "Purchased contract");
                     return ResponseEntity.ok(saved);

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/ForwardContract.java
@@ -51,6 +51,12 @@ public class ForwardContract {
     private String technicalContactPhone;
     private String companyDescription;
 
+    @Lob
+    private String sellerSignature;
+
+    @Lob
+    private String buyerSignature;
+
     // Getters and setters
 
     public Long getId() {
@@ -315,5 +321,21 @@ public class ForwardContract {
 
     public void setCompanyDescription(String companyDescription) {
         this.companyDescription = companyDescription;
+    }
+
+    public String getSellerSignature() {
+        return sellerSignature;
+    }
+
+    public void setSellerSignature(String sellerSignature) {
+        this.sellerSignature = sellerSignature;
+    }
+
+    public String getBuyerSignature() {
+        return buyerSignature;
+    }
+
+    public void setBuyerSignature(String buyerSignature) {
+        this.buyerSignature = buyerSignature;
     }
 }

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/SignatureRequest.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/model/SignatureRequest.java
@@ -1,0 +1,13 @@
+package com.bellingham.datafutures.model;
+
+public class SignatureRequest {
+    private String signature;
+
+    public String getSignature() {
+        return signature;
+    }
+
+    public void setSignature(String signature) {
+        this.signature = signature;
+    }
+}

--- a/bellingham-frontend/package-lock.json
+++ b/bellingham-frontend/package-lock.json
@@ -16,7 +16,8 @@
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
-        "react-router-dom": "^7.5.0"
+        "react-router-dom": "^7.5.0",
+        "react-signature-canvas": "^1.0.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -4349,6 +4350,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -4580,6 +4591,25 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -4737,6 +4767,21 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-signature-canvas": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/react-signature-canvas/-/react-signature-canvas-1.0.7.tgz",
+      "integrity": "sha512-yo0x0uTMVmcClaqryuQu6F8xEVapk5zdM9/nuQ7GalDJWccoVNZPMmCFGK7U5r3I0mrEHPB9E5/rFSYUgZcfmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "signature_pad": "^2.3.2",
+        "trim-canvas": "^0.1.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.5.8",
+        "react": "0.14 - 19",
+        "react-dom": "0.14 - 19"
       }
     },
     "node_modules/redent": {
@@ -4901,6 +4946,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/signature_pad": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-2.3.2.tgz",
+      "integrity": "sha512-peYXLxOsIY6MES2TrRLDiNg2T++8gGbpP2yaC+6Ohtxr+a2dzoaqWosWDY9sWqTAAk6E/TyQO+LJw9zQwyu5kA==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -5105,6 +5156,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/trim-canvas": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/trim-canvas/-/trim-canvas-0.1.2.tgz",
+      "integrity": "sha512-nd4Ga3iLFV94mdhW9JFMLpQbHUyCQuhFOD71PEAt1NjtMD5wbZctzhX8c3agHNybMR5zXD1XTGoIEWk995E6pQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/turbo-stream": {
       "version": "2.4.0",

--- a/bellingham-frontend/package.json
+++ b/bellingham-frontend/package.json
@@ -19,11 +19,14 @@
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
-    "react-router-dom": "^7.5.0"
+    "react-router-dom": "^7.5.0",
+    "react-signature-canvas": "^1.0.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
     "@tailwindcss/postcss": "^4.1.10",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",
@@ -32,12 +35,10 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.3.0",
     "jsdom": "^24.0.0",
-    "vitest": "^1.2.1",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.10",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^1.2.1"
   }
 }

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -7,6 +7,7 @@ import ContractDetailsPanel from "./ContractDetailsPanel";
 import Layout from "./Layout";
 import Button from "./ui/Button";
 import { useNavigate } from "react-router-dom";
+import SignatureModal from "./SignatureModal";
 
 const Buy = () => {
     const navigate = useNavigate();
@@ -41,13 +42,24 @@ const Buy = () => {
         fetchContracts();
     }, []);
 
-    const handleBuy = async (contractId) => {
+    const [showSignature, setShowSignature] = useState(false);
+    const [pendingBuyId, setPendingBuyId] = useState(null);
+
+    const handleBuy = (contractId) => {
+        setPendingBuyId(contractId);
+        setShowSignature(true);
+    };
+
+    const confirmBuy = async (signature) => {
         try {
-            await api.post(`/api/contracts/${contractId}/buy`);
+            await api.post(`/api/contracts/${pendingBuyId}/buy`, { signature });
             alert("Contract purchased successfully!");
         } catch (err) {
             console.error(err);
             alert("Failed to purchase contract.");
+        } finally {
+            setShowSignature(false);
+            setPendingBuyId(null);
         }
     };
 
@@ -191,6 +203,12 @@ const Buy = () => {
                     />
                 </main>
         </Layout>
+        {showSignature && (
+            <SignatureModal
+                onConfirm={confirmBuy}
+                onCancel={() => setShowSignature(false)}
+            />
+        )}
     );
 };
 

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useContext } from "react";
+import SignatureModal from "./SignatureModal";
 import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
 import Button from "./ui/Button";
@@ -120,6 +121,9 @@ const Sell = () => {
         setSnippet(e.target.files[0]);
     };
 
+    const [showSignature, setShowSignature] = useState(false);
+    const [pendingData, setPendingData] = useState(null);
+
     const handleSubmit = async (e) => {
         e.preventDefault();
 
@@ -142,9 +146,14 @@ const Sell = () => {
         if (snippet) {
             data.termsFileName = snippet.name;
         }
+        setPendingData(data);
+        setShowSignature(true);
+    };
 
+    const submitWithSignature = async (signature) => {
         try {
-            await api.post(`/api/contracts`, data);
+            const payload = { ...pendingData, sellerSignature: signature };
+            await api.post(`/api/contracts`, payload);
             setMessage("✅ Data contract submitted!");
             setForm({
                 effectiveDate: "",
@@ -166,6 +175,9 @@ const Sell = () => {
         } catch (err) {
             setMessage("❌ Submission failed.");
             console.error(err);
+        } finally {
+            setShowSignature(false);
+            setPendingData(null);
         }
     };
 
@@ -414,6 +426,12 @@ const Sell = () => {
             </table>
         </main>
         </Layout>
+        {showSignature && (
+            <SignatureModal
+                onConfirm={submitWithSignature}
+                onCancel={() => setShowSignature(false)}
+            />
+        )}
     );
 };
 

--- a/bellingham-frontend/src/components/SignatureModal.jsx
+++ b/bellingham-frontend/src/components/SignatureModal.jsx
@@ -1,0 +1,37 @@
+import React, { useRef } from 'react';
+import SignatureCanvas from 'react-signature-canvas';
+import Button from './ui/Button';
+
+const SignatureModal = ({ onConfirm, onCancel }) => {
+  const sigRef = useRef(null);
+
+  const handleClear = () => {
+    sigRef.current && sigRef.current.clear();
+  };
+
+  const handleSave = () => {
+    if (sigRef.current && !sigRef.current.isEmpty()) {
+      const data = sigRef.current.toDataURL();
+      onConfirm(data);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="bg-white p-4 rounded shadow-md">
+        <SignatureCanvas
+          ref={sigRef}
+          penColor="black"
+          canvasProps={{ width: 400, height: 200, className: 'border border-gray-300' }}
+        />
+        <div className="mt-2 flex justify-end gap-2">
+          <Button variant="ghost" onClick={handleClear}>Clear</Button>
+          <Button variant="danger" onClick={onCancel}>Cancel</Button>
+          <Button variant="success" onClick={handleSave}>Save</Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SignatureModal;


### PR DESCRIPTION
## Summary
- add signature capture component using react-signature-canvas
- require signatures when submitting or buying a contract
- persist buyer and seller signatures on the backend

## Testing
- `npm test`
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a333ae49988329ab79dd628de966cc