### PR TITLE
Restyle header navigation to match dashboard design

### DIFF
--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -1,5 +1,5 @@
-import React, { useContext } from "react";
-import { Link } from "react-router-dom";
+import React, { useContext, useMemo } from "react";
+import { Link, useLocation } from "react-router-dom";
 import { BellAlertIcon } from "@heroicons/react/24/outline";
 
 import logoImage from "../assets/login.png";
@@ -9,37 +9,93 @@ import NavMenuItem from "./ui/NavMenuItem";
 
 const Header = () => {
     const { username } = useContext(AuthContext);
+    const location = useLocation();
+
+    const groupedNavItems = useMemo(() => {
+        return navItems.reduce((acc, item) => {
+            if (!acc[item.section]) {
+                acc[item.section] = [];
+            }
+            acc[item.section].push(item);
+            return acc;
+        }, {});
+    }, []);
+
+    const activeItem = useMemo(() => {
+        const currentPath = location.pathname;
+        const matched = navItems.find((item) =>
+            item.path === "/" ? currentPath === "/" : currentPath.startsWith(item.path),
+        );
+        return matched ?? navItems[0];
+    }, [location.pathname]);
 
     return (
-        <header className="bg-slate-950/90 px-6 py-4 backdrop-blur border-b border-slate-800 shadow-sm">
-            <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 md:flex-row md:items-center md:justify-between">
-                <div className="flex flex-col gap-4 md:flex-row md:items-center md:gap-6">
-                    <img
-                        src={logoImage}
-                        alt="Bellingham Data Futures logo"
-                        className="h-[72px] w-[72px] rounded-xl border border-white/10 bg-white/10 p-2 shadow-inner shadow-black/30 md:h-[90px] md:w-[90px]"
-                    />
+        <header className="relative z-20 border-b border-slate-800/80 bg-[#0b1120]/95 px-6 py-5 shadow-[0_20px_45px_rgba(3,10,24,0.65)] backdrop-blur">
+            <div className="mx-auto flex w-full max-w-6xl flex-col gap-5">
+                <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div className="flex items-center gap-5">
+                        <div className="relative">
+                            <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-emerald-500/30 via-sky-500/20 to-indigo-500/20 blur-lg opacity-80" />
+                            <div className="relative rounded-2xl border border-white/10 bg-white/5 p-3 shadow-[0_10px_30px_rgba(2,8,23,0.6)]">
+                                <img
+                                    src={logoImage}
+                                    alt="Bellingham Data Futures logo"
+                                    className="h-[68px] w-[68px] rounded-xl border border-white/10 bg-slate-900/80 p-2 shadow-inner shadow-black/40 md:h-[82px] md:w-[82px]"
+                                />
+                            </div>
+                        </div>
+                        <div className="space-y-1">
+                            <p className="text-[11px] uppercase tracking-[0.45em] text-slate-400/80">Active Module</p>
+                            <div className="flex flex-wrap items-baseline gap-3">
+                                <h1 className="text-2xl font-semibold text-white drop-shadow">{activeItem?.label ?? "Overview"}</h1>
+                                {activeItem?.section && (
+                                    <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200/90">
+                                        {activeItem.section}
+                                    </span>
+                                )}
+                            </div>
+                        </div>
+                    </div>
                     {username && (
-                        <nav className="flex flex-wrap gap-2 rounded-2xl border border-white/10 bg-white/5 px-3 py-3 shadow-inner shadow-black/20">
-                            {navItems.map((item) => (
-                                <NavMenuItem key={item.path} item={item} layout="header" />
-                            ))}
-                        </nav>
+                        <div className="flex items-center gap-4 text-white text-sm">
+                            <Link
+                                to="/notifications"
+                                className="group relative inline-flex items-center gap-2 overflow-hidden rounded-2xl border border-emerald-500/40 bg-gradient-to-r from-emerald-500/80 via-cyan-500/80 to-sky-500/80 px-5 py-2 font-semibold text-white shadow-[0_15px_40px_rgba(14,165,233,0.35)] transition-transform duration-300 hover:scale-[1.02] focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0b1120]"
+                            >
+                                <span className="absolute inset-0 -z-10 bg-gradient-to-r from-emerald-400/40 via-cyan-400/30 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+                                <BellAlertIcon aria-hidden="true" className="h-5 w-5" />
+                                Notifications
+                            </Link>
+                            <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-right shadow-[0_12px_30px_rgba(2,10,26,0.45)]">
+                                <span className="block text-[10px] font-semibold uppercase tracking-[0.4em] text-slate-400/80">
+                                    User
+                                </span>
+                                <span className="text-sm font-semibold text-white">{username}</span>
+                            </div>
+                        </div>
                     )}
                 </div>
                 {username && (
-                    <div className="flex items-center gap-3 text-white text-sm">
-                        <Link
-                            to="/notifications"
-                            className="flex items-center gap-2 rounded-full border border-emerald-500/60 bg-emerald-500/90 px-4 py-2 font-semibold text-white shadow-lg shadow-emerald-500/25 transition-colors hover:bg-emerald-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
-                        >
-                            <BellAlertIcon aria-hidden="true" className="h-5 w-5" />
-                            Notifications
-                        </Link>
-                        <span className="rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-wider text-slate-100 shadow-inner shadow-black/20">
-                            Logged in as: <strong className="text-white">{username}</strong>
-                        </span>
-                    </div>
+                    <nav className="flex flex-wrap items-center gap-4 rounded-3xl border border-slate-800/80 bg-gradient-to-br from-[#101b32]/95 via-[#0d1628]/90 to-[#0b1224]/90 p-4 shadow-[0_18px_40px_rgba(3,16,36,0.65)]">
+                        {Object.entries(groupedNavItems).map(([section, items]) => (
+                            <div
+                                key={section}
+                                className="flex flex-wrap items-center gap-3 border-slate-800/70 pb-1 last:border-none last:pb-0 md:border-r md:pb-0 md:pr-6 last:md:border-r-0 last:md:pr-0"
+                            >
+                                <div className="flex flex-col justify-center">
+                                    <span className="text-[10px] uppercase tracking-[0.4em] text-slate-500/70">Section</span>
+                                    <span className="text-xs font-semibold uppercase tracking-[0.35em] text-slate-200">
+                                        {section}
+                                    </span>
+                                </div>
+                                <div className="flex flex-wrap items-center gap-2">
+                                    {items.map((item) => (
+                                        <NavMenuItem key={item.path} item={item} layout="header" />
+                                    ))}
+                                </div>
+                            </div>
+                        ))}
+                    </nav>
                 )}
             </div>
         </header>

--- a/bellingham-frontend/src/components/ui/NavMenuItem.jsx
+++ b/bellingham-frontend/src/components/ui/NavMenuItem.jsx
@@ -2,23 +2,35 @@ import React from "react";
 import { NavLink } from "react-router-dom";
 
 const baseClasses = {
-    header: "group inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900",
-    sidebar: "group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900",
+    header:
+        "group relative inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 focus-visible:ring-offset-0",
+    sidebar:
+        "group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900",
 };
 
 const activeClasses = {
-    header: "bg-emerald-500 text-white shadow-lg shadow-emerald-500/25",
+    header:
+        "border-transparent bg-gradient-to-br from-emerald-400 via-cyan-500 to-indigo-500 text-white shadow-[0_12px_28px_rgba(12,142,227,0.45)]",
     sidebar: "bg-slate-800 text-white",
 };
 
 const inactiveClasses = {
-    header: "text-slate-200 hover:bg-slate-700/70 hover:text-white",
+    header:
+        "border-slate-700/60 bg-slate-900/40 text-slate-300/80 hover:border-slate-500/70 hover:text-white hover:shadow-[0_10px_22px_rgba(16,185,129,0.35)]",
     sidebar: "text-slate-200 hover:bg-slate-800/70",
 };
 
 const iconClasses = {
-    header: "h-5 w-5 text-white/90 transition-transform duration-200 group-hover:scale-110",
-    sidebar: "h-5 w-5 text-emerald-300",
+    header: {
+        base: "h-4 w-4 transition-transform duration-300",
+        active: "text-white",
+        inactive: "text-emerald-200",
+    },
+    sidebar: {
+        base: "h-5 w-5 text-emerald-300",
+        active: "",
+        inactive: "",
+    },
 };
 
 const NavMenuItem = ({ item, layout = "header", onNavigate }) => {
@@ -34,8 +46,17 @@ const NavMenuItem = ({ item, layout = "header", onNavigate }) => {
                 `${baseClasses[layout]} ${isActive ? activeClasses[layout] : inactiveClasses[layout]}`
             }
         >
-            {Icon && <Icon aria-hidden="true" className={iconClasses[layout]} />}
-            <span>{label}</span>
+            {({ isActive }) => (
+                <>
+                    {Icon && (
+                        <Icon
+                            aria-hidden="true"
+                            className={`${iconClasses[layout].base} ${isActive ? iconClasses[layout].active : iconClasses[layout].inactive}`}
+                        />
+                    )}
+                    <span>{label}</span>
+                </>
+            )}
         </NavLink>
     );
 };


### PR DESCRIPTION
## Summary
- redesign the dashboard header with grouped sections, gradients, and active module display inspired by the provided reference styling
- enhance header navigation pills with neon gradients, hover states, and icon color transitions to reinforce the new aesthetic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce64367fa48329a6e6d4bfe9135070