### PR TITLE
Refine navigation menus for clarity and consistency

### DIFF
--- a/bellingham-frontend/src/__tests__/Sidebar.test.jsx
+++ b/bellingham-frontend/src/__tests__/Sidebar.test.jsx
@@ -12,7 +12,7 @@ test('renders navigation links from configuration', () => {
     );
     navItems.forEach((item) => {
         const matches = screen.getAllByText(item.label);
-        expect(matches.some((match) => match.getAttribute('href') === item.path)).toBe(true);
+        expect(matches.some((match) => match.closest('a')?.getAttribute('href') === item.path)).toBe(true);
     });
 });
 
@@ -37,8 +37,8 @@ test('highlights the active link', () => {
             <Sidebar />
         </MemoryRouter>
     );
-    expect(screen.getByText('Sell')).toHaveClass('bg-gray-700');
-    expect(screen.getByText('Home')).not.toHaveClass('bg-gray-700');
+    expect(screen.getByRole('link', { name: 'Sell' })).toHaveClass('bg-slate-800');
+    expect(screen.getByRole('link', { name: 'Home' })).not.toHaveClass('bg-slate-800');
 });
 
 test('shows contextual action button', () => {

--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -1,63 +1,47 @@
 import React, { useContext } from "react";
-import { Link, NavLink } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { BellAlertIcon } from "@heroicons/react/24/outline";
 
 import logoImage from "../assets/login.png";
 import { AuthContext } from "../context";
 import navItems from "../config/navItems";
+import NavMenuItem from "./ui/NavMenuItem";
 
 const Header = () => {
     const { username } = useContext(AuthContext);
 
     return (
-        <header className="bg-gradient-to-r from-gray-900 via-gray-800 to-gray-900 px-6 py-4 flex flex-col gap-4 border-b border-gray-800/80 shadow-lg shadow-black/30 md:flex-row md:items-center md:justify-between">
-            <div className="flex flex-col gap-4 md:flex-row md:items-center md:gap-6">
-                <img
-                    src={logoImage}
-                    alt="Bellingham Data Futures logo"
-                    className="h-[100px] w-[100px] rounded-xl border border-white/10 bg-white/5 p-2 shadow-inner shadow-black/40 backdrop-blur-sm md:h-[130px] md:w-[130px]"
-                />
+        <header className="bg-slate-950/90 px-6 py-4 backdrop-blur border-b border-slate-800 shadow-sm">
+            <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div className="flex flex-col gap-4 md:flex-row md:items-center md:gap-6">
+                    <img
+                        src={logoImage}
+                        alt="Bellingham Data Futures logo"
+                        className="h-[72px] w-[72px] rounded-xl border border-white/10 bg-white/10 p-2 shadow-inner shadow-black/30 md:h-[90px] md:w-[90px]"
+                    />
+                    {username && (
+                        <nav className="flex flex-wrap gap-2 rounded-2xl border border-white/10 bg-white/5 px-3 py-3 shadow-inner shadow-black/20">
+                            {navItems.map((item) => (
+                                <NavMenuItem key={item.path} item={item} layout="header" />
+                            ))}
+                        </nav>
+                    )}
+                </div>
                 {username && (
-                    <nav className="flex flex-wrap gap-2 rounded-2xl border border-white/5 bg-white/5 px-2 py-2 shadow-inner shadow-black/30 backdrop-blur">
-                        {navItems.map(({ path, label, icon: Icon }) => (
-                            <NavLink
-                                key={path}
-                                to={path}
-                                end={path === "/"}
-                                className={({ isActive }) =>
-                                    `group flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-400/80 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 ${
-                                        isActive
-                                            ? "bg-green-500 text-white shadow-lg shadow-green-500/30"
-                                            : "text-gray-200 hover:bg-gray-800/80 hover:text-white"
-                                    }`
-                                }
-                            >
-                                {Icon && (
-                                    <Icon
-                                        aria-hidden="true"
-                                        className="h-5 w-5 text-white/80 transition-transform duration-200 group-hover:scale-110"
-                                    />
-                                )}
-                                <span>{label}</span>
-                            </NavLink>
-                        ))}
-                    </nav>
+                    <div className="flex items-center gap-3 text-white text-sm">
+                        <Link
+                            to="/notifications"
+                            className="flex items-center gap-2 rounded-full border border-emerald-500/60 bg-emerald-500/90 px-4 py-2 font-semibold text-white shadow-lg shadow-emerald-500/25 transition-colors hover:bg-emerald-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                        >
+                            <BellAlertIcon aria-hidden="true" className="h-5 w-5" />
+                            Notifications
+                        </Link>
+                        <span className="rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-wider text-slate-100 shadow-inner shadow-black/20">
+                            Logged in as: <strong className="text-white">{username}</strong>
+                        </span>
+                    </div>
                 )}
             </div>
-            {username && (
-                <div className="flex items-center gap-3 text-white text-sm">
-                    <Link
-                        to="/notifications"
-                        className="flex items-center gap-2 rounded-full border border-green-500/60 bg-green-500/90 px-4 py-2 font-semibold text-white shadow-lg shadow-green-500/30 transition-colors hover:bg-green-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-300 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
-                    >
-                        <BellAlertIcon aria-hidden="true" className="h-5 w-5" />
-                        Notifications
-                    </Link>
-                    <span className="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs uppercase tracking-wider text-gray-200 shadow-inner shadow-black/30">
-                        Logged in as: <strong className="text-white">{username}</strong>
-                    </span>
-                </div>
-            )}
         </header>
     );
 };

--- a/bellingham-frontend/src/components/Sidebar.jsx
+++ b/bellingham-frontend/src/components/Sidebar.jsx
@@ -1,7 +1,8 @@
 import React, { useMemo, useState } from "react";
-import { NavLink, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import Button from "./ui/Button";
 import navItems from "../config/navItems";
+import NavMenuItem from "./ui/NavMenuItem";
 
 const Sidebar = ({ onLogout }) => {
     const navigate = useNavigate();
@@ -30,25 +31,16 @@ const Sidebar = ({ onLogout }) => {
     };
 
     return (
-        <div className="relative md:w-64 flex-shrink-0">
+        <div className="relative flex-shrink-0 md:w-64">
             <button
                 type="button"
                 onClick={toggleMobile}
-                className="md:hidden fixed top-24 left-4 z-50 inline-flex items-center justify-center p-2 rounded-md bg-gray-900 text-white shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-green-500"
+                className="md:hidden fixed top-20 left-4 z-50 inline-flex items-center justify-center rounded-full bg-slate-900 p-3 text-white shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-950 focus:ring-emerald-400"
                 aria-label={isMobileOpen ? "Close navigation" : "Open navigation"}
                 aria-expanded={isMobileOpen}
             >
-                <span className="sr-only">
-                    {isMobileOpen ? "Close navigation" : "Open navigation"}
-                </span>
-                <svg
-                    className="h-6 w-6"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    aria-hidden="true"
-                >
+                <span className="sr-only">{isMobileOpen ? "Close navigation" : "Open navigation"}</span>
+                <svg className="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                     {isMobileOpen ? (
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
                     ) : (
@@ -58,47 +50,41 @@ const Sidebar = ({ onLogout }) => {
             </button>
 
             {isMobileOpen && (
-                <div
-                    className="md:hidden fixed inset-0 bg-black/50 z-40"
-                    role="presentation"
-                    onClick={closeMobile}
-                />
+                <div className="fixed inset-0 z-40 bg-black/50 md:hidden" role="presentation" onClick={closeMobile} />
             )}
 
             <aside
-                className={`fixed inset-y-0 left-0 z-40 w-64 transform bg-gray-900 p-6 flex flex-col justify-between border-r border-gray-700 transition-transform duration-300 ease-in-out md:static md:translate-x-0 md:transform-none md:w-64 ${
+                className={`fixed inset-y-0 left-0 z-50 flex w-64 transform flex-col justify-between border-r border-slate-800 bg-slate-950/95 p-6 shadow-xl shadow-black/20 backdrop-blur transition-transform duration-300 ease-in-out md:static md:z-auto md:translate-x-0 md:transform-none md:w-64 ${
                     isMobileOpen ? "translate-x-0" : "-translate-x-full"
                 }`}
             >
-                <nav className="flex flex-col space-y-6 overflow-y-auto">
-                    {Array.from(groupedNavItems.entries()).map(([section, items], index) => (
-                        <div key={section} className="flex flex-col space-y-2">
-                            <p
-                                className={`px-4 text-xs font-semibold uppercase tracking-wide text-gray-400 ${
-                                    index === 0 ? "" : "mt-2"
-                                }`}
-                            >
-                                {section}
-                            </p>
-                            {items.map(({ path, label }) => (
-                                <NavLink
-                                    key={path}
-                                    to={path}
-                                    end={path === "/"}
-                                    onClick={closeMobile}
-                                    className={({ isActive }) =>
-                                        `block text-left px-4 py-2 rounded text-white transition-colors duration-150 hover:bg-green-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 ${
-                                            isActive ? "bg-gray-700" : "bg-transparent"
-                                        }`
-                                    }
-                                >
-                                    {label}
-                                </NavLink>
-                            ))}
+                <div className="flex items-center justify-between pb-4 md:hidden">
+                    <h2 className="text-base font-semibold text-white">Navigation</h2>
+                    <button
+                        type="button"
+                        onClick={closeMobile}
+                        className="inline-flex items-center justify-center rounded-full bg-slate-800 p-2 text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+                    >
+                        <span className="sr-only">Close navigation</span>
+                        <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
+
+                <nav className="flex flex-1 flex-col gap-6 overflow-y-auto pr-2">
+                    {Array.from(groupedNavItems.entries()).map(([section, items]) => (
+                        <div key={section} className="flex flex-col gap-2">
+                            <p className="px-1 text-xs font-semibold uppercase tracking-widest text-slate-400/90">{section}</p>
+                            <div className="flex flex-col gap-1">
+                                {items.map((item) => (
+                                    <NavMenuItem key={item.path} item={item} layout="sidebar" onNavigate={handleNavigate} />
+                                ))}
+                            </div>
                         </div>
                     ))}
                 </nav>
-                <div className="mt-6 flex flex-col space-y-2">
+                <div className="mt-6 flex flex-col space-y-2 border-t border-slate-800 pt-4">
                     <Button
                         variant="success"
                         className="w-full"

--- a/bellingham-frontend/src/components/ui/NavMenuItem.jsx
+++ b/bellingham-frontend/src/components/ui/NavMenuItem.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+
+const baseClasses = {
+    header: "group inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900",
+    sidebar: "group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900",
+};
+
+const activeClasses = {
+    header: "bg-emerald-500 text-white shadow-lg shadow-emerald-500/25",
+    sidebar: "bg-slate-800 text-white",
+};
+
+const inactiveClasses = {
+    header: "text-slate-200 hover:bg-slate-700/70 hover:text-white",
+    sidebar: "text-slate-200 hover:bg-slate-800/70",
+};
+
+const iconClasses = {
+    header: "h-5 w-5 text-white/90 transition-transform duration-200 group-hover:scale-110",
+    sidebar: "h-5 w-5 text-emerald-300",
+};
+
+const NavMenuItem = ({ item, layout = "header", onNavigate }) => {
+    const { path, label, icon: Icon } = item;
+
+    return (
+        <NavLink
+            key={path}
+            to={path}
+            end={path === "/"}
+            onClick={() => onNavigate?.(path)}
+            className={({ isActive }) =>
+                `${baseClasses[layout]} ${isActive ? activeClasses[layout] : inactiveClasses[layout]}`
+            }
+        >
+            {Icon && <Icon aria-hidden="true" className={iconClasses[layout]} />}
+            <span>{label}</span>
+        </NavLink>
+    );
+};
+
+export default NavMenuItem;


### PR DESCRIPTION
## Summary
- simplify the header layout and reuse a shared navigation item component for consistent icon usage
- restyle the sidebar with clearer section hierarchy, icons, and improved mobile drawer controls
- add a NavMenuItem utility component and align tests with the updated styling

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd5df807108329979bd0a1434db3a2