### PR TITLE
Reduce logo size across the app

### DIFF
--- a/bellingham-frontend/src/components/Logo.jsx
+++ b/bellingham-frontend/src/components/Logo.jsx
@@ -4,7 +4,7 @@ import logoImage from "../assets/login.png";
 const Logo = () => {
     const isLogin = window.location.pathname === "/login";
     const style = isLogin ? { right: "calc(1rem + 10px)" } : {};
-    const sizeClass = isLogin ? "w-[300px] h-[300px]" : "w-[360px] h-[360px]";
+    const sizeClass = isLogin ? "w-[180px] h-[180px]" : "w-[220px] h-[220px]";
 
     return (
         <img


### PR DESCRIPTION
## Summary
- shrink the floating logo dimensions on login and authenticated pages to free up screen space

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce675ae7d88329bef1464f970b82e3