### PR TITLE
Fix overlay blocking Sell and Buy actions

### DIFF
--- a/bellingham-frontend/src/components/NotificationPopup.jsx
+++ b/bellingham-frontend/src/components/NotificationPopup.jsx
@@ -59,22 +59,24 @@ const NotificationPopup = () => {
     };
 
     return (
-        <div className="fixed top-24 left-4 right-4 md:left-72 md:right-8 bg-gray-800 text-white p-4 rounded shadow-lg z-40 flex flex-col md:flex-row md:items-center md:justify-between gap-3">
-            <p className="font-semibold">
-                You have {unreadCount === 1 ? "1 unread notification" : `${unreadCount} unread notifications`}.
-            </p>
-            {latest?.message && (
-                <p className="text-sm text-gray-300 flex-1">
-                    Latest: {latest.message}
+        <div className="fixed top-24 left-4 right-4 md:left-72 md:right-8 z-40 pointer-events-none">
+            <div className="bg-gray-800 text-white p-4 rounded shadow-lg flex flex-col md:flex-row md:items-center md:justify-between gap-3 pointer-events-auto">
+                <p className="font-semibold">
+                    You have {unreadCount === 1 ? "1 unread notification" : `${unreadCount} unread notifications`}.
                 </p>
-            )}
-            <div className="flex gap-2 flex-wrap">
-                <Button variant="success" className="px-3 py-1" onClick={handleViewContracts}>
-                    View my contracts
-                </Button>
-                <Button variant="ghost" className="px-3 py-1" onClick={handleDismiss}>
-                    Dismiss
-                </Button>
+                {latest?.message && (
+                    <p className="text-sm text-gray-300 flex-1">
+                        Latest: {latest.message}
+                    </p>
+                )}
+                <div className="flex gap-2 flex-wrap">
+                    <Button variant="success" className="px-3 py-1" onClick={handleViewContracts}>
+                        View my contracts
+                    </Button>
+                    <Button variant="ghost" className="px-3 py-1" onClick={handleDismiss}>
+                        Dismiss
+                    </Button>
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- prevent the fixed notification banner from intercepting clicks meant for page content
- wrap the popup content in a pointer-events enabled container so users can still interact with the banner buttons

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc2ff7ae888329b4a943acc1281dfb