### PR TITLE
feat: add DTOs and validation for auth endpoints

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/dto/LoginRequest.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/dto/LoginRequest.java
@@ -1,0 +1,28 @@
+package com.bellingham.datafutures.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/dto/RegisterRequest.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/dto/RegisterRequest.java
@@ -1,0 +1,151 @@
+package com.bellingham.datafutures.controller.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class RegisterRequest {
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String password;
+
+    private String legalBusinessName;
+
+    private String name;
+
+    private String countryOfIncorporation;
+
+    private String taxId;
+
+    private String companyRegistrationNumber;
+
+    private String primaryContactName;
+
+    @Email
+    private String primaryContactEmail;
+
+    private String primaryContactPhone;
+
+    private String technicalContactName;
+
+    @Email
+    private String technicalContactEmail;
+
+    private String technicalContactPhone;
+
+    private String companyDescription;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getLegalBusinessName() {
+        return legalBusinessName;
+    }
+
+    public void setLegalBusinessName(String legalBusinessName) {
+        this.legalBusinessName = legalBusinessName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCountryOfIncorporation() {
+        return countryOfIncorporation;
+    }
+
+    public void setCountryOfIncorporation(String countryOfIncorporation) {
+        this.countryOfIncorporation = countryOfIncorporation;
+    }
+
+    public String getTaxId() {
+        return taxId;
+    }
+
+    public void setTaxId(String taxId) {
+        this.taxId = taxId;
+    }
+
+    public String getCompanyRegistrationNumber() {
+        return companyRegistrationNumber;
+    }
+
+    public void setCompanyRegistrationNumber(String companyRegistrationNumber) {
+        this.companyRegistrationNumber = companyRegistrationNumber;
+    }
+
+    public String getPrimaryContactName() {
+        return primaryContactName;
+    }
+
+    public void setPrimaryContactName(String primaryContactName) {
+        this.primaryContactName = primaryContactName;
+    }
+
+    public String getPrimaryContactEmail() {
+        return primaryContactEmail;
+    }
+
+    public void setPrimaryContactEmail(String primaryContactEmail) {
+        this.primaryContactEmail = primaryContactEmail;
+    }
+
+    public String getPrimaryContactPhone() {
+        return primaryContactPhone;
+    }
+
+    public void setPrimaryContactPhone(String primaryContactPhone) {
+        this.primaryContactPhone = primaryContactPhone;
+    }
+
+    public String getTechnicalContactName() {
+        return technicalContactName;
+    }
+
+    public void setTechnicalContactName(String technicalContactName) {
+        this.technicalContactName = technicalContactName;
+    }
+
+    public String getTechnicalContactEmail() {
+        return technicalContactEmail;
+    }
+
+    public void setTechnicalContactEmail(String technicalContactEmail) {
+        this.technicalContactEmail = technicalContactEmail;
+    }
+
+    public String getTechnicalContactPhone() {
+        return technicalContactPhone;
+    }
+
+    public void setTechnicalContactPhone(String technicalContactPhone) {
+        this.technicalContactPhone = technicalContactPhone;
+    }
+
+    public String getCompanyDescription() {
+        return companyDescription;
+    }
+
+    public void setCompanyDescription(String companyDescription) {
+        this.companyDescription = companyDescription;
+    }
+}


### PR DESCRIPTION
## Summary
- replace map-based auth payload parsing with typed request DTOs that leverage bean validation
- return conflict and created HTTP responses from the registration endpoint instead of plain strings
- add DTO classes for login and registration requests with appropriate validation annotations

## Testing
- `mvn test` *(fails: unable to download Spring Boot parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d11dc63740832991ac6e79dfeee1ff