### PR TITLE
Verify notification owner before marking read

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/NotificationController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/NotificationController.java
@@ -24,7 +24,7 @@ public class NotificationController {
     }
 
     @PostMapping("/{id}/read")
-    public void markRead(@PathVariable Long id) {
-        notificationService.markRead(id);
+    public void markRead(@PathVariable Long id, Authentication authentication) {
+        notificationService.markRead(id, authentication.getName());
     }
 }

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/service/NotificationService.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/service/NotificationService.java
@@ -2,7 +2,9 @@ package com.bellingham.datafutures.service;
 
 import com.bellingham.datafutures.model.Notification;
 import com.bellingham.datafutures.repository.NotificationRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 
@@ -32,8 +34,11 @@ public class NotificationService {
         return repository.findByUsernameOrderByTimestampDesc(username);
     }
 
-    public void markRead(Long id) {
+    public void markRead(Long id, String username) {
         repository.findById(id).ifPresent(n -> {
+            if (!n.getUsername().equals(username)) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Cannot modify notifications for another user");
+            }
             n.setReadFlag(true);
             repository.save(n);
         });


### PR DESCRIPTION
## Summary
- require the authenticated username when marking notifications as read
- prevent users from marking other users' notifications as read by enforcing an ownership check

## Testing
- `./mvnw test` *(fails: unable to resolve parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d116242f588329b8bded52cd5ab182