### PR TITLE
Configure explicit CORS origins

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/CorsConfig.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/CorsConfig.java
@@ -1,25 +1,42 @@
 package com.bellingham.datafutures.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.web.servlet.config.annotation.CorsRegistration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@EnableConfigurationProperties(CorsProperties.class)
 public class CorsConfig {
+
+    private final CorsProperties corsProperties;
+
+    public CorsConfig(CorsProperties corsProperties) {
+        this.corsProperties = corsProperties;
+    }
 
     @Bean
     public WebMvcConfigurer corsConfigurer() {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
-                // Apply global CORS policy allowing any origin with credentials
-                registry.addMapping("/**")
-                        .allowedOriginPatterns("*")
+                CorsRegistration registration = registry.addMapping("/**")
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("Authorization", "Content-Type")
                         .exposedHeaders("Authorization")
                         .allowCredentials(true);
+
+                List<String> allowedOrigins = corsProperties.getAllowedOrigins();
+                if (allowedOrigins.isEmpty()) {
+                    throw new IllegalStateException(
+                            "No CORS allowed origins configured. Set app.cors.allowed-origins to at least one domain.");
+                }
+
+                registration.allowedOrigins(allowedOrigins.toArray(new String[0]));
             }
         };
     }

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/CorsProperties.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/config/CorsProperties.java
@@ -1,0 +1,25 @@
+package com.bellingham.datafutures.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.cors")
+public class CorsProperties {
+
+    /**
+     * The list of allowed origins for CORS requests. Configure this in
+     * application properties to explicitly enumerate frontend domains that are
+     * permitted to call the backend.
+     */
+    private List<String> allowedOrigins = new ArrayList<>();
+
+    public List<String> getAllowedOrigins() {
+        return allowedOrigins;
+    }
+
+    public void setAllowedOrigins(List<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+}

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
@@ -14,9 +14,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RestController
-// Allow the frontend to call these endpoints from any host during development.
-// In production the origin should be restricted via configuration.
-@CrossOrigin(originPatterns = "*", allowCredentials = "true")
 @RequestMapping("/api")
 public class AuthController {
 

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -21,8 +21,6 @@ import org.springframework.data.domain.Pageable;
 
 
 @RestController
-// Allow CORS from any host during development.
-@CrossOrigin(originPatterns = "*", allowCredentials = "true")
 @RequestMapping("/api/contracts")
 public class ForwardContractController {
 

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/NotificationController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/NotificationController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@CrossOrigin(originPatterns = "*", allowCredentials = "true")
 @RequestMapping("/api/notifications")
 public class NotificationController {
 

--- a/bellingham-datafutures/src/main/resources/application.yml
+++ b/bellingham-datafutures/src/main/resources/application.yml
@@ -17,3 +17,8 @@ jwt:
   rotation:
     initial-key-id: ${JWT_INITIAL_KEY_ID:local-dev-key}
     initial-secret: ${JWT_INITIAL_SECRET:dGhpc19pc19hX2xvY2FsX3Rlc3Rfc2VjcmV0X2tleV9mb3JfZGV2ZWxvcG1lbnQ=}
+
+app:
+  cors:
+    allowed-origins:
+      - http://localhost:3000


### PR DESCRIPTION
## Summary
- add configuration properties to manage allowed CORS origins
- update the global CORS configuration to require explicit origins from configuration
- remove controller-level wildcard CrossOrigin annotations and document localhost frontend in application properties

## Testing
- `./mvnw test` *(fails: unable to reach Maven Central to download parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d1127895048329990c36d7b5a1f7ed