### PR TITLE
feat: refresh login screen styling

### DIFF
--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -5,7 +5,7 @@ import { useNavigate } from "react-router-dom";
 import LoginImage from "../assets/login.png";
 import Button from "./ui/Button";
 import api from "../utils/api";
-import { AuthContext } from '../context';
+import { AuthContext } from "../context";
 
 const Login = () => {
     const [username, setUsername] = useState("");
@@ -39,47 +39,115 @@ const Login = () => {
     };
 
     return (
-        <div className="flex flex-col min-h-screen items-center justify-center">
-            <div className="flex flex-col items-center justify-center">
-                <img
-                    src={LoginImage}
-                    alt="Bellingham Data Futures logo"
-                    className="h-32 w-32 mb-4"
-                />
-                <form
-                    onSubmit={handleLogin}
-                    className="bg-white bg-opacity-90 shadow-lg rounded-2xl p-8 w-96 flex flex-col items-center"
-                >
-                {error && <div className="text-red-600 mb-2">{error}</div>}
-                <input
-                    type="text"
-                    placeholder="Username"
-                    value={username}
-                    onChange={(e) => setUsername(e.target.value)}
-                    className="w-full p-2 mb-4 border rounded-lg"
-                />
-                <input
-                    type="password"
-                    placeholder="Password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    className="w-full p-2 mb-6 border rounded-lg"
-                />
-                <Button type="submit" className="w-full rounded-lg" variant="primary">
-                    Sign In
-                </Button>
-                <Button
-                    type="button"
-                    variant="link"
-                    className="w-full mt-2"
-                    onClick={() => navigate("/signup")}
-                >
-                    Create Account
-                </Button>
-            </form>
+        <div className="min-h-screen bg-slate-950 text-slate-100">
+            <div className="mx-auto flex min-h-screen w-full max-w-6xl items-center justify-center px-6 py-16">
+                <div className="relative w-full overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/70 shadow-[0_40px_80px_-20px_rgba(15,23,42,0.9)] backdrop-blur">
+                    <div className="pointer-events-none absolute inset-0 opacity-60" aria-hidden="true">
+                        <div className="absolute -left-24 -top-24 h-72 w-72 rounded-full bg-blue-600/40 blur-3xl" />
+                        <div className="absolute -bottom-32 -right-20 h-80 w-80 rounded-full bg-cyan-400/30 blur-3xl" />
+                    </div>
+                    <div className="relative grid gap-12 p-10 md:grid-cols-2 lg:p-16">
+                        <div className="flex flex-col justify-between gap-8">
+                            <div className="flex items-center gap-4">
+                                <img
+                                    src={LoginImage}
+                                    alt="Bellingham Data Futures logo"
+                                    className="h-16 w-16 rounded-xl border border-slate-700/70 bg-slate-950/60 p-3 shadow-lg"
+                                />
+                                <div>
+                                    <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">
+                                        Bellingham Data Futures
+                                    </p>
+                                    <h1 className="text-3xl font-semibold text-slate-50 sm:text-4xl">
+                                        Welcome back.
+                                    </h1>
+                                </div>
+                            </div>
+                            <div className="space-y-4 text-slate-300">
+                                <p className="text-base leading-relaxed">
+                                    Sign in to access your energy market dashboards, manage live bids, and
+                                    collaborate with your team in real time.
+                                </p>
+                                <ul className="space-y-3 text-sm text-slate-400">
+                                    <li className="flex items-start gap-3">
+                                        <span className="mt-1 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-blue-400" />
+                                        <span>Track portfolio performance with high-contrast visualisations.</span>
+                                    </li>
+                                    <li className="flex items-start gap-3">
+                                        <span className="mt-1 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-cyan-400" />
+                                        <span>Coordinate bids and settlements securely from a single control room.</span>
+                                    </li>
+                                    <li className="flex items-start gap-3">
+                                        <span className="mt-1 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-emerald-400" />
+                                        <span>Receive proactive alerts before market deadlines hit.</span>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div className="text-sm text-slate-500">
+                                Need a trading workspace for your organisation?{" "}
+                                <button
+                                    type="button"
+                                    onClick={() => navigate("/signup")}
+                                    className="font-medium text-sky-400 transition hover:text-sky-300"
+                                >
+                                    Request access
+                                </button>
+                            </div>
+                        </div>
+                        <form
+                            onSubmit={handleLogin}
+                            className="flex flex-col gap-6 rounded-2xl border border-slate-800/60 bg-slate-950/70 p-8 shadow-lg"
+                        >
+                            <div>
+                                <h2 className="text-2xl font-semibold text-slate-50">Sign in</h2>
+                                <p className="mt-2 text-sm text-slate-400">
+                                    Use your Bellingham credentials to continue.
+                                </p>
+                            </div>
+                            {error && <div className="rounded-lg border border-red-500/60 bg-red-500/10 px-3 py-2 text-sm text-red-300">{error}</div>}
+                            <div className="space-y-2">
+                                <label htmlFor="username" className="text-sm font-medium text-slate-300">
+                                    Username
+                                </label>
+                                <input
+                                    id="username"
+                                    type="text"
+                                    placeholder="Enter your username"
+                                    value={username}
+                                    onChange={(e) => setUsername(e.target.value)}
+                                    className="w-full rounded-lg border border-slate-700/80 bg-slate-900/70 px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <label htmlFor="password" className="text-sm font-medium text-slate-300">
+                                    Password
+                                </label>
+                                <input
+                                    id="password"
+                                    type="password"
+                                    placeholder="Enter your password"
+                                    value={password}
+                                    onChange={(e) => setPassword(e.target.value)}
+                                    className="w-full rounded-lg border border-slate-700/80 bg-slate-900/70 px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
+                                />
+                            </div>
+                            <Button type="submit" className="w-full rounded-lg py-3 text-base font-semibold shadow-lg shadow-sky-500/20" variant="primary">
+                                Sign In
+                            </Button>
+                            <Button
+                                type="button"
+                                variant="link"
+                                className="text-center text-sm text-sky-300 hover:text-sky-200"
+                                onClick={() => navigate("/signup")}
+                            >
+                                Create Account
+                            </Button>
+                        </form>
+                    </div>
+                </div>
+            </div>
         </div>
-    </div>
-        );
+    );
 };
 
 export default Login;


### PR DESCRIPTION
## Summary
- restyle the login view with the same dark frame and glassmorphism cues used across the app
- introduce richer contextual copy and highlights alongside the sign-in form
- update form controls for high-contrast, accessible presentation within the new layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1783002308329a28a66c8ec4e5066