### PR TITLE
Restrict contract relisting to original owner

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -230,8 +230,11 @@ public class ForwardContractController {
         return repository.findById(id)
                 .map(contract -> {
                     String username = SecurityContextHolder.getContext().getAuthentication().getName();
+                    if (!username.equals(contract.getCreatorUsername())) {
+                        return ResponseEntity.status(org.springframework.http.HttpStatus.FORBIDDEN)
+                                .<ForwardContract>build();
+                    }
                     userRepository.findByUsername(username).ifPresent(user -> fillSellerDetails(contract, user));
-                    contract.setCreatorUsername(username);
                     contract.setStatus("Available");
                     contract.setBuyerUsername(null);
                     contract.setPurchaseDate(null);


### PR DESCRIPTION
## Summary
- prevent non-owners from relisting contracts by enforcing a creator username check
- stop overwriting the contract creator when relisting and leave existing ownership intact

## Testing
- `./mvnw test` *(fails: network is unreachable when resolving spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68d15089f3d4832998a1d857247bba8c