### PR TITLE
Enhance header navigation with icons and styling

### DIFF
--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -1,37 +1,44 @@
 import React, { useContext } from "react";
 import { Link, NavLink } from "react-router-dom";
+import { BellAlertIcon } from "@heroicons/react/24/outline";
 
 import logoImage from "../assets/login.png";
-import { AuthContext } from '../context';
+import { AuthContext } from "../context";
 import navItems from "../config/navItems";
 
 const Header = () => {
     const { username } = useContext(AuthContext);
 
     return (
-        <header className="bg-gray-800 p-4 flex flex-col gap-4 border-b border-gray-700 md:flex-row md:items-center md:justify-between">
+        <header className="bg-gradient-to-r from-gray-900 via-gray-800 to-gray-900 px-6 py-4 flex flex-col gap-4 border-b border-gray-800/80 shadow-lg shadow-black/30 md:flex-row md:items-center md:justify-between">
             <div className="flex flex-col gap-4 md:flex-row md:items-center md:gap-6">
                 <img
                     src={logoImage}
                     alt="Bellingham Data Futures logo"
-                    className="h-[120px] w-[120px] md:h-[150px] md:w-[150px]"
+                    className="h-[100px] w-[100px] rounded-xl border border-white/10 bg-white/5 p-2 shadow-inner shadow-black/40 backdrop-blur-sm md:h-[130px] md:w-[130px]"
                 />
                 {username && (
-                    <nav className="flex flex-wrap gap-2 text-sm">
-                        {navItems.map(({ path, label }) => (
+                    <nav className="flex flex-wrap gap-2 rounded-2xl border border-white/5 bg-white/5 px-2 py-2 shadow-inner shadow-black/30 backdrop-blur">
+                        {navItems.map(({ path, label, icon: Icon }) => (
                             <NavLink
                                 key={path}
                                 to={path}
                                 end={path === "/"}
                                 className={({ isActive }) =>
-                                    `rounded px-3 py-1 font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800 ${
+                                    `group flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-400/80 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 ${
                                         isActive
-                                            ? "bg-green-600 text-white"
-                                            : "text-gray-200 hover:bg-gray-700"
+                                            ? "bg-green-500 text-white shadow-lg shadow-green-500/30"
+                                            : "text-gray-200 hover:bg-gray-800/80 hover:text-white"
                                     }`
                                 }
                             >
-                                {label}
+                                {Icon && (
+                                    <Icon
+                                        aria-hidden="true"
+                                        className="h-5 w-5 text-white/80 transition-transform duration-200 group-hover:scale-110"
+                                    />
+                                )}
+                                <span>{label}</span>
                             </NavLink>
                         ))}
                     </nav>
@@ -41,11 +48,14 @@ const Header = () => {
                 <div className="flex items-center gap-3 text-white text-sm">
                     <Link
                         to="/notifications"
-                        className="rounded bg-green-600 px-3 py-1 font-semibold text-white transition-colors hover:bg-green-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800"
+                        className="flex items-center gap-2 rounded-full border border-green-500/60 bg-green-500/90 px-4 py-2 font-semibold text-white shadow-lg shadow-green-500/30 transition-colors hover:bg-green-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-300 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
                     >
+                        <BellAlertIcon aria-hidden="true" className="h-5 w-5" />
                         Notifications
                     </Link>
-                    <span>Logged in as: {username}</span>
+                    <span className="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs uppercase tracking-wider text-gray-200 shadow-inner shadow-black/30">
+                        Logged in as: <strong className="text-white">{username}</strong>
+                    </span>
                 </div>
             )}
         </header>

--- a/bellingham-frontend/src/config/navItems.js
+++ b/bellingham-frontend/src/config/navItems.js
@@ -1,13 +1,25 @@
+import {
+    CalendarDaysIcon,
+    ChartBarIcon,
+    ClockIcon,
+    Cog6ToothIcon,
+    CurrencyDollarIcon,
+    DocumentMagnifyingGlassIcon,
+    HomeIcon,
+    ShoppingCartIcon,
+    UserCircleIcon,
+} from "@heroicons/react/24/outline";
+
 const navItems = [
-    { path: "/", label: "Home", section: "Overview" },
-    { path: "/buy", label: "Buy", section: "Buyer" },
-    { path: "/reports", label: "Reports", section: "Buyer" },
-    { path: "/sell", label: "Sell", section: "Seller" },
-    { path: "/sales", label: "Sales", section: "Seller" },
-    { path: "/calendar", label: "Calendar", section: "Operations" },
-    { path: "/history", label: "History", section: "Operations" },
-    { path: "/settings", label: "Settings", section: "Account" },
-    { path: "/account", label: "Account", section: "Account" },
+    { path: "/", label: "Home", section: "Overview", icon: HomeIcon },
+    { path: "/buy", label: "Buy", section: "Buyer", icon: ShoppingCartIcon },
+    { path: "/reports", label: "Reports", section: "Buyer", icon: DocumentMagnifyingGlassIcon },
+    { path: "/sell", label: "Sell", section: "Seller", icon: CurrencyDollarIcon },
+    { path: "/sales", label: "Sales", section: "Seller", icon: ChartBarIcon },
+    { path: "/calendar", label: "Calendar", section: "Operations", icon: CalendarDaysIcon },
+    { path: "/history", label: "History", section: "Operations", icon: ClockIcon },
+    { path: "/settings", label: "Settings", section: "Account", icon: Cog6ToothIcon },
+    { path: "/account", label: "Account", section: "Account", icon: UserCircleIcon },
 ];
 
 export default navItems;


### PR DESCRIPTION
## Summary
- refresh the top navigation bar styling with a gradient background and refined spacing
- render heroicon-based icons alongside each navigation item to improve scannability
- enhance the notifications button and user badge for a more polished header experience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd5b2c8b088329b4804b07b77036e8