### PR TITLE
Restyle signature capture modal

### DIFF
--- a/bellingham-frontend/src/components/SignatureModal.jsx
+++ b/bellingham-frontend/src/components/SignatureModal.jsx
@@ -41,8 +41,8 @@ const SignatureModal = ({ onConfirm, onCancel }) => {
     const signaturePad = new SignaturePad(canvas, {
       minWidth: 1,
       maxWidth: 2.5,
-      penColor: '#000000',
-      backgroundColor: '#ffffff',
+      penColor: '#f9fafb',
+      backgroundColor: '#0f172a',
     });
 
     signaturePadRef.current = signaturePad;
@@ -92,20 +92,28 @@ const SignatureModal = ({ onConfirm, onCancel }) => {
   };
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
-      <div className="bg-white p-4 rounded shadow-md">
-        <canvas
-          ref={canvasRef}
-          className="border border-gray-300"
-          width={400}
-          height={200}
-          data-testid="signature-canvas"
-        />
-        {error && <p className="mt-2 text-sm text-red-600" role="alert">{error}</p>}
-        <div className="mt-2 flex justify-end gap-2">
-          <Button variant="ghost" onClick={handleClear}>Clear</Button>
-          <Button variant="danger" onClick={onCancel}>Cancel</Button>
-          <Button variant="success" onClick={handleSave}>Save</Button>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 backdrop-blur-sm">
+      <div className="w-full max-w-xl rounded-2xl border border-slate-700 bg-slate-900 p-6 shadow-2xl">
+        <header className="mb-4">
+          <h2 className="text-xl font-semibold text-white">Capture signature</h2>
+          <p className="mt-1 text-sm text-slate-300">
+            Use your pointer or touch to draw your signature below. When you are satisfied, save it to continue.
+          </p>
+        </header>
+        <div className="rounded-xl border border-slate-700 bg-slate-950/40 p-3">
+          <canvas
+            ref={canvasRef}
+            className="mx-auto block h-auto w-full max-w-md rounded-lg border border-slate-700 bg-slate-900"
+            width={400}
+            height={200}
+            data-testid="signature-canvas"
+          />
+        </div>
+        {error && <p className="mt-3 text-sm text-red-400" role="alert">{error}</p>}
+        <div className="mt-6 flex flex-wrap justify-end gap-2">
+          <Button variant="ghost" className="border border-slate-600/60 bg-slate-800 text-slate-100 hover:bg-slate-700" onClick={handleClear}>Clear</Button>
+          <Button variant="danger" className="shadow-lg shadow-red-900/40" onClick={onCancel}>Cancel</Button>
+          <Button variant="success" className="font-semibold shadow-lg shadow-emerald-900/40" onClick={handleSave}>Save</Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- restyle the signature capture modal to use the platform's dark surface palette and add contextual guidance
- update signature pad colors and button treatments for improved contrast on the dark theme

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d17b7d85f88329932a3bb7a20ad5ed