### PR TITLE
Require configured admin bootstrap password

### DIFF
--- a/bellingham-datafutures/README.md
+++ b/bellingham-datafutures/README.md
@@ -60,6 +60,13 @@ spring.datasource.password=bdf_pass
 The following environment variables can be used to configure the runtime:
 
 - `server.port` – optional port the API listens on. Defaults to `8080`.
+- `APP_ADMIN_PASSWORD` – **required** bootstrap credential used to create
+  or update the initial administrative account. The value must be at
+  least 12 characters and should be unique per deployment. The
+  application refuses to start if this value is missing or a common
+  default (`admin`, `password`, `changeme`). Operators can alternately
+  provide the same value via the Spring property
+  `app.bootstrap.admin-password`.
 
 Start the service with the Maven wrapper:
 

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/DefaultAdminSetup.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/DefaultAdminSetup.java
@@ -5,31 +5,60 @@ import com.bellingham.datafutures.repository.UserRepository;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.util.StringUtils;
 
 @Configuration
 public class DefaultAdminSetup {
 
+    private static final String ADMIN_USERNAME = "admin";
+    private static final int MIN_PASSWORD_LENGTH = 12;
+
     @Bean
-    public ApplicationRunner ensureDefaultAdmin(UserRepository users, PasswordEncoder encoder) {
+    public ApplicationRunner ensureDefaultAdmin(UserRepository users, PasswordEncoder encoder, Environment environment) {
         return args -> {
-            users.findByUsername("admin").ifPresentOrElse(user -> {
-                // If admin exists but password is not encoded, update it
-                if (!user.getPassword().startsWith("$2")) {
-                    user.setPassword(encoder.encode("admin"));
+            String bootstrapPassword = resolveBootstrapPassword(environment);
+
+            users.findByUsername(ADMIN_USERNAME).ifPresentOrElse(user -> {
+                if (!encoder.matches(bootstrapPassword, user.getPassword())) {
+                    user.setPassword(encoder.encode(bootstrapPassword));
                     users.save(user);
-                    System.out.println("🔑 Updated admin password hash");
+                    System.out.println("🔐 Admin password synchronized with bootstrap configuration");
                 } else {
-                    System.out.println("ℹ️ Admin user already present");
+                    System.out.println("ℹ️ Admin password already matches bootstrap configuration");
                 }
             }, () -> {
                 User user = new User();
-                user.setUsername("admin");
-                user.setPassword(encoder.encode("admin"));
+                user.setUsername(ADMIN_USERNAME);
+                user.setPassword(encoder.encode(bootstrapPassword));
                 user.setRole("ROLE_USER");
                 users.save(user);
-                System.out.println("✅ Default admin user created");
+                System.out.println("✅ Bootstrap admin user created");
             });
         };
+    }
+
+    private String resolveBootstrapPassword(Environment environment) {
+        String password = environment.getProperty("app.bootstrap.admin-password");
+        if (!StringUtils.hasText(password)) {
+            password = environment.getProperty("APP_ADMIN_PASSWORD");
+        }
+
+        if (!StringUtils.hasText(password)) {
+            throw new IllegalStateException("APP_ADMIN_PASSWORD (or app.bootstrap.admin-password) must be set to a strong, non-default value before startup");
+        }
+
+        password = password.trim();
+
+        if (password.length() < MIN_PASSWORD_LENGTH) {
+            throw new IllegalStateException("Bootstrap admin password must be at least " + MIN_PASSWORD_LENGTH + " characters");
+        }
+
+        if ("admin".equalsIgnoreCase(password) || "password".equalsIgnoreCase(password) || "changeme".equalsIgnoreCase(password)) {
+            throw new IllegalStateException("Bootstrap admin password cannot use a default or insecure value");
+        }
+
+        return password;
     }
 }

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
@@ -52,19 +52,6 @@ public class AuthController {
         }
     }
 
-    @PostMapping("/register-default")
-    public String registerDefaultUser() {
-        if (userRepository.findByUsername("admin").isPresent()) {
-            return "Admin already exists";
-        }
-        User user = new User();
-        user.setUsername("admin");
-        user.setPassword(encoder.encode("admin")); // bcrypt
-        user.setRole("ROLE_USER");
-        userRepository.save(user);
-        return "✅ Default user created";
-    }
-
     @PostMapping("/register")
     public String registerUser(@RequestBody Map<String, String> creds) {
         String username = creds.get("username");

--- a/bellingham-datafutures/src/main/resources/application.properties
+++ b/bellingham-datafutures/src/main/resources/application.properties
@@ -8,3 +8,9 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
+# === Bootstrap Admin Credential ===
+# Provide a strong password via environment variable APP_ADMIN_PASSWORD
+# or uncomment and set the property below. The application will refuse to
+# start if no password is supplied.
+# app.bootstrap.admin-password=
+

--- a/bellingham-datafutures/src/test/java/com/bellingham/datafutures/BellinghamApplicationTests.java
+++ b/bellingham-datafutures/src/test/java/com/bellingham/datafutures/BellinghamApplicationTests.java
@@ -2,8 +2,10 @@ package com.bellingham.datafutures;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class BellinghamApplicationTests {
 
     @Test

--- a/bellingham-datafutures/src/test/resources/application-test.properties
+++ b/bellingham-datafutures/src/test/resources/application-test.properties
@@ -5,3 +5,4 @@ spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 logging.level.org.springframework=warn
+app.bootstrap.admin-password=test-password-123


### PR DESCRIPTION
## Summary
- replace the default admin/admin seeding with an environment-driven bootstrap that validates a strong password before the application starts
- remove the register-default admin endpoint and document the new APP_ADMIN_PASSWORD requirement for operators
- update configuration and test resources to surface the bootstrap password requirement in local development and automated tests

## Testing
- `./mvnw test -Dspring.profiles.active=test` *(fails: Maven cannot reach repo.maven.apache.org in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d10eea80a08329a33841516a42eee2