### PR TITLE
Throw 404 when marking missing notifications read

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/service/NotificationService.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/service/NotificationService.java
@@ -38,13 +38,15 @@ public class NotificationService {
     }
 
     public void markRead(Long id, String username) {
-        repository.findById(id).ifPresent(n -> {
-            if (!n.getUsername().equals(username)) {
-                throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Cannot modify notifications for another user");
-            }
-            n.setReadFlag(true);
-            Notification saved = repository.save(n);
-            streamService.sendNotification(username, saved);
-        });
+        Notification notification = repository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Notification not found"));
+
+        if (!notification.getUsername().equals(username)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Cannot modify notifications for another user");
+        }
+
+        notification.setReadFlag(true);
+        Notification saved = repository.save(notification);
+        streamService.sendNotification(username, saved);
     }
 }

--- a/bellingham-datafutures/src/test/java/com/bellingham/datafutures/NotificationServiceTest.java
+++ b/bellingham-datafutures/src/test/java/com/bellingham/datafutures/NotificationServiceTest.java
@@ -13,7 +13,11 @@ import org.springframework.test.context.ActiveProfiles;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DataJpaTest
 @Import({NotificationService.class, NotificationStreamService.class})
@@ -61,5 +65,12 @@ class NotificationServiceTest {
 
         Notification updated = notificationRepository.findById(n.getId()).orElseThrow();
         assertThat(updated.isReadFlag()).isTrue();
+    }
+
+    @Test
+    void markReadThrowsWhenNotificationMissing() {
+        assertThatThrownBy(() -> notificationService.markRead(999L, "bob"))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND));
     }
 }


### PR DESCRIPTION
## Summary
- throw a 404 ResponseStatusException when attempting to mark a notification that does not exist as read
- ensure markRead still enforces ownership checks before updating and streaming notifications
- add a service test that verifies the not found behavior

## Testing
- ./mvnw test *(fails: cannot reach Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d160c977cc832985881df3047d6f0b