### PR TITLE
Add bid modal and notification handling to buy flow

### DIFF
--- a/bellingham-frontend/src/components/BidModal.jsx
+++ b/bellingham-frontend/src/components/BidModal.jsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import Button from './ui/Button';
+
+const BidModal = ({ onConfirm, onCancel, initialBid = '' }) => {
+  const [bidAmount, setBidAmount] = useState(initialBid);
+  const [error, setError] = useState('');
+
+  const handleChange = (event) => {
+    setBidAmount(event.target.value);
+    if (error) {
+      setError('');
+    }
+  };
+
+  const handleSubmit = () => {
+    const parsedAmount = Number(bidAmount);
+
+    if (bidAmount === '') {
+      setError('Please enter a bid amount.');
+      return;
+    }
+
+    if (Number.isNaN(parsedAmount)) {
+      setError('Bid amount must be a valid number.');
+      return;
+    }
+
+    if (parsedAmount <= 0) {
+      setError('Bid amount must be greater than zero.');
+      return;
+    }
+
+    onConfirm(parsedAmount);
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="w-full max-w-md rounded bg-white p-6 shadow-md">
+        <h2 className="text-lg font-semibold">Submit a Bid</h2>
+        <label htmlFor="bid-amount" className="mt-4 block text-sm font-medium text-gray-700">
+          Bid Amount
+        </label>
+        <input
+          id="bid-amount"
+          type="number"
+          inputMode="decimal"
+          min="0"
+          step="0.01"
+          value={bidAmount}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          className="mt-1 w-full rounded border border-gray-300 p-2"
+          placeholder="Enter your bid"
+        />
+        {error && (
+          <p className="mt-2 text-sm text-red-600" role="alert">
+            {error}
+          </p>
+        )}
+        <div className="mt-4 flex justify-end gap-2">
+          <Button variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button variant="success" onClick={handleSubmit}>
+            Submit Bid
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BidModal;

--- a/bellingham-frontend/src/components/NotificationBanner.jsx
+++ b/bellingham-frontend/src/components/NotificationBanner.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Button from './ui/Button';
+
+const styles = {
+  info: 'bg-blue-100 text-blue-800 border-blue-300',
+  success: 'bg-green-100 text-green-800 border-green-300',
+  error: 'bg-red-100 text-red-800 border-red-300',
+  warning: 'bg-yellow-100 text-yellow-800 border-yellow-300',
+};
+
+const NotificationBanner = ({ type = 'info', message, onDismiss }) => {
+  if (!message) {
+    return null;
+  }
+
+  const tone = styles[type] || styles.info;
+
+  return (
+    <div className={`mb-4 flex items-center justify-between rounded border px-4 py-3 text-sm ${tone}`}>
+      <span>{message}</span>
+      {onDismiss && (
+        <Button variant="link" onClick={onDismiss} className="text-current">
+          Dismiss
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default NotificationBanner;


### PR DESCRIPTION
## Summary
- add a reusable BidModal for entering validated bid amounts and expose confirm/cancel handlers
- introduce a dismissible NotificationBanner for inline success and error messaging
- update Buy page to use the new modal and banner for bids and purchases, refreshing contract data after actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd3f5882f88329b4354e0106f4f5f9