### PR TITLE
fix: prebundle signature canvas dependency

### DIFF
--- a/bellingham-frontend/vite.config.js
+++ b/bellingham-frontend/vite.config.js
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  optimizeDeps: {
+    include: ['react-signature-canvas'],
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- configure Vite to explicitly prebundle `react-signature-canvas`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac11e7cb388329915acca089120251