### PR TITLE
Fix regex escapes in RegisterRequest

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/dto/RegisterRequest.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/dto/RegisterRequest.java
@@ -13,7 +13,7 @@ public class RegisterRequest {
 
     @NotBlank
     @Size(min = 12, max = 128, message = "Password must be between 12 and 128 characters")
-    @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[\\p{Punct}]).+$",
+    @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[^A-Za-z0-9]).+$",
             message = "Password must include upper and lower case letters, a number, and a special character")
     private String password;
 
@@ -48,7 +48,7 @@ public class RegisterRequest {
     private String primaryContactEmail;
 
     @NotBlank
-    @Pattern(regexp = "^\+?[-0-9 .()]{7,20}$",
+    @Pattern(regexp = "^(?:\\+)?[0-9 .()\\-]{7,20}$",
             message = "Primary contact phone must be a valid international phone number")
     private String primaryContactPhone;
 
@@ -62,7 +62,7 @@ public class RegisterRequest {
     private String technicalContactEmail;
 
     @NotBlank
-    @Pattern(regexp = "^\+?[-0-9 .()]{7,20}$",
+    @Pattern(regexp = "^(?:\\+)?[0-9 .()\\-]{7,20}$",
             message = "Technical contact phone must be a valid international phone number")
     private String technicalContactPhone;
 


### PR DESCRIPTION
## Summary
- replace password regex with one that avoids Java escape sequences while preserving validation requirements
- adjust phone number regex patterns to use non-escaped character classes to prevent illegal escape errors

## Testing
- `./mvnw test` *(fails: unable to download parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d16c5fd0d883298b1fd2866980d34a