### PR TITLE
test: add signature modal tests

### DIFF
--- a/bellingham-frontend/src/__tests__/SignatureModal.test.jsx
+++ b/bellingham-frontend/src/__tests__/SignatureModal.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import SignatureModal from '../components/SignatureModal';
+
+vi.mock('react-signature-canvas', () => ({
+  default: React.forwardRef((props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      clear: vi.fn(),
+      isEmpty: () => false,
+      toDataURL: () => 'mock-data-url',
+    }));
+    return <canvas {...props.canvasProps} data-testid="signature-canvas" />;
+  }),
+}));
+
+test('invokes handlers for actions', () => {
+  const onConfirm = vi.fn();
+  const onCancel = vi.fn();
+  render(<SignatureModal onConfirm={onConfirm} onCancel={onCancel} />);
+  fireEvent.click(screen.getByText('Save'));
+  expect(onConfirm).toHaveBeenCalledWith('mock-data-url');
+  fireEvent.click(screen.getByText('Cancel'));
+  expect(onCancel).toHaveBeenCalled();
+  fireEvent.click(screen.getByText('Clear'));
+  expect(screen.getByTestId('signature-canvas')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add SignatureModal unit tests mocking react-signature-canvas

## Testing
- `cd bellingham-frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac178250c48329bd1db7499ff4aacd