### PR TITLE
Increase Reports pie chart size

### DIFF
--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -148,7 +148,7 @@ const Reports = () => {
                         <div className="bg-gray-800 border border-gray-700 rounded-lg p-6 shadow-md">
                             <h2 className="text-xl font-semibold mb-4">Allocation Overview</h2>
                             <div className="flex flex-col lg:flex-row items-center gap-6">
-                                <div className="w-full lg:w-1/2 max-w-xs lg:max-w-sm mx-auto h-64">
+                                <div className="w-full lg:w-[70%] max-w-3xl mx-auto h-[32rem]">
                                     <Pie data={pieData} options={pieOptions} />
                                 </div>
                                 <div className="w-full lg:w-1/2 space-y-2 text-sm text-gray-200">


### PR DESCRIPTION
## Summary
- expand the pie chart container in the Reports view to take up 70% width and a taller max size for a noticeably larger chart

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc03acdfd08329a75a5ca3f9dd0254