### PR TITLE
Optimize expired contract maintenance query

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/repository/ForwardContractRepository.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/repository/ForwardContractRepository.java
@@ -1,12 +1,16 @@
 package com.bellingham.datafutures.repository;
 
 import com.bellingham.datafutures.model.ForwardContract;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface ForwardContractRepository extends JpaRepository<ForwardContract, Long> {
@@ -23,5 +27,15 @@ public interface ForwardContractRepository extends JpaRepository<ForwardContract
             String status2,
             String creatorUsername,
             Pageable pageable);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+            "update ForwardContract c "
+                    + "set c.status = :newStatus "
+                    + "where c.deliveryDate < :cutoff and lower(c.status) = lower(:currentStatus)")
+    int updateStatusForExpiredContracts(
+            @Param("cutoff") LocalDate cutoff,
+            @Param("currentStatus") String currentStatus,
+            @Param("newStatus") String newStatus);
 }
 


### PR DESCRIPTION
## Summary
- add a repository bulk update query to retag expired contracts without loading all records
- update the scheduled maintenance job to call the bulk updates inside a transaction for void and delivered transitions

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM due to network restrictions when downloading org.springframework.boot:spring-boot-starter-parent:3.4.4)*

------
https://chatgpt.com/codex/tasks/task_e_68d15bd5ef6c8329956303bb77ba72cb