### PR TITLE
Mock signature pad in SignatureModal test

### DIFF
--- a/bellingham-frontend/src/__tests__/SignatureModal.test.jsx
+++ b/bellingham-frontend/src/__tests__/SignatureModal.test.jsx
@@ -6,7 +6,39 @@ import SignatureModal from '../components/SignatureModal';
 
 // Provide a mock implementation for the signature canvas library so the
 // component can be tested without requiring the actual dependency or DOM APIs.
-vi.mock('react-signature-canvas');
+vi.mock(
+  'signature_pad/dist/signature_pad.js',
+  () => ({
+    default: class {
+      clear() {}
+
+      isEmpty() {
+        return false;
+      }
+
+      toDataURL() {
+        return 'mock-data-url';
+      }
+
+      off() {}
+    },
+  }),
+  { virtual: true },
+);
+
+const originalGetContext = HTMLCanvasElement.prototype.getContext;
+
+beforeAll(() => {
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+    setTransform: vi.fn(),
+    scale: vi.fn(),
+    clearRect: vi.fn(),
+  }));
+});
+
+afterAll(() => {
+  HTMLCanvasElement.prototype.getContext = originalGetContext;
+});
 
 test('invokes handlers for actions', () => {
   const onConfirm = vi.fn();

--- a/bellingham-frontend/src/components/SignatureModal.jsx
+++ b/bellingham-frontend/src/components/SignatureModal.jsx
@@ -64,6 +64,7 @@ const SignatureModal = ({ onConfirm, onCancel }) => {
           className="border border-gray-300"
           width={400}
           height={200}
+          data-testid="signature-canvas"
         />
         <div className="mt-2 flex justify-end gap-2">
           <Button variant="ghost" onClick={handleClear}>Clear</Button>

--- a/bellingham-frontend/vite.config.js
+++ b/bellingham-frontend/vite.config.js
@@ -4,6 +4,11 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      'signature_pad/dist/signature_pad.js': 'signature_pad',
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- stub `signature_pad/dist/signature_pad.js` in the SignatureModal test with the canvas methods the component uses
- add a data-testid to the signature canvas so the test can continue to locate it
- alias the signature pad distribution path in Vite for predictable module resolution during tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbe7c3fbc8832993e271272e242327