### PR TITLE
Add centralized Axios error handling with retries

### DIFF
--- a/bellingham-frontend/src/__tests__/api.test.js
+++ b/bellingham-frontend/src/__tests__/api.test.js
@@ -1,7 +1,11 @@
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import api from '../utils/api';
 
 describe('api utility', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test('requests include credentials for cookie-based auth', async () => {
     await api.get('/test', {
       adapter: (config) => {
@@ -15,6 +19,8 @@ describe('api utility', () => {
   test('dispatches session-expired event on 401 responses', async () => {
     const listener = vi.fn();
     window.addEventListener('session-expired', listener);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const error = {
       response: { status: 401 },
@@ -28,6 +34,78 @@ describe('api utility', () => {
     })).rejects.toEqual(error);
 
     expect(listener).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      '[api] Unauthorized response received; dispatching session-expired event.',
+    );
+    expect(console.error).toHaveBeenCalledWith('[api] Request failed', {
+      method: undefined,
+      message: undefined,
+      status: 401,
+      url: undefined,
+    });
     window.removeEventListener('session-expired', listener);
+  });
+
+  test('retries retryable errors up to the configured limit', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    let attempt = 0;
+    const adapter = vi.fn((config) => {
+      attempt += 1;
+      if (attempt === 1) {
+        const error = new Error('Server error');
+        error.config = config;
+        error.response = { status: 502 };
+        error.isAxiosError = true;
+        error.toJSON = () => ({});
+        return Promise.reject(error);
+      }
+
+      return Promise.resolve({
+        data: { success: true },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+      });
+    });
+
+    const response = await api.get('/retry-test', { adapter, retry: 2 });
+
+    expect(response.status).toBe(200);
+    expect(adapter).toHaveBeenCalledTimes(2);
+    expect(console.warn).toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  test('logs error details when retries are exhausted', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const adapter = vi.fn((config) => {
+      const error = new Error('Bad Gateway');
+      error.config = config;
+      error.response = { status: 502 };
+      error.isAxiosError = true;
+      error.toJSON = () => ({});
+      return Promise.reject(error);
+    });
+
+    await expect(
+      api.get('/retry-test', {
+        adapter,
+        retry: 1,
+      }),
+    ).rejects.toMatchObject({ response: { status: 502 } });
+
+    expect(adapter).toHaveBeenCalledTimes(2);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('[api] Request failed', {
+      method: 'get',
+      message: 'Bad Gateway',
+      status: 502,
+      url: '/retry-test',
+    });
   });
 });

--- a/bellingham-frontend/src/utils/api.js
+++ b/bellingham-frontend/src/utils/api.js
@@ -5,12 +5,73 @@ const api = axios.create({
   withCredentials: true,
 });
 
+const parseRetryCount = (value, fallback) => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value >= 0 ? value : fallback;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+  }
+
+  return fallback;
+};
+
+const DEFAULT_MAX_RETRIES = parseRetryCount(import.meta.env.VITE_API_MAX_RETRIES, 1);
+
+const shouldRetryRequest = (error, maxRetries) => {
+  const { config, response } = error ?? {};
+
+  if (!config) {
+    return false;
+  }
+
+  const currentRetryCount = config.__retryCount ?? 0;
+  if (currentRetryCount >= maxRetries) {
+    return false;
+  }
+
+  if (response) {
+    return response.status >= 500 && response.status < 600;
+  }
+
+  // Retry network errors (no response received)
+  return true;
+};
+
 api.interceptors.response.use(
   (response) => response,
-  (error) => {
-    if (error?.response?.status === 401 && typeof window !== 'undefined') {
+  async (error) => {
+    const { config, response } = error ?? {};
+
+    if (response?.status === 401 && typeof window !== 'undefined') {
+      console.warn('[api] Unauthorized response received; dispatching session-expired event.');
       window.dispatchEvent(new Event('session-expired'));
     }
+
+    if (config) {
+      const maxRetries = parseRetryCount(config.retry, DEFAULT_MAX_RETRIES);
+
+      if (shouldRetryRequest(error, maxRetries)) {
+        config.__retryCount = (config.__retryCount ?? 0) + 1;
+        console.warn(
+          `[api] Retry attempt ${config.__retryCount}/${maxRetries} for ${
+            config.method?.toUpperCase() ?? 'REQUEST'
+          } ${config.url ?? ''}.`,
+        );
+
+        return api(config);
+      }
+    }
+
+    console.error('[api] Request failed', {
+      url: config?.url,
+      method: config?.method,
+      status: response?.status,
+      message: error?.message,
+    });
+
     return Promise.reject(error);
   },
 );


### PR DESCRIPTION
## Summary
- enhance the shared Axios instance with retry-aware response interceptors that surface 401 expirations, retry transient failures, and emit structured logs
- add vitest coverage for unauthorized handling, retry success, and exhausted retries to verify the new interceptor behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1283eedb48329b17b82ac78c79d75