### PR TITLE
fix: allow vite to resolve signature pad

### DIFF
--- a/bellingham-frontend/vite.config.js
+++ b/bellingham-frontend/vite.config.js
@@ -4,11 +4,6 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  resolve: {
-    alias: {
-      'signature_pad/dist/signature_pad.js': 'signature_pad',
-    },
-  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- remove the incorrect signature_pad alias from Vite config so the package can be resolved normally

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbf25606748329910027632421503a