### PR TITLE
Simplify buy and sell workflows

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -174,7 +174,8 @@ public class ForwardContractController {
     }
 
     @PostMapping("/{id}/buy")
-    public ResponseEntity<ForwardContract> buy(@PathVariable Long id, @RequestBody SignatureRequest signature) {
+    public ResponseEntity<ForwardContract> buy(@PathVariable Long id,
+                                               @RequestBody(required = false) SignatureRequest signature) {
         return repository.findById(id)
                 .map(contract -> {
                     if (!"Available".equalsIgnoreCase(contract.getStatus())) {
@@ -185,7 +186,11 @@ public class ForwardContractController {
                             .getContext().getAuthentication().getName();
                     contract.setBuyerUsername(username);
                     contract.setPurchaseDate(LocalDate.now());
-                    contract.setBuyerSignature(signature.getSignature());
+                    if (signature != null) {
+                        contract.setBuyerSignature(signature.getSignature());
+                    } else {
+                        contract.setBuyerSignature(null);
+                    }
                     ForwardContract saved = repository.save(contract);
                     logActivity(saved, username, "Purchased contract");
 

--- a/bellingham-datafutures/src/test/java/com/bellingham/datafutures/ForwardContractControllerTest.java
+++ b/bellingham-datafutures/src/test/java/com/bellingham/datafutures/ForwardContractControllerTest.java
@@ -60,7 +60,7 @@ class ForwardContractControllerTest {
     }
 
     @Test
-    void buyContractStoresSignature() throws Exception {
+    void buyContractStoresSignatureWhenProvided() throws Exception {
         ForwardContract contract = new ForwardContract();
         contract.setId(1L);
         contract.setStatus("Available");
@@ -78,5 +78,25 @@ class ForwardContractControllerTest {
         org.junit.jupiter.api.Assertions.assertEquals("sig", contract.getBuyerSignature());
         org.mockito.Mockito.verify(notificationService)
                 .notifyUser("seller", "Your contract Test Contract was purchased", 1L);
+    }
+
+    @Test
+    void buyContractWithoutSignatureIsAllowed() throws Exception {
+        ForwardContract contract = new ForwardContract();
+        contract.setId(2L);
+        contract.setStatus("Available");
+        contract.setTitle("Second Contract");
+        contract.setCreatorUsername("seller2");
+        given(repository.findById(2L)).willReturn(java.util.Optional.of(contract));
+        given(repository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken("buyer", "pass"));
+
+        mockMvc.perform(post("/api/contracts/2/buy")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        org.junit.jupiter.api.Assertions.assertNull(contract.getBuyerSignature());
+        org.mockito.Mockito.verify(notificationService)
+                .notifyUser("seller2", "Your contract Second Contract was purchased", 2L);
     }
 }

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -7,8 +7,6 @@ import ContractDetailsPanel from "./ContractDetailsPanel";
 import Layout from "./Layout";
 import Button from "./ui/Button";
 import { useNavigate } from "react-router-dom";
-import SignatureModal from "./SignatureModal";
-import BidModal from "./BidModal";
 import NotificationBanner from "./NotificationBanner";
 
 const Buy = () => {
@@ -46,28 +44,10 @@ const Buy = () => {
         fetchContracts();
     }, [fetchContracts]);
 
-    const [showSignature, setShowSignature] = useState(false);
-    const [pendingBuyId, setPendingBuyId] = useState(null);
-    const [showBidModal, setShowBidModal] = useState(false);
-    const [pendingBidId, setPendingBidId] = useState(null);
-
-    const handleBuy = (contractId) => {
+    const handleBuy = async (contractId) => {
         setNotification(null);
-        setPendingBuyId(contractId);
-        setShowSignature(true);
-    };
-
-    const confirmBuy = async (signature) => {
-        const contractId = pendingBuyId;
-        if (!contractId) {
-            setNotification({ type: "error", message: "We couldn't determine which contract to purchase." });
-            setShowSignature(false);
-            setPendingBuyId(null);
-            return;
-        }
-
         try {
-            const response = await api.post(`/api/contracts/${contractId}/buy`, { signature });
+            const response = await api.post(`/api/contracts/${contractId}/buy`, {});
             const purchased = response?.data;
             setNotification({
                 type: "success",
@@ -85,46 +65,6 @@ const Buy = () => {
                 type: "error",
                 message: status ? `Unable to complete purchase (${status}): ${message}` : message,
             });
-        } finally {
-            setShowSignature(false);
-            setPendingBuyId(null);
-        }
-    };
-
-    const handleBid = (contractId) => {
-        setNotification(null);
-        setPendingBidId(contractId);
-        setShowBidModal(true);
-    };
-
-    const submitBid = async (amount) => {
-        const contractId = pendingBidId;
-
-        if (!contractId) {
-            setNotification({ type: "error", message: "We couldn't determine which contract to bid on." });
-            setShowBidModal(false);
-            setPendingBidId(null);
-            return;
-        }
-
-        try {
-            await api.post(`/api/contracts/${contractId}/bid`, { amount });
-            setNotification({
-                type: "success",
-                message: `Bid of $${amount} submitted successfully.`,
-            });
-            await fetchContracts();
-        } catch (err) {
-            console.error(err);
-            const status = err.response?.status;
-            const message = err.response?.data?.message || err.message || "Failed to submit bid.";
-            setNotification({
-                type: "error",
-                message: status ? `Unable to submit bid (${status}): ${message}` : message,
-            });
-        } finally {
-            setShowBidModal(false);
-            setPendingBidId(null);
         }
     };
 
@@ -229,16 +169,6 @@ const Buy = () => {
                                         >
                                             Buy
                                         </Button>
-                                        <Button
-                                            variant="primary"
-                                            onClick={(e) => {
-                                                e.stopPropagation();
-                                                handleBid(contract.id);
-                                            }}
-                                            className="ml-2 px-2 py-1"
-                                        >
-                                            Bid
-                                        </Button>
                                     </td>
                                 </tr>
                             ))}
@@ -251,18 +181,6 @@ const Buy = () => {
                     />
                 </main>
         </Layout>
-        {showSignature && (
-            <SignatureModal
-                onConfirm={confirmBuy}
-                onCancel={() => setShowSignature(false)}
-            />
-        )}
-        {showBidModal && (
-            <BidModal
-                onConfirm={submitBid}
-                onCancel={() => setShowBidModal(false)}
-            />
-        )}
         </>
     );
 };

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useContext, useCallback } from "react";
-import SignatureModal from "./SignatureModal";
 import Layout from "./Layout";
 import { useNavigate } from "react-router-dom";
 import Button from "./ui/Button";
@@ -84,9 +83,6 @@ const Sell = () => {
         setAgreementModalOpen(false);
     };
 
-    const [showSignature, setShowSignature] = useState(false);
-    const [pendingData, setPendingData] = useState(null);
-
     const handleSubmit = async (e) => {
         e.preventDefault();
         if (currentStep < steps.length - 1) {
@@ -114,23 +110,10 @@ const Sell = () => {
         if (snippet) {
             data.termsFileName = snippet.name;
         }
-        setPendingData(data);
-        setShowSignature(true);
         setMessage("");
-    };
-
-    const submitWithSignature = async (signature) => {
-        if (isSubmitting) return;
-        if (!pendingData) {
-            setMessage("❌ Something went wrong while preparing your contract. Please try again.");
-            setShowSignature(false);
-            return;
-        }
-
         setIsSubmitting(true);
         try {
-            const payload = { ...pendingData, sellerSignature: signature };
-            const response = await api.post(`/api/contracts`, payload);
+            const response = await api.post(`/api/contracts`, data);
             const savedContract = response?.data;
             if (savedContract) {
                 setContracts((prev) => [savedContract, ...prev]);
@@ -171,8 +154,6 @@ const Sell = () => {
             );
         } finally {
             setIsSubmitting(false);
-            setShowSignature(false);
-            setPendingData(null);
         }
     };
 
@@ -454,12 +435,6 @@ const Sell = () => {
                 initialValue={form.agreementText}
                 onSave={handleAgreementSave}
                 onCancel={handleAgreementCancel}
-            />
-        )}
-        {showSignature && (
-            <SignatureModal
-                onConfirm={submitWithSignature}
-                onCancel={() => setShowSignature(false)}
             />
         )}
         </>


### PR DESCRIPTION
## Summary
- make the purchase endpoint accept optional signatures while continuing to notify sellers
- update contract controller tests to cover purchases with and without a signature
- simplify the Buy page to a single-click purchase flow and remove the bid modal
- submit new contracts directly from the Sell form so listings appear immediately

## Testing
- npm run build
- ./mvnw test *(fails: unable to download parent POM because the Maven Central network endpoint is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd433bb9ac8329b6ccae54fca0df1f