### PR TITLE
Refine signature capture workflow

### DIFF
--- a/bellingham-frontend/__mocks__/signature_pad.js
+++ b/bellingham-frontend/__mocks__/signature_pad.js
@@ -1,0 +1,22 @@
+class SignaturePad {
+  constructor() {
+    this._empty = false;
+  }
+
+  clear() {
+    this._empty = true;
+  }
+
+  isEmpty() {
+    return this._empty;
+  }
+
+  toDataURL() {
+    this._empty = false;
+    return 'data:image/png;base64,mock-signature';
+  }
+
+  off() {}
+}
+
+export default SignaturePad;

--- a/bellingham-frontend/src/__tests__/Buy.test.jsx
+++ b/bellingham-frontend/src/__tests__/Buy.test.jsx
@@ -7,6 +7,21 @@ import Buy from '../components/Buy';
 import { AuthContext } from '../context';
 import api from '../utils/api';
 
+vi.mock('signature_pad');
+
+const originalGetContext = HTMLCanvasElement.prototype.getContext;
+
+beforeAll(() => {
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+    setTransform: vi.fn(),
+    scale: vi.fn(),
+  }));
+});
+
+afterAll(() => {
+  HTMLCanvasElement.prototype.getContext = originalGetContext;
+});
+
 vi.mock('../utils/api');
 
 const renderWithProviders = (ui) => {


### PR DESCRIPTION
## Summary
- replace the manual canvas drawing logic in `SignatureModal` with `signature_pad`
- add a manual `signature_pad` mock and update tests to work with the new implementation
- stub canvas contexts in tests to prevent jsdom errors

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cd306dd4b48329bcc13e81485ffafa