### PR TITLE
Add validation starter dependency

### DIFF
--- a/bellingham-datafutures/pom.xml
+++ b/bellingham-datafutures/pom.xml
@@ -33,6 +33,11 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
         <!-- Important: Security Config (for AuthenticationConfiguration) -->
         <dependency>
             <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
## Summary
- add Spring Boot validation starter to provide jakarta validation API used by login DTO

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d12f292cfc8329b4d079d0f6e36505