### PR TITLE
Fix notification timestamp rendering

### DIFF
--- a/bellingham-frontend/src/components/Notifications.jsx
+++ b/bellingham-frontend/src/components/Notifications.jsx
@@ -127,9 +127,11 @@ const Notifications = () => {
                                                     {notification.message}
                                                 </p>
                                             )}
-                                            {notification.createdAt && (
+                                            {(notification.timestamp || notification.createdAt) && (
                                                 <p className="text-xs text-slate-500">
-                                                    {new Date(notification.createdAt).toLocaleString()}
+                                                    {new Date(
+                                                        notification.timestamp || notification.createdAt
+                                                    ).toLocaleString()}
                                                 </p>
                                             )}
                                         </div>


### PR DESCRIPTION
## Summary
- update the notifications component to read the API's `timestamp` property while keeping backward compatibility with `createdAt`

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d161c41838832994b2c05a1e54946e