### PR TITLE
Wrap Buy JSX in fragment for SignatureModal integration

### DIFF
--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -111,6 +111,7 @@ const Buy = () => {
     });
 
     return (
+        <>
         <Layout onLogout={handleLogout}>
             <main className="flex-1 p-8 overflow-auto">
                 <h1 className="text-3xl font-bold mb-6">Available Contracts</h1>
@@ -209,6 +210,7 @@ const Buy = () => {
                 onCancel={() => setShowSignature(false)}
             />
         )}
+        </>
     );
 };
 


### PR DESCRIPTION
## Summary
- Fix Buy page JSX structure by wrapping Layout and conditional SignatureModal in a React fragment
- Ensure react-signature-canvas dependency is installed for signature capture

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9f258d2d48329b26113380b42f8aa