### PR TITLE
Add loading indicators for contract tables

### DIFF
--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -9,6 +9,7 @@ import Button from "./ui/Button";
 import { useNavigate } from "react-router-dom";
 import NotificationBanner from "./NotificationBanner";
 import SignatureModal from "./SignatureModal";
+import TableSkeleton from "./ui/TableSkeleton";
 
 const Buy = () => {
     const navigate = useNavigate();
@@ -21,13 +22,16 @@ const Buy = () => {
     const [maxPrice, setMaxPrice] = useState("");
     const [sellerFilter, setSellerFilter] = useState("");
     const [pendingContractId, setPendingContractId] = useState(null);
+    const [isLoading, setIsLoading] = useState(true);
 
     const { logout } = useContext(AuthContext);
 
     const fetchContracts = useCallback(async () => {
         try {
+            setIsLoading(true);
             const res = await api.get(`/api/contracts/available`);
             setContracts(res.data.content);
+            setError("");
         } catch (err) {
             console.error(err);
             if (err.response) {
@@ -39,6 +43,8 @@ const Buy = () => {
             } else {
                 setError("Failed to fetch contracts");
             }
+        } finally {
+            setIsLoading(false);
         }
     }, []);
 
@@ -191,36 +197,42 @@ const Buy = () => {
                                 </tr>
                             </thead>
                             <tbody className="divide-y divide-slate-800/70">
-                                {filteredContracts.map((contract) => (
-                                    <tr
-                                        key={contract.id}
-                                        className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-emerald-500/10"
-                                        onClick={() => setSelectedContract(contract)}
-                                    >
-                                        <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
-                                        <td className="px-4 py-3">{contract.seller}</td>
-                                        <td className="px-4 py-3 font-semibold text-emerald-300">${contract.price}</td>
-                                        <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
-                                        <td className="px-4 py-3">
-                                            <Button
-                                                variant="success"
-                                                onClick={(e) => {
-                                                    e.stopPropagation();
-                                                    openSignatureModal(contract.id);
-                                                }}
-                                                className="px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
+                                {isLoading ? (
+                                    <TableSkeleton columns={5} rows={5} />
+                                ) : (
+                                    <>
+                                        {filteredContracts.map((contract) => (
+                                            <tr
+                                                key={contract.id}
+                                                className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-emerald-500/10"
+                                                onClick={() => setSelectedContract(contract)}
                                             >
-                                                Buy
-                                            </Button>
-                                        </td>
-                                    </tr>
-                                ))}
-                                {filteredContracts.length === 0 && (
-                                    <tr>
-                                        <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
-                                            No contracts match your current filters.
-                                        </td>
-                                    </tr>
+                                                <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
+                                                <td className="px-4 py-3">{contract.seller}</td>
+                                                <td className="px-4 py-3 font-semibold text-emerald-300">${contract.price}</td>
+                                                <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
+                                                <td className="px-4 py-3">
+                                                    <Button
+                                                        variant="success"
+                                                        onClick={(e) => {
+                                                            e.stopPropagation();
+                                                            openSignatureModal(contract.id);
+                                                        }}
+                                                        className="px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
+                                                    >
+                                                        Buy
+                                                    </Button>
+                                                </td>
+                                            </tr>
+                                        ))}
+                                        {filteredContracts.length === 0 && (
+                                            <tr>
+                                                <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
+                                                    No contracts match your current filters.
+                                                </td>
+                                            </tr>
+                                        )}
+                                    </>
                                 )}
                             </tbody>
                         </table>

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -6,10 +6,12 @@ import ContractDetailsPanel from "./ContractDetailsPanel";
 import Layout from "./Layout";
 import api from "../utils/api";
 import { AuthContext } from '../context';
+import TableSkeleton from "./ui/TableSkeleton";
 
 const Dashboard = () => {
     const [contracts, setContracts] = useState([]);
     const [selectedContract, setSelectedContract] = useState(null);
+    const [isLoading, setIsLoading] = useState(true);
     const navigate = useNavigate();
 
     const { isAuthenticated, logout } = useContext(AuthContext);
@@ -21,12 +23,15 @@ const Dashboard = () => {
                     navigate("/login");
                     return;
                 }
+                setIsLoading(true);
                 const res = await api.get(`/api/contracts/available`);
                 setContracts(res.data.content);
             } catch (err) {
                 console.error("Error fetching contracts", err);
                 logout();
                 navigate("/login");
+            } finally {
+                setIsLoading(false);
             }
         };
 
@@ -61,31 +66,37 @@ const Dashboard = () => {
                                 </tr>
                             </thead>
                             <tbody className="divide-y divide-slate-800/70">
-                                {contracts.map((contract) => (
-                                    <tr
-                                        key={contract.id}
-                                        className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-emerald-500/10"
-                                        onClick={() => setSelectedContract(contract)}
-                                    >
-                                        <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
-                                        <td className="px-4 py-3">{contract.seller}</td>
-                                        <td className="px-4 py-3 font-semibold text-emerald-300">
-                                            ${contract.price}
-                                        </td>
-                                        <td className="px-4 py-3">
-                                            <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-100">
-                                                {contract.status}
-                                            </span>
-                                        </td>
-                                        <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
-                                    </tr>
-                                ))}
-                                {contracts.length === 0 && (
-                                    <tr>
-                                        <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
-                                            No contracts available at the moment.
-                                        </td>
-                                    </tr>
+                                {isLoading ? (
+                                    <TableSkeleton columns={5} rows={5} />
+                                ) : (
+                                    <>
+                                        {contracts.map((contract) => (
+                                            <tr
+                                                key={contract.id}
+                                                className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-emerald-500/10"
+                                                onClick={() => setSelectedContract(contract)}
+                                            >
+                                                <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
+                                                <td className="px-4 py-3">{contract.seller}</td>
+                                                <td className="px-4 py-3 font-semibold text-emerald-300">
+                                                    ${contract.price}
+                                                </td>
+                                                <td className="px-4 py-3">
+                                                    <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-100">
+                                                        {contract.status}
+                                                    </span>
+                                                </td>
+                                                <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
+                                            </tr>
+                                        ))}
+                                        {contracts.length === 0 && (
+                                            <tr>
+                                                <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
+                                                    No contracts available at the moment.
+                                                </td>
+                                            </tr>
+                                        )}
+                                    </>
                                 )}
                             </tbody>
                         </table>

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router-dom";
 import Button from "./ui/Button";
 import api from "../utils/api";
 import { AuthContext } from '../context';
+import TableSkeleton from "./ui/TableSkeleton";
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
@@ -15,6 +16,7 @@ const Reports = () => {
     const [contracts, setContracts] = useState([]);
     const [error, setError] = useState("");
     const [selectedContract, setSelectedContract] = useState(null);
+    const [isLoading, setIsLoading] = useState(true);
 
     const totalValue = contracts.reduce(
         (sum, contract) => sum + Number(contract.price || 0),
@@ -104,10 +106,14 @@ const Reports = () => {
     useEffect(() => {
         const fetchPurchased = async () => {
             try {
+                setIsLoading(true);
                 const res = await api.get(`/api/contracts/purchased`);
                 setContracts(res.data.content);
+                setError("");
             } catch {
                 setError("Failed to load purchased contracts.");
+            } finally {
+                setIsLoading(false);
             }
         };
         fetchPurchased();
@@ -153,7 +159,11 @@ const Reports = () => {
 
                     <div className="mt-6 grid gap-6">
                         <div className="rounded-2xl border border-slate-800 bg-slate-950/40 p-6">
-                            {contracts.length ? (
+                            {isLoading ? (
+                                <div className="flex h-72 items-center justify-center lg:h-96">
+                                    <div className="h-12 w-12 animate-spin rounded-full border-2 border-emerald-400 border-t-transparent" />
+                                </div>
+                            ) : contracts.length ? (
                                 <div className="flex flex-col gap-6 lg:flex-row">
                                     <div className="h-72 w-full lg:h-96 lg:flex-1">
                                         <Pie data={pieData} options={pieOptions} />
@@ -199,47 +209,53 @@ const Reports = () => {
                                     </tr>
                                 </thead>
                                 <tbody className="divide-y divide-slate-800/70">
-                                    {contracts.map((contract) => (
-                                        <tr
-                                            key={contract.id}
-                                            className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-emerald-500/10"
-                                            onClick={() => setSelectedContract(contract)}
-                                        >
-                                            <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
-                                            <td className="px-4 py-3">{contract.seller}</td>
-                                            <td className="px-4 py-3 font-semibold text-emerald-300">${contract.price}</td>
-                                            <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
-                                            <td className="px-4 py-3">
-                                                <div className="flex flex-wrap gap-2">
-                                                    <Button
-                                                        onClick={(e) => {
-                                                            e.stopPropagation();
-                                                            handleListForSale(contract.id);
-                                                        }}
-                                                        className="px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
-                                                    >
-                                                        List for Sale
-                                                    </Button>
-                                                    <Button
-                                                        variant="danger"
-                                                        onClick={(e) => {
-                                                            e.stopPropagation();
-                                                            handleCloseout(contract.id);
-                                                        }}
-                                                        className="px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
-                                                    >
-                                                        Closeout
-                                                    </Button>
-                                                </div>
-                                            </td>
-                                        </tr>
-                                    ))}
-                                    {contracts.length === 0 && (
-                                        <tr>
-                                            <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
-                                                No purchased contracts available.
-                                            </td>
-                                        </tr>
+                                    {isLoading ? (
+                                        <TableSkeleton columns={5} rows={5} />
+                                    ) : (
+                                        <>
+                                            {contracts.map((contract) => (
+                                                <tr
+                                                    key={contract.id}
+                                                    className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-emerald-500/10"
+                                                    onClick={() => setSelectedContract(contract)}
+                                                >
+                                                    <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
+                                                    <td className="px-4 py-3">{contract.seller}</td>
+                                                    <td className="px-4 py-3 font-semibold text-emerald-300">${contract.price}</td>
+                                                    <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
+                                                    <td className="px-4 py-3">
+                                                        <div className="flex flex-wrap gap-2">
+                                                            <Button
+                                                                onClick={(e) => {
+                                                                    e.stopPropagation();
+                                                                    handleListForSale(contract.id);
+                                                                }}
+                                                                className="px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
+                                                            >
+                                                                List for Sale
+                                                            </Button>
+                                                            <Button
+                                                                variant="danger"
+                                                                onClick={(e) => {
+                                                                    e.stopPropagation();
+                                                                    handleCloseout(contract.id);
+                                                                }}
+                                                                className="px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
+                                                            >
+                                                                Closeout
+                                                            </Button>
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                            ))}
+                                            {contracts.length === 0 && (
+                                                <tr>
+                                                    <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
+                                                        No purchased contracts available.
+                                                    </td>
+                                                </tr>
+                                            )}
+                                        </>
                                     )}
                                 </tbody>
                             </table>

--- a/bellingham-frontend/src/components/ui/Button.jsx
+++ b/bellingham-frontend/src/components/ui/Button.jsx
@@ -73,6 +73,8 @@ const Button = forwardRef(
       ? renderIcon(loadingIcon, 'h-4 w-4 animate-spin') || <DefaultSpinner />
       : null;
 
+    const childContent = isLoading ? <span className="opacity-90">{children}</span> : children;
+
     return (
       <button
         ref={ref}
@@ -85,7 +87,7 @@ const Button = forwardRef(
       >
         {loadingIconNode && <span className="flex items-center" aria-hidden="true">{loadingIconNode}</span>}
         {leadingIconNode && <span className="flex items-center" aria-hidden="true">{leadingIconNode}</span>}
-        <span className={isLoading ? 'opacity-90' : undefined}>{children}</span>
+        {childContent}
       </button>
     );
   },

--- a/bellingham-frontend/src/components/ui/TableSkeleton.jsx
+++ b/bellingham-frontend/src/components/ui/TableSkeleton.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+const widths = ["w-3/4", "w-2/3", "w-1/2", "w-5/6", "w-1/3"];
+
+const TableSkeleton = ({ columns = 4, rows = 5 }) => {
+    return (
+        <>
+            {Array.from({ length: rows }).map((_, rowIndex) => (
+                <tr
+                    key={`skeleton-row-${rowIndex}`}
+                    className="animate-pulse bg-slate-950/30"
+                >
+                    {Array.from({ length: columns }).map((__, columnIndex) => (
+                        <td key={`skeleton-cell-${rowIndex}-${columnIndex}`} className="px-4 py-3">
+                            <div
+                                className={`h-4 rounded-full bg-slate-800/80 ${widths[columnIndex % widths.length]}`}
+                            />
+                        </td>
+                    ))}
+                </tr>
+            ))}
+        </>
+    );
+};
+
+export default TableSkeleton;


### PR DESCRIPTION
## Summary
- add a reusable table skeleton component for loading states
- integrate skeleton rows and spinners across dashboard, buy, and reports tables
- adjust button rendering so tests can detect variant classes while loading

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d4fc7847448329938b843bb504036f