### PR TITLE
test: provide mock for signature canvas

### DIFF
--- a/bellingham-frontend/__mocks__/react-signature-canvas.jsx
+++ b/bellingham-frontend/__mocks__/react-signature-canvas.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { vi } from 'vitest';
+
+export default React.forwardRef((props, ref) => {
+  React.useImperativeHandle(ref, () => ({
+    clear: vi.fn(),
+    isEmpty: () => false,
+    toDataURL: () => 'mock-data-url',
+  }));
+  return <canvas {...props.canvasProps} data-testid="signature-canvas" />;
+});

--- a/bellingham-frontend/src/__tests__/SignatureModal.test.jsx
+++ b/bellingham-frontend/src/__tests__/SignatureModal.test.jsx
@@ -4,20 +4,9 @@ import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import SignatureModal from '../components/SignatureModal';
 
-vi.mock(
-  'react-signature-canvas',
-  () => ({
-    default: React.forwardRef((props, ref) => {
-      React.useImperativeHandle(ref, () => ({
-        clear: vi.fn(),
-        isEmpty: () => false,
-        toDataURL: () => 'mock-data-url',
-      }));
-      return <canvas {...props.canvasProps} data-testid="signature-canvas" />;
-    }),
-  }),
-  { virtual: true }
-);
+// Provide a mock implementation for the signature canvas library so the
+// component can be tested without requiring the actual dependency or DOM APIs.
+vi.mock('react-signature-canvas');
 
 test('invokes handlers for actions', () => {
   const onConfirm = vi.fn();


### PR DESCRIPTION
## Summary
- mock `react-signature-canvas` with manual implementation so tests don't require the real package
- streamline `SignatureModal` test by using the manual mock

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac1c370e8c8329a0055c647427f405