### PR TITLE
Replace signature modal dependency with signature_pad

### DIFF
--- a/bellingham-frontend/package-lock.json
+++ b/bellingham-frontend/package-lock.json
@@ -17,7 +17,7 @@
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.5.0",
-        "react-signature-canvas": "^1.0.7"
+        "signature_pad": "^5.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -4350,16 +4350,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -4591,25 +4581,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -4767,21 +4738,6 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
-      }
-    },
-    "node_modules/react-signature-canvas": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/react-signature-canvas/-/react-signature-canvas-1.0.7.tgz",
-      "integrity": "sha512-yo0x0uTMVmcClaqryuQu6F8xEVapk5zdM9/nuQ7GalDJWccoVNZPMmCFGK7U5r3I0mrEHPB9E5/rFSYUgZcfmA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "signature_pad": "^2.3.2",
-        "trim-canvas": "^0.1.0"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.5.8",
-        "react": "0.14 - 19",
-        "react-dom": "0.14 - 19"
       }
     },
     "node_modules/redent": {
@@ -4948,9 +4904,9 @@
       }
     },
     "node_modules/signature_pad": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-2.3.2.tgz",
-      "integrity": "sha512-peYXLxOsIY6MES2TrRLDiNg2T++8gGbpP2yaC+6Ohtxr+a2dzoaqWosWDY9sWqTAAk6E/TyQO+LJw9zQwyu5kA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-5.1.1.tgz",
+      "integrity": "sha512-BT5JJygS5BS0oV+tffPRorIud6q17bM7v/1LdQwd0o6mTqGoI25yY1NjSL99OqkekWltS4uon6p52Y8j1Zqu7g==",
       "license": "MIT"
     },
     "node_modules/source-map-js": {
@@ -5156,12 +5112,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/trim-canvas": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/trim-canvas/-/trim-canvas-0.1.2.tgz",
-      "integrity": "sha512-nd4Ga3iLFV94mdhW9JFMLpQbHUyCQuhFOD71PEAt1NjtMD5wbZctzhX8c3agHNybMR5zXD1XTGoIEWk995E6pQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/turbo-stream": {
       "version": "2.4.0",

--- a/bellingham-frontend/package.json
+++ b/bellingham-frontend/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.5.0",
-    "react-signature-canvas": "^1.0.7"
+    "signature_pad": "^5.1.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/bellingham-frontend/vite.config.js
+++ b/bellingham-frontend/vite.config.js
@@ -4,9 +4,6 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  optimizeDeps: {
-    include: ['react-signature-canvas'],
-  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- replace the react-signature-canvas dependency with signature_pad and remove related Vite configuration
- rebuild the signature modal component to manage a native canvas via signature_pad
- update project dependencies to reflect the new implementation

## Testing
- npm run lint (warns about existing AuthContext export pattern)


------
https://chatgpt.com/codex/tasks/task_e_68cbd78bfc208329a930454a0eb8265c