### PR TITLE
Add responsive collapsible header navigation

### DIFF
--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { Link } from "react-router-dom";
 
 import logoImage from "../assets/login.png";
@@ -8,6 +8,15 @@ import NavMenuItem from "./ui/NavMenuItem";
 
 const Header = ({ onLogout }) => {
     const { username } = useContext(AuthContext);
+    const [isNavOpen, setIsNavOpen] = useState(false);
+
+    const toggleNavigation = () => {
+        setIsNavOpen((prev) => !prev);
+    };
+
+    const handleNavigate = () => {
+        setIsNavOpen(false);
+    };
 
     return (
         <header className="relative z-20 border-b border-slate-800/70 bg-slate-950/95 shadow-[0_16px_40px_rgba(8,20,45,0.65)]">
@@ -49,9 +58,39 @@ const Header = ({ onLogout }) => {
                 </div>
 
                 <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-3 shadow-inner shadow-black/20">
-                    <nav className="flex flex-wrap items-center gap-2">
+                    <div className="flex items-center justify-between gap-4 lg:hidden">
+                        <span className="text-[0.65rem] font-semibold uppercase tracking-[0.32em] text-slate-400">
+                            Navigation
+                        </span>
+                        <button
+                            type="button"
+                            onClick={toggleNavigation}
+                            aria-expanded={isNavOpen}
+                            aria-controls="primary-navigation"
+                            className="inline-flex items-center gap-2 rounded-lg border border-emerald-400/40 bg-slate-900/80 px-3 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.26em] text-emerald-100 transition-colors hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+                        >
+                            <span>{isNavOpen ? "Close" : "Menu"}</span>
+                            <svg
+                                aria-hidden="true"
+                                className={`h-4 w-4 transition-transform ${isNavOpen ? "rotate-180" : ""}`}
+                                xmlns="http://www.w3.org/2000/svg"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                strokeWidth="1.5"
+                                stroke="currentColor"
+                            >
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                            </svg>
+                        </button>
+                    </div>
+                    <nav
+                        id="primary-navigation"
+                        className={`${
+                            isNavOpen ? "flex" : "hidden"
+                        } flex-col items-stretch gap-2 pt-3 lg:flex lg:flex-row lg:flex-wrap lg:items-center lg:gap-2 lg:pt-0`}
+                    >
                         {navItems.map((item) => (
-                            <NavMenuItem key={item.path} item={item} layout="header" />
+                            <NavMenuItem key={item.path} item={item} layout="header" onNavigate={handleNavigate} />
                         ))}
                     </nav>
                 </div>


### PR DESCRIPTION
## Summary
- add a toggle button to the header navigation for mobile layouts
- collapse the navigation links into a panel that only opens when requested on small screens while preserving the desktop layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5143538a8832997903414b1465ac4