### PR TITLE
Mock signature canvas for tests

### DIFF
--- a/bellingham-frontend/src/__tests__/SignatureModal.test.jsx
+++ b/bellingham-frontend/src/__tests__/SignatureModal.test.jsx
@@ -4,16 +4,20 @@ import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import SignatureModal from '../components/SignatureModal';
 
-vi.mock('react-signature-canvas', () => ({
-  default: React.forwardRef((props, ref) => {
-    React.useImperativeHandle(ref, () => ({
-      clear: vi.fn(),
-      isEmpty: () => false,
-      toDataURL: () => 'mock-data-url',
-    }));
-    return <canvas {...props.canvasProps} data-testid="signature-canvas" />;
+vi.mock(
+  'react-signature-canvas',
+  () => ({
+    default: React.forwardRef((props, ref) => {
+      React.useImperativeHandle(ref, () => ({
+        clear: vi.fn(),
+        isEmpty: () => false,
+        toDataURL: () => 'mock-data-url',
+      }));
+      return <canvas {...props.canvasProps} data-testid="signature-canvas" />;
+    }),
   }),
-}));
+  { virtual: true }
+);
 
 test('invokes handlers for actions', () => {
   const onConfirm = vi.fn();


### PR DESCRIPTION
## Summary
- mock react-signature-canvas as a virtual module in SignatureModal tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac1891a62883298e03fa632de70978