### PR TITLE
Fix phone regex escaping

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/dto/RegisterRequest.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/dto/RegisterRequest.java
@@ -48,7 +48,7 @@ public class RegisterRequest {
     private String primaryContactEmail;
 
     @NotBlank
-    @Pattern(regexp = "^\+?[0-9 .\-()]{7,20}$",
+    @Pattern(regexp = "^\+?[-0-9 .()]{7,20}$",
             message = "Primary contact phone must be a valid international phone number")
     private String primaryContactPhone;
 
@@ -62,7 +62,7 @@ public class RegisterRequest {
     private String technicalContactEmail;
 
     @NotBlank
-    @Pattern(regexp = "^\+?[0-9 .\-()]{7,20}$",
+    @Pattern(regexp = "^\+?[-0-9 .()]{7,20}$",
             message = "Technical contact phone must be a valid international phone number")
     private String technicalContactPhone;
 


### PR DESCRIPTION
## Summary
- update registration phone regex to avoid illegal escape sequences by placing the hyphen at the start of the character class

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d16a6cc5288329b9ec40ff1e7db309