### PR TITLE
Fix signature pad import path

### DIFF
--- a/bellingham-frontend/src/components/SignatureModal.jsx
+++ b/bellingham-frontend/src/components/SignatureModal.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import SignaturePad from 'signature_pad/dist/signature_pad.mjs';
+import SignaturePad from 'signature_pad';
 import Button from './ui/Button';
 
 const SignatureModal = ({ onConfirm, onCancel }) => {


### PR DESCRIPTION
## Summary
- update the signature pad import to use the package entry point so Vite can resolve it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbe29455908329a3c692b51499c78c