### PR TITLE
Fix Sell component JSX syntax error

### DIFF
--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -219,6 +219,7 @@ const Sell = () => {
     };
 
     return (
+        <>
         <Layout onLogout={handleLogout}>
             <main className="flex-1 p-8">
                 <h1 className="text-3xl font-bold mb-6">Sell Your Data Contract</h1>
@@ -432,6 +433,7 @@ const Sell = () => {
                 onCancel={() => setShowSignature(false)}
             />
         )}
+        </>
     );
 };
 


### PR DESCRIPTION
## Summary
- wrap Sell component return in React fragment to enable sibling signature modal

## Testing
- `cd bellingham-frontend && npm test`
- `cd bellingham-frontend && npm run lint` *(fails: Parsing error: Unexpected token in Buy.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a97eabb82883299089ae7833e821f2