### PR TITLE
Add signature validation when buying contracts

### DIFF
--- a/bellingham-frontend/src/__tests__/Buy.test.jsx
+++ b/bellingham-frontend/src/__tests__/Buy.test.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import Buy from '../components/Buy';
+import { AuthContext } from '../context';
+import api from '../utils/api';
+
+vi.mock('../utils/api');
+
+const renderWithProviders = (ui) => {
+  const logout = vi.fn();
+  return render(
+    <AuthContext.Provider value={{ token: 'token', logout }}>
+      <MemoryRouter>
+        {ui}
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+};
+
+describe('Buy component', () => {
+  beforeEach(() => {
+    api.get.mockImplementation((url) => {
+      if (url === '/api/contracts/available') {
+        return Promise.resolve({
+          data: {
+            content: [
+              {
+                id: 1,
+                title: 'Contract A',
+                seller: 'Seller 1',
+                price: 100,
+                deliveryDate: '2024-01-01',
+              },
+            ],
+          },
+        });
+      }
+      return Promise.resolve({ data: [] });
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('shows signature modal when buy button clicked', async () => {
+    renderWithProviders(<Buy />);
+
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith('/api/contracts/available'));
+
+    const buyButton = screen.getAllByRole('button', { name: 'Buy' })[0];
+    fireEvent.click(buyButton);
+
+    expect(await screen.findByTestId('signature-canvas')).toBeInTheDocument();
+  });
+});

--- a/bellingham-frontend/src/__tests__/SignatureModal.test.jsx
+++ b/bellingham-frontend/src/__tests__/SignatureModal.test.jsx
@@ -70,3 +70,13 @@ test('invokes handlers for actions', () => {
   fireEvent.click(screen.getByText('Clear'));
   expect(screen.getByTestId('signature-canvas')).toBeInTheDocument();
 });
+
+test('displays error if attempting to save without a signature', () => {
+  const onConfirm = vi.fn();
+  render(<SignatureModal onConfirm={onConfirm} onCancel={vi.fn()} />);
+
+  fireEvent.click(screen.getByText('Save'));
+
+  expect(onConfirm).not.toHaveBeenCalled();
+  expect(screen.getByRole('alert')).toHaveTextContent('Please provide your signature before saving.');
+});

--- a/bellingham-frontend/src/components/SignatureModal.jsx
+++ b/bellingham-frontend/src/components/SignatureModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Button from './ui/Button';
 
 const SignatureModal = ({ onConfirm, onCancel }) => {
@@ -7,6 +7,7 @@ const SignatureModal = ({ onConfirm, onCancel }) => {
   const isDrawingRef = useRef(false);
   const isEmptyRef = useRef(true);
   const ratioRef = useRef(1);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -112,14 +113,21 @@ const SignatureModal = ({ onConfirm, onCancel }) => {
 
     context.clearRect(0, 0, canvas.width, canvas.height);
     isEmptyRef.current = true;
+    setError('');
   };
 
   const handleSave = () => {
     const canvas = canvasRef.current;
-    if (canvas && !isEmptyRef.current) {
-      const data = canvas.toDataURL('image/png');
-      onConfirm(data);
+    if (!canvas) return;
+
+    if (isEmptyRef.current) {
+      setError('Please provide your signature before saving.');
+      return;
     }
+
+    setError('');
+    const data = canvas.toDataURL('image/png');
+    onConfirm(data);
   };
 
   return (
@@ -132,6 +140,7 @@ const SignatureModal = ({ onConfirm, onCancel }) => {
           height={200}
           data-testid="signature-canvas"
         />
+        {error && <p className="mt-2 text-sm text-red-600" role="alert">{error}</p>}
         <div className="mt-2 flex justify-end gap-2">
           <Button variant="ghost" onClick={handleClear}>Clear</Button>
           <Button variant="danger" onClick={onCancel}>Cancel</Button>


### PR DESCRIPTION
## Summary
- prevent empty signature submissions by tracking when no drawing has occurred and surfacing an inline validation message in the signature modal
- reset the validation message when the signature pad is cleared to allow a new attempt
- add tests for the updated signature modal behaviour and cover the Buy page flow to ensure the signature modal opens

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc2a33c2f48329ba5856132e62ea00