### PR TITLE
Enhance calendar styling and event markers

### DIFF
--- a/bellingham-frontend/src/components/Calendar.jsx
+++ b/bellingham-frontend/src/components/Calendar.jsx
@@ -1,10 +1,15 @@
 import React, { useEffect, useState, useContext } from "react";
 import Calendar from "react-calendar";
-import 'react-calendar/dist/Calendar.css';
+import "./CalendarOverrides.css";
 import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
 import api from "../utils/api";
 import { AuthContext } from '../context';
+
+const TYPE_INFO = {
+    "Bought": { color: "bg-emerald-400", initial: "B" },
+    "Ends": { color: "bg-amber-400", initial: "E" }
+};
 
 const ContractCalendar = () => {
     const navigate = useNavigate();
@@ -45,7 +50,28 @@ const ContractCalendar = () => {
             const key = date.toISOString().split('T')[0];
             const events = eventsByDate[key];
             if (events && events.length > 0) {
-                return <div className="mt-1 w-2 h-2 bg-blue-500 rounded-full mx-auto"/>;
+                const uniqueTypes = Array.from(new Set(events.map((ev) => ev.type)));
+                return (
+                    <div className="flex justify-center mt-1 space-x-1">
+                        {uniqueTypes.map((type) => (
+                            <span
+                                key={type}
+                                className={`w-2 h-2 rounded-full ${TYPE_INFO[type]?.color ?? "bg-slate-400"}`}
+                                aria-hidden="true"
+                            />
+                        ))}
+                    </div>
+                );
+            }
+        }
+        return null;
+    };
+
+    const tileClassName = ({ date, view }) => {
+        if (view === 'month') {
+            const key = date.toISOString().split('T')[0];
+            if (eventsByDate[key]?.length) {
+                return 'calendar-has-event';
             }
         }
         return null;
@@ -63,22 +89,35 @@ const ContractCalendar = () => {
         <Layout onLogout={handleLogout}>
             <main className="flex-1 p-8 overflow-auto">
                 <h1 className="text-3xl font-bold mb-6">Contract Calendar</h1>
-                    <Calendar
-                        onChange={setSelectedDate}
-                        value={selectedDate}
-                        tileContent={tileContent}
-                    />
-                    <div className="mt-6">
-                        <h2 className="text-xl font-semibold mb-2">Events on {formattedSelected}</h2>
-                        {events.length === 0 && <p>No events.</p>}
-                        <ul className="space-y-1">
-                            {events.map((ev, idx) => (
-                                <li key={idx} className="text-sm">
-                                    {ev.type}: {ev.title}
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
+                <Calendar
+                    onChange={setSelectedDate}
+                    value={selectedDate}
+                    tileContent={tileContent}
+                    tileClassName={tileClassName}
+                />
+                <div className="mt-4 flex items-center space-x-4 text-sm text-gray-300">
+                    {Object.entries(TYPE_INFO).map(([type, info]) => (
+                        <div key={type} className="flex items-center space-x-2">
+                            <span className={`w-3 h-3 rounded-full ${info.color}`} aria-hidden="true" />
+                            <span>{type}</span>
+                        </div>
+                    ))}
+                </div>
+                <div className="mt-6">
+                    <h2 className="text-xl font-semibold mb-2">Events on {formattedSelected}</h2>
+                    {events.length === 0 && <p>No events.</p>}
+                    <ul className="space-y-1">
+                        {events.map((ev, idx) => (
+                            <li key={idx} className="text-sm flex items-center space-x-2">
+                                <span className={`inline-flex items-center justify-center w-5 h-5 rounded-full text-[0.6rem] font-semibold text-gray-900 ${TYPE_INFO[ev.type]?.color ?? 'bg-slate-400'}`}>
+                                    {TYPE_INFO[ev.type]?.initial ?? '?'}
+                                </span>
+                                <span className="text-gray-200">{ev.type}:</span>
+                                <span className="text-gray-100">{ev.title}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
             </main>
         </Layout>
     );

--- a/bellingham-frontend/src/components/CalendarOverrides.css
+++ b/bellingham-frontend/src/components/CalendarOverrides.css
@@ -1,0 +1,79 @@
+.react-calendar {
+  background-color: #111827;
+  color: #f9fafb;
+  border: 1px solid #1f2937;
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+.react-calendar button {
+  color: inherit;
+}
+
+.react-calendar__navigation button {
+  min-height: 2.5rem;
+  color: #e5e7eb;
+}
+
+.react-calendar__navigation button:enabled:hover,
+.react-calendar__navigation button:enabled:focus {
+  background-color: #1f2937;
+}
+
+.react-calendar__month-view__weekdays {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.react-calendar__month-view__days__day {
+  color: #f9fafb;
+}
+
+.react-calendar__tile {
+  background: transparent;
+  border-radius: 0.375rem;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.react-calendar__tile:enabled:hover,
+.react-calendar__tile:enabled:focus {
+  background-color: #1f2937;
+}
+
+.react-calendar__tile--active {
+  background-color: #2563eb;
+  color: #f9fafb;
+}
+
+.react-calendar__tile--active:enabled:hover,
+.react-calendar__tile--active:enabled:focus {
+  background-color: #1d4ed8;
+}
+
+.react-calendar__tile--hasActive {
+  background-color: #1d4ed8;
+  color: #f9fafb;
+}
+
+.react-calendar__tile--now {
+  background: rgba(37, 99, 235, 0.15);
+  border-radius: 0.375rem;
+}
+
+.react-calendar__tile:disabled {
+  background-color: transparent;
+  color: #4b5563;
+}
+
+.react-calendar__month-view__weekdays__weekday {
+  padding: 0.5rem 0;
+}
+
+.calendar-has-event {
+  position: relative;
+}
+
+.calendar-has-event:hover {
+  background-color: #1f2937 !important;
+}

--- a/bellingham-frontend/src/components/SignatureModal.jsx
+++ b/bellingham-frontend/src/components/SignatureModal.jsx
@@ -26,7 +26,7 @@ const SignatureModal = ({ onConfirm, onCancel }) => {
       let context = null;
       try {
         context = canvas.getContext('2d');
-      } catch (err) {
+      } catch {
         context = null;
       }
 


### PR DESCRIPTION
## Summary
- replace the vendor calendar stylesheet with a scoped dark theme override tailored to the app
- add multi-type day markers, a legend, and color-coded badges to reinforce calendar event types
- tidy the signature modal canvas setup to satisfy linting when getContext fails

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd3bf8fec08329bf0a1cfa1a63f705