### PR TITLE
refactor notifications into shared context

### DIFF
--- a/bellingham-frontend/src/__tests__/Login.test.jsx
+++ b/bellingham-frontend/src/__tests__/Login.test.jsx
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Login from '../components/Login';
@@ -6,9 +7,11 @@ import { AuthProvider } from '../context';
 
 test('renders username and password fields', () => {
   render(
-    <AuthProvider>
-      <Login />
-    </AuthProvider>
+    <MemoryRouter>
+      <AuthProvider>
+        <Login />
+      </AuthProvider>
+    </MemoryRouter>
   );
   expect(screen.getByPlaceholderText(/Username/i)).toBeInTheDocument();
   expect(screen.getByPlaceholderText(/Password/i)).toBeInTheDocument();

--- a/bellingham-frontend/src/components/NotificationPopup.jsx
+++ b/bellingham-frontend/src/components/NotificationPopup.jsx
@@ -1,104 +1,11 @@
-import React, { useCallback, useEffect, useState, useContext } from "react";
+import React, { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import Button from "./ui/Button";
-import api from "../utils/api";
-import { AuthContext } from "../context";
+import { useNotifications } from "../context";
 
 const NotificationPopup = () => {
-    const [notifications, setNotifications] = useState([]);
-
-    const { isAuthenticated } = useContext(AuthContext);
     const navigate = useNavigate();
-
-    const fetchNotifications = useCallback(async () => {
-        if (!isAuthenticated) return;
-        try {
-            const res = await api.get(`/api/notifications`);
-            setNotifications(res.data || []);
-        } catch (err) {
-            console.error("Failed to fetch notifications", err);
-        }
-    }, [isAuthenticated]);
-
-    useEffect(() => {
-        if (!isAuthenticated) {
-            setNotifications([]);
-            return undefined;
-        }
-
-        fetchNotifications();
-
-        if (typeof window === "undefined" || typeof window.EventSource === "undefined") {
-            return undefined;
-        }
-
-        const baseUrl = import.meta.env.VITE_API_BASE_URL;
-        let streamUrl;
-
-        try {
-            streamUrl = new URL(
-                "/api/notifications/stream",
-                baseUrl || window.location.origin
-            ).toString();
-        } catch (err) {
-            console.error("Failed to construct notification stream URL", err);
-            streamUrl = "/api/notifications/stream";
-        }
-
-        const eventSource = new EventSource(streamUrl, {
-            withCredentials: true,
-        });
-
-        const handleNotification = (event) => {
-            try {
-                const notification = JSON.parse(event.data);
-                setNotifications((prev) => {
-                    const existingIndex = prev.findIndex((n) => n.id === notification.id);
-                    if (existingIndex !== -1) {
-                        const updated = [...prev];
-                        updated[existingIndex] = { ...prev[existingIndex], ...notification };
-                        return updated;
-                    }
-                    return [notification, ...prev];
-                });
-            } catch (err) {
-                console.error("Failed to parse notification event", err);
-            }
-        };
-
-        eventSource.addEventListener("notification", handleNotification);
-        eventSource.onerror = (err) => {
-            console.error("Notification stream error", err);
-        };
-
-        return () => {
-            eventSource.removeEventListener("notification", handleNotification);
-            eventSource.close();
-        };
-    }, [fetchNotifications, isAuthenticated]);
-
-    const markRead = useCallback(
-        async (id) => {
-            if (!isAuthenticated) return;
-            try {
-                await api.post(`/api/notifications/${id}/read`);
-                setNotifications((prev) =>
-                    prev.map((notification) =>
-                        notification.id === id
-                            ? { ...notification, readFlag: true }
-                            : notification
-                    )
-                );
-            } catch (err) {
-                console.error("Failed to mark notification read", err);
-            }
-        },
-        [isAuthenticated]
-    );
-
-    const unreadNotifications = notifications.filter(
-        (notification) => !notification.readFlag
-    );
+    const { unreadNotifications, markRead } = useNotifications();
 
     const handleViewContracts = useCallback(
         async (id) => {
@@ -109,8 +16,8 @@ const NotificationPopup = () => {
     );
 
     const handleDismiss = useCallback(
-        async (id) => {
-            await markRead(id);
+        (id) => {
+            markRead(id);
         },
         [markRead]
     );

--- a/bellingham-frontend/src/context/NotificationContext.js
+++ b/bellingham-frontend/src/context/NotificationContext.js
@@ -1,0 +1,14 @@
+import { createContext } from "react";
+
+const NotificationContext = createContext({
+    notifications: [],
+    unreadNotifications: [],
+    unreadCount: 0,
+    loading: true,
+    error: "",
+    refresh: async () => {},
+    markRead: async () => {},
+    markAllRead: async () => {},
+});
+
+export default NotificationContext;

--- a/bellingham-frontend/src/context/NotificationProvider.jsx
+++ b/bellingham-frontend/src/context/NotificationProvider.jsx
@@ -1,0 +1,226 @@
+import React, {
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
+import AuthContext from "./AuthContext";
+import NotificationContext from "./NotificationContext";
+import api from "../utils/api";
+
+const createStreamUrl = () => {
+    if (typeof window === "undefined") {
+        return null;
+    }
+
+    const baseUrl = import.meta.env.VITE_API_BASE_URL;
+    try {
+        return new URL(
+            "/api/notifications/stream",
+            baseUrl || window.location.origin
+        ).toString();
+    } catch (error) {
+        console.error("Failed to construct notification stream URL", error);
+        return "/api/notifications/stream";
+    }
+};
+
+const NotificationProvider = ({ children }) => {
+    const { isAuthenticated } = useContext(AuthContext);
+
+    const [notifications, setNotifications] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+    const eventSourceRef = useRef(null);
+
+    const handleNotificationEvent = useCallback((event) => {
+        try {
+            const notification = JSON.parse(event.data);
+            setNotifications((prev) => {
+                const existingIndex = prev.findIndex(
+                    (item) => item.id === notification.id
+                );
+
+                if (existingIndex !== -1) {
+                    const updated = [...prev];
+                    updated[existingIndex] = {
+                        ...prev[existingIndex],
+                        ...notification,
+                    };
+                    return updated;
+                }
+
+                return [notification, ...prev];
+            });
+        } catch (err) {
+            console.error("Failed to parse notification event", err);
+        }
+    }, []);
+
+    const closeEventSource = useCallback(() => {
+        if (eventSourceRef.current) {
+            eventSourceRef.current.removeEventListener(
+                "notification",
+                handleNotificationEvent
+            );
+            eventSourceRef.current.close();
+            eventSourceRef.current = null;
+        }
+    }, [handleNotificationEvent]);
+
+    const fetchNotifications = useCallback(async () => {
+        if (!isAuthenticated) {
+            setNotifications([]);
+            setLoading(false);
+            setError("");
+            return;
+        }
+
+        setLoading(true);
+        setError("");
+        try {
+            const res = await api.get(`/api/notifications`);
+            setNotifications(res.data || []);
+        } catch (err) {
+            console.error("Failed to load notifications", err);
+            setError("Failed to load notifications");
+        } finally {
+            setLoading(false);
+        }
+    }, [isAuthenticated]);
+
+    const markRead = useCallback(
+        async (id) => {
+            if (!isAuthenticated || !id) return;
+            try {
+                await api.post(`/api/notifications/${id}/read`);
+                setNotifications((prev) =>
+                    prev.map((notification) =>
+                        notification.id === id
+                            ? { ...notification, readFlag: true }
+                            : notification
+                    )
+                );
+            } catch (err) {
+                console.error("Failed to mark notification read", err);
+            }
+        },
+        [isAuthenticated]
+    );
+
+    const markAllRead = useCallback(async () => {
+        if (!isAuthenticated) return;
+        const unreadIds = notifications
+            .filter((notification) => !notification.readFlag)
+            .map((notification) => notification.id);
+
+        if (!unreadIds.length) return;
+
+        try {
+            await Promise.all(
+                unreadIds.map((id) => api.post(`/api/notifications/${id}/read`))
+            );
+            setNotifications((prev) =>
+                prev.map((notification) =>
+                    unreadIds.includes(notification.id)
+                        ? { ...notification, readFlag: true }
+                        : notification
+                )
+            );
+        } catch (err) {
+            console.error("Failed to mark all notifications read", err);
+        }
+    }, [isAuthenticated, notifications]);
+
+    useEffect(() => {
+        if (!isAuthenticated) {
+            closeEventSource();
+            setNotifications([]);
+            setLoading(false);
+            setError("");
+            return undefined;
+        }
+
+        fetchNotifications();
+
+        if (
+            typeof window === "undefined" ||
+            typeof window.EventSource === "undefined"
+        ) {
+            return undefined;
+        }
+
+        const streamUrl = createStreamUrl();
+        if (!streamUrl) {
+            return undefined;
+        }
+
+        const eventSource = new EventSource(streamUrl, {
+            withCredentials: true,
+        });
+
+        eventSource.addEventListener("notification", handleNotificationEvent);
+
+        eventSource.onerror = (err) => {
+            console.error("Notification stream error", err);
+        };
+
+        eventSourceRef.current = eventSource;
+
+        return () => {
+            eventSource.removeEventListener(
+                "notification",
+                handleNotificationEvent
+            );
+            eventSource.close();
+            eventSourceRef.current = null;
+        };
+    }, [closeEventSource, fetchNotifications, handleNotificationEvent, isAuthenticated]);
+
+    useEffect(
+        () => () => {
+            closeEventSource();
+        },
+        [closeEventSource]
+    );
+
+    const unreadNotifications = useMemo(
+        () => notifications.filter((notification) => !notification.readFlag),
+        [notifications]
+    );
+
+    const unreadCount = unreadNotifications.length;
+
+    const value = useMemo(
+        () => ({
+            notifications,
+            unreadNotifications,
+            unreadCount,
+            loading,
+            error,
+            refresh: fetchNotifications,
+            markRead,
+            markAllRead,
+        }),
+        [
+            notifications,
+            unreadNotifications,
+            unreadCount,
+            loading,
+            error,
+            fetchNotifications,
+            markRead,
+            markAllRead,
+        ]
+    );
+
+    return (
+        <NotificationContext.Provider value={value}>
+            {children}
+        </NotificationContext.Provider>
+    );
+};
+
+export default NotificationProvider;

--- a/bellingham-frontend/src/context/index.js
+++ b/bellingham-frontend/src/context/index.js
@@ -1,2 +1,5 @@
 export { default as AuthContext } from './AuthContext';
 export { default as AuthProvider } from './AuthProvider';
+export { default as NotificationContext } from './NotificationContext';
+export { default as NotificationProvider } from './NotificationProvider';
+export { default as useNotifications } from './useNotifications';

--- a/bellingham-frontend/src/context/useNotifications.js
+++ b/bellingham-frontend/src/context/useNotifications.js
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import NotificationContext from "./NotificationContext";
+
+const useNotifications = () => useContext(NotificationContext);
+
+export default useNotifications;

--- a/bellingham-frontend/src/main.jsx
+++ b/bellingham-frontend/src/main.jsx
@@ -3,13 +3,15 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
-import { AuthProvider } from './context';
+import { AuthProvider, NotificationProvider } from "./context";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
     <React.StrictMode>
         <BrowserRouter>
             <AuthProvider>
-                <App />
+                <NotificationProvider>
+                    <App />
+                </NotificationProvider>
             </AuthProvider>
         </BrowserRouter>
     </React.StrictMode>,


### PR DESCRIPTION
## Summary
- add a NotificationProvider that manages fetching, SSE subscriptions, and read-state updates in one place
- update the notifications page and popup to consume the shared notification hook instead of duplicating logic
- wrap the app with the new provider and adjust the login test to render within a router context

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d16790a7f88329a6af801e19163f51