### PR TITLE
Enlarge floating logo graphic

### DIFF
--- a/bellingham-frontend/src/components/Logo.jsx
+++ b/bellingham-frontend/src/components/Logo.jsx
@@ -4,7 +4,7 @@ import logoImage from "../assets/login.png";
 const Logo = () => {
     const isLogin = window.location.pathname === "/login";
     const style = isLogin ? { right: "calc(1rem + 10px)" } : {};
-    const sizeClass = isLogin ? "w-[150px] h-[150px]" : "w-[180px] h-[180px]";
+    const sizeClass = isLogin ? "w-[300px] h-[300px]" : "w-[360px] h-[360px]";
 
     return (
         <img


### PR DESCRIPTION
## Summary
- double the displayed size of the floating logo on login and authenticated screens

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cc0217af1c8329aae382585ffd7128