### PR TITLE
feat: enhance shared button component

### DIFF
--- a/bellingham-frontend/src/components/ui/Button.jsx
+++ b/bellingham-frontend/src/components/ui/Button.jsx
@@ -1,21 +1,97 @@
-import React from 'react';
+import React, { cloneElement, forwardRef, isValidElement } from 'react';
 
-const baseClasses = 'px-4 py-2 rounded';
+const classNames = (...classes) => classes.filter(Boolean).join(' ');
+
+const baseClasses =
+  'inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
 
 const variantClasses = {
-  primary: 'bg-blue-600 hover:bg-blue-700 text-white',
-  success: 'bg-green-600 hover:bg-green-700 text-white',
-  danger: 'bg-red-600 hover:bg-red-700 text-white',
-  ghost: 'bg-gray-600 hover:bg-gray-700 text-white',
-  link: 'bg-transparent text-blue-600 hover:underline px-0 py-0 rounded-none',
+  primary: 'bg-blue-600 text-white hover:bg-blue-500 focus-visible:ring-blue-500',
+  success: 'bg-green-600 text-white hover:bg-green-500 focus-visible:ring-green-500',
+  danger: 'bg-red-600 text-white hover:bg-red-500 focus-visible:ring-red-500',
+  ghost: 'bg-gray-600 text-white hover:bg-gray-700 focus-visible:ring-gray-500',
+  link: 'bg-transparent px-0 py-0 text-blue-600 underline-offset-4 hover:underline focus-visible:ring-blue-500 focus-visible:ring-offset-0 rounded-none',
 };
 
-const Button = ({ variant = 'primary', className = '', ...props }) => {
-  const variantClass = variantClasses[variant] || '';
-  return (
-    <button className={`${baseClasses} ${variantClass} ${className}`} {...props} />
-  );
+const renderIcon = (icon, className) => {
+  if (!icon) {
+    return null;
+  }
+
+  if (isValidElement(icon)) {
+    return cloneElement(icon, {
+      className: classNames(icon.props.className, className),
+      'aria-hidden': true,
+      focusable: false,
+    });
+  }
+
+  if (typeof icon === 'function') {
+    const IconComponent = icon;
+    return <IconComponent className={className} aria-hidden="true" focusable="false" />;
+  }
+
+  return icon;
 };
+
+const DefaultSpinner = ({ className }) => (
+  <svg
+    className={classNames('h-4 w-4 animate-spin', className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+    <path
+      className="opacity-75"
+      fill="currentColor"
+      d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+    />
+  </svg>
+);
+
+const Button = forwardRef(
+  (
+    {
+      variant = 'primary',
+      className = '',
+      leadingIcon,
+      loadingIcon,
+      isLoading = false,
+      disabled = false,
+      type = 'button',
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const variantClass = variantClasses[variant] || variantClasses.primary;
+    const resolvedDisabled = disabled || isLoading;
+    const leadingIconNode = !isLoading ? renderIcon(leadingIcon, 'h-4 w-4') : null;
+    const loadingIconNode = isLoading
+      ? renderIcon(loadingIcon, 'h-4 w-4 animate-spin') || <DefaultSpinner />
+      : null;
+
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={classNames(baseClasses, variantClass, className)}
+        disabled={resolvedDisabled}
+        aria-busy={isLoading}
+        data-variant={variant}
+        {...props}
+      >
+        {loadingIconNode && <span className="flex items-center" aria-hidden="true">{loadingIconNode}</span>}
+        {leadingIconNode && <span className="flex items-center" aria-hidden="true">{leadingIconNode}</span>}
+        <span className={isLoading ? 'opacity-90' : undefined}>{children}</span>
+      </button>
+    );
+  },
+);
+
+Button.displayName = 'Button';
 
 export default Button;
 


### PR DESCRIPTION
## Summary
- add consistent focus-visible ring and disabled styling to the shared button
- support loading and leading icon slots with a default spinner

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4fafa86b083299902b9f22f7840ab