### PR TITLE
feat: highlight selected contract row

### DIFF
--- a/bellingham-frontend/src/components/Sales.jsx
+++ b/bellingham-frontend/src/components/Sales.jsx
@@ -55,23 +55,37 @@ const Sales = () => {
                                 </tr>
                             </thead>
                             <tbody className="divide-y divide-slate-800/70">
-                                {contracts.map((c) => (
-                                    <tr
-                                        key={c.id}
-                                        className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-emerald-500/10"
-                                        onClick={() => setSelectedContract(c)}
-                                    >
-                                        <td className="px-4 py-3 font-semibold text-slate-100">{c.title}</td>
-                                        <td className="px-4 py-3">{c.buyerUsername}</td>
-                                        <td className="px-4 py-3 font-semibold text-emerald-300">${c.price}</td>
-                                        <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
-                                        <td className="px-4 py-3">
-                                            <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-100">
-                                                {c.status}
-                                            </span>
-                                        </td>
-                                    </tr>
-                                ))}
+                                {contracts.map((c) => {
+                                    const isSelected = selectedContract?.id === c.id;
+
+                                    return (
+                                        <tr
+                                            key={c.id}
+                                            className={`group cursor-pointer transition-colors ${isSelected ? "bg-emerald-500/15" : "bg-slate-950/40 hover:bg-emerald-500/10"}`}
+                                            onClick={() => setSelectedContract(c)}
+                                            aria-selected={isSelected}
+                                        >
+                                            <td className="px-4 py-3 font-semibold text-slate-100">
+                                                <div className="flex items-center gap-2">
+                                                    {isSelected && (
+                                                        <span className="inline-flex items-center rounded-full border border-emerald-300/70 bg-emerald-500/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-emerald-100">
+                                                            Selected
+                                                        </span>
+                                                    )}
+                                                    <span>{c.title}</span>
+                                                </div>
+                                            </td>
+                                            <td className="px-4 py-3">{c.buyerUsername}</td>
+                                            <td className="px-4 py-3 font-semibold text-emerald-300">${c.price}</td>
+                                            <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
+                                            <td className="px-4 py-3">
+                                                <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-100">
+                                                    {c.status}
+                                                </span>
+                                            </td>
+                                        </tr>
+                                    );
+                                })}
                                 {contracts.length === 0 && (
                                     <tr>
                                         <td colSpan="5" className="px-4 py-10 text-center text-slate-500">


### PR DESCRIPTION
## Summary
- highlight the active contract row in the sales table for clearer selection feedback
- display a "Selected" badge and accent background when a row drives the details panel

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4ff974b408329be6a86cd04a749e7