### PR TITLE
Replace signature pad dependency with custom canvas drawing

### DIFF
--- a/bellingham-frontend/src/App.jsx
+++ b/bellingham-frontend/src/App.jsx
@@ -12,7 +12,7 @@ import Account from "./components/Account";
 import Settings from "./components/Settings";
 import History from "./components/History";
 import Logo from "./components/Logo";
-import { AuthContext } from "./context/AuthContext";
+import { AuthContext } from './context';
 
 const App = () => {
     const { token } = useContext(AuthContext);

--- a/bellingham-frontend/src/__tests__/AuthContext.test.jsx
+++ b/bellingham-frontend/src/__tests__/AuthContext.test.jsx
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import React from 'react';
 import { renderHook, act } from '@testing-library/react';
-import { AuthProvider, AuthContext } from '../context/AuthContext';
+import { AuthProvider, AuthContext } from '../context';
 
 beforeEach(() => {
   localStorage.clear();

--- a/bellingham-frontend/src/__tests__/Login.test.jsx
+++ b/bellingham-frontend/src/__tests__/Login.test.jsx
@@ -2,7 +2,7 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Login from '../components/Login';
-import { AuthProvider } from '../context/AuthContext';
+import { AuthProvider } from '../context';
 
 test('renders username and password fields', () => {
   render(

--- a/bellingham-frontend/src/__tests__/SignatureModal.test.jsx
+++ b/bellingham-frontend/src/__tests__/SignatureModal.test.jsx
@@ -4,46 +4,65 @@ import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import SignatureModal from '../components/SignatureModal';
 
-// Provide a mock implementation for the signature canvas library so the
-// component can be tested without requiring the actual dependency or DOM APIs.
-vi.mock(
-  'signature_pad/dist/signature_pad.js',
-  () => ({
-    default: class {
-      clear() {}
-
-      isEmpty() {
-        return false;
-      }
-
-      toDataURL() {
-        return 'mock-data-url';
-      }
-
-      off() {}
-    },
-  }),
-  { virtual: true },
-);
-
-const originalGetContext = HTMLCanvasElement.prototype.getContext;
+const originalCanvasProps = {
+  getContext: HTMLCanvasElement.prototype.getContext,
+  toDataURL: HTMLCanvasElement.prototype.toDataURL,
+  getBoundingClientRect: HTMLCanvasElement.prototype.getBoundingClientRect,
+  setPointerCapture: HTMLCanvasElement.prototype.setPointerCapture,
+  releasePointerCapture: HTMLCanvasElement.prototype.releasePointerCapture,
+  hasPointerCapture: HTMLCanvasElement.prototype.hasPointerCapture,
+};
 
 beforeAll(() => {
   HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
     setTransform: vi.fn(),
     scale: vi.fn(),
     clearRect: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    closePath: vi.fn(),
+    lineCap: 'round',
+    lineJoin: 'round',
+    strokeStyle: 'black',
+    lineWidth: 2,
   }));
+  HTMLCanvasElement.prototype.toDataURL = vi.fn(() => 'mock-data-url');
+  HTMLCanvasElement.prototype.getBoundingClientRect = vi.fn(() => ({
+    left: 0,
+    top: 0,
+    width: 400,
+    height: 200,
+  }));
+  HTMLCanvasElement.prototype.setPointerCapture = vi.fn();
+  HTMLCanvasElement.prototype.releasePointerCapture = vi.fn();
+  HTMLCanvasElement.prototype.hasPointerCapture = vi.fn(() => true);
 });
 
 afterAll(() => {
-  HTMLCanvasElement.prototype.getContext = originalGetContext;
+  HTMLCanvasElement.prototype.getContext = originalCanvasProps.getContext;
+  HTMLCanvasElement.prototype.toDataURL = originalCanvasProps.toDataURL;
+  HTMLCanvasElement.prototype.getBoundingClientRect =
+    originalCanvasProps.getBoundingClientRect;
+  HTMLCanvasElement.prototype.setPointerCapture =
+    originalCanvasProps.setPointerCapture;
+  HTMLCanvasElement.prototype.releasePointerCapture =
+    originalCanvasProps.releasePointerCapture;
+  HTMLCanvasElement.prototype.hasPointerCapture =
+    originalCanvasProps.hasPointerCapture;
 });
 
 test('invokes handlers for actions', () => {
   const onConfirm = vi.fn();
   const onCancel = vi.fn();
   render(<SignatureModal onConfirm={onConfirm} onCancel={onCancel} />);
+  const canvas = screen.getByTestId('signature-canvas');
+
+  fireEvent.pointerDown(canvas, { clientX: 10, clientY: 10, pointerId: 1 });
+  fireEvent.pointerMove(canvas, { clientX: 20, clientY: 20, pointerId: 1 });
+  fireEvent.pointerUp(canvas, { clientX: 20, clientY: 20, pointerId: 1 });
+
   fireEvent.click(screen.getByText('Save'));
   expect(onConfirm).toHaveBeenCalledWith('mock-data-url');
   fireEvent.click(screen.getByText('Cancel'));

--- a/bellingham-frontend/src/components/Account.jsx
+++ b/bellingham-frontend/src/components/Account.jsx
@@ -3,7 +3,7 @@ import Layout from "./Layout";
 import Button from "./ui/Button";
 import { useNavigate } from "react-router-dom";
 import api from "../utils/api";
-import { AuthContext } from "../context/AuthContext";
+import { AuthContext } from '../context';
 
 const Account = () => {
     const [profile, setProfile] = useState(null);

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState, useContext } from "react";
 import api from "../utils/api";
-import { AuthContext } from "../context/AuthContext";
+import { AuthContext } from '../context';
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import Layout from "./Layout";
 import Button from "./ui/Button";

--- a/bellingham-frontend/src/components/Calendar.jsx
+++ b/bellingham-frontend/src/components/Calendar.jsx
@@ -4,7 +4,7 @@ import 'react-calendar/dist/Calendar.css';
 import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
 import api from "../utils/api";
-import { AuthContext } from "../context/AuthContext";
+import { AuthContext } from '../context';
 
 const ContractCalendar = () => {
     const navigate = useNavigate();

--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useContext } from "react";
 import BidChart from "./BidChart";
 import Button from "./ui/Button";
 import api from "../utils/api";
-import { AuthContext } from "../context/AuthContext";
+import { AuthContext } from '../context';
 
 const ContractDetailsPanel = ({
     contract,

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -5,7 +5,7 @@ import { useNavigate } from "react-router-dom";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import Layout from "./Layout";
 import api from "../utils/api";
-import { AuthContext } from "../context/AuthContext";
+import { AuthContext } from '../context';
 
 const Dashboard = () => {
     const [contracts, setContracts] = useState([]);

--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 
 import logoImage from "../assets/login.png";
-import { AuthContext } from "../context/AuthContext";
+import { AuthContext } from '../context';
 
 const Header = () => {
     const { username } = useContext(AuthContext);

--- a/bellingham-frontend/src/components/History.jsx
+++ b/bellingham-frontend/src/components/History.jsx
@@ -3,7 +3,7 @@ import Layout from "./Layout";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import { useNavigate } from "react-router-dom";
 import api from "../utils/api";
-import { AuthContext } from "../context/AuthContext";
+import { AuthContext } from '../context';
 
 const History = () => {
     const navigate = useNavigate();

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -4,7 +4,7 @@ import React, { useState, useContext } from "react";
 import LoginImage from "../assets/login.png";
 import Button from "./ui/Button";
 import api from "../utils/api";
-import { AuthContext } from "../context/AuthContext";
+import { AuthContext } from '../context';
 
 const Login = () => {
     const [username, setUsername] = useState("");

--- a/bellingham-frontend/src/components/NotificationPopup.jsx
+++ b/bellingham-frontend/src/components/NotificationPopup.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useContext } from "react";
 import Button from "./ui/Button";
 import api from "../utils/api";
-import { AuthContext } from "../context/AuthContext";
+import { AuthContext } from '../context';
 
 const NotificationPopup = () => {
     const [notification, setNotification] = useState(null);

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -4,7 +4,7 @@ import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
 import Button from "./ui/Button";
 import api from "../utils/api";
-import { AuthContext } from "../context/AuthContext";
+import { AuthContext } from '../context';
 
 const Reports = () => {
     const navigate = useNavigate();

--- a/bellingham-frontend/src/components/Sales.jsx
+++ b/bellingham-frontend/src/components/Sales.jsx
@@ -3,7 +3,7 @@ import Layout from "./Layout";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import { useNavigate } from "react-router-dom";
 import api from "../utils/api";
-import { AuthContext } from "../context/AuthContext";
+import { AuthContext } from '../context';
 
 const Sales = () => {
     const navigate = useNavigate();

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -4,7 +4,7 @@ import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
 import Button from "./ui/Button";
 import api from "../utils/api";
-import { AuthContext } from "../context/AuthContext";
+import { AuthContext } from '../context';
 
 const defaultAgreement = `Forward Data Sale Agreement (England & Wales Law)
 

--- a/bellingham-frontend/src/components/Settings.jsx
+++ b/bellingham-frontend/src/components/Settings.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
-import { AuthContext } from "../context/AuthContext";
+import { AuthContext } from '../context';
 
 const Settings = () => {
     const navigate = useNavigate();

--- a/bellingham-frontend/src/context/AuthContext.js
+++ b/bellingham-frontend/src/context/AuthContext.js
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+
+const AuthContext = createContext({
+  token: null,
+  username: null,
+  login: () => {},
+  logout: () => {},
+});
+
+export default AuthContext;

--- a/bellingham-frontend/src/context/AuthProvider.jsx
+++ b/bellingham-frontend/src/context/AuthProvider.jsx
@@ -1,8 +1,7 @@
-import React, { createContext, useState } from 'react';
+import React, { useState } from 'react';
+import AuthContext from './AuthContext';
 
-export const AuthContext = createContext({ token: null, username: null, login: () => {}, logout: () => {} });
-
-export const AuthProvider = ({ children }) => {
+const AuthProvider = ({ children }) => {
   const [token, setToken] = useState(() => localStorage.getItem('token'));
   const [username, setUsername] = useState(() => localStorage.getItem('username'));
 
@@ -27,4 +26,4 @@ export const AuthProvider = ({ children }) => {
   );
 };
 
-export default AuthContext;
+export default AuthProvider;

--- a/bellingham-frontend/src/context/index.js
+++ b/bellingham-frontend/src/context/index.js
@@ -1,0 +1,2 @@
+export { default as AuthContext } from './AuthContext';
+export { default as AuthProvider } from './AuthProvider';

--- a/bellingham-frontend/src/main.jsx
+++ b/bellingham-frontend/src/main.jsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
-import { AuthProvider } from "./context/AuthContext";
+import { AuthProvider } from './context';
 
 ReactDOM.createRoot(document.getElementById("root")).render(
     <React.StrictMode>


### PR DESCRIPTION
## Summary
- replace the signature capture dependency with a pointer-driven canvas implementation to resolve the missing module error
- split the authentication context into dedicated context and provider modules and update consumers to use the new barrel export
- adjust the signature modal test to exercise the canvas interactions used by the custom implementation

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbf54513f883299291d20a72514afd