### PR TITLE
Fix signature pad import resolution

### DIFF
--- a/bellingham-frontend/src/components/SignatureModal.jsx
+++ b/bellingham-frontend/src/components/SignatureModal.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import SignaturePad from 'signature_pad';
+import SignaturePad from 'signature_pad/dist/signature_pad.mjs';
 import Button from './ui/Button';
 
 const SignatureModal = ({ onConfirm, onCancel }) => {


### PR DESCRIPTION
## Summary
- update SignatureModal to import the explicit ESM build of signature_pad so Vite can resolve it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbdf4881fc83298d4791866060c7a3