### PR TITLE
Restore navigation links in header

### DIFF
--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -1,20 +1,41 @@
 import React, { useContext } from "react";
-import { Link } from "react-router-dom";
+import { Link, NavLink } from "react-router-dom";
 
 import logoImage from "../assets/login.png";
 import { AuthContext } from '../context';
+import navItems from "../config/navItems";
 
 const Header = () => {
     const { username } = useContext(AuthContext);
 
     return (
-        <header className="bg-gray-800 p-4 flex justify-between items-center border-b border-gray-700">
-            <div className="flex items-center gap-4">
+        <header className="bg-gray-800 p-4 flex flex-col gap-4 border-b border-gray-700 md:flex-row md:items-center md:justify-between">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:gap-6">
                 <img
                     src={logoImage}
                     alt="Bellingham Data Futures logo"
-                    className="h-[150px] w-[150px]"
+                    className="h-[120px] w-[120px] md:h-[150px] md:w-[150px]"
                 />
+                {username && (
+                    <nav className="flex flex-wrap gap-2 text-sm">
+                        {navItems.map(({ path, label }) => (
+                            <NavLink
+                                key={path}
+                                to={path}
+                                end={path === "/"}
+                                className={({ isActive }) =>
+                                    `rounded px-3 py-1 font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800 ${
+                                        isActive
+                                            ? "bg-green-600 text-white"
+                                            : "text-gray-200 hover:bg-gray-700"
+                                    }`
+                                }
+                            >
+                                {label}
+                            </NavLink>
+                        ))}
+                    </nav>
+                )}
             </div>
             {username && (
                 <div className="flex items-center gap-3 text-white text-sm">


### PR DESCRIPTION
## Summary
- add horizontal navigation links to the authenticated header so navigation is always available
- adjust header layout and logo sizing to accommodate the inline navigation menu

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cd54dc05848329aef15db15393a579