### PR TITLE
Add skip link and main region for routed pages

### DIFF
--- a/bellingham-frontend/src/components/Layout.jsx
+++ b/bellingham-frontend/src/components/Layout.jsx
@@ -4,12 +4,15 @@ import NotificationPopup from "./NotificationPopup";
 
 const Layout = ({ children, onLogout }) => (
     <div className="flex min-h-screen flex-col bg-slate-950 font-sans text-slate-100">
+        <a href="#main-content" className="skip-link">
+            Skip to main content
+        </a>
         <Header onLogout={onLogout} />
-        <div className="flex-1">
+        <main id="main-content" tabIndex="-1" className="flex-1">
             <div className="mx-auto w-full max-w-7xl px-6 py-8">
                 {children}
             </div>
-        </div>
+        </main>
         <NotificationPopup />
     </div>
 );

--- a/bellingham-frontend/src/index.css
+++ b/bellingham-frontend/src/index.css
@@ -28,6 +28,26 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+.skip-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateY(-120%);
+  padding: 0.75rem 1.25rem;
+  background-color: #0f172a;
+  color: #f8fafc;
+  font-weight: 600;
+  border-bottom-right-radius: 0.75rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.45);
+  transition: transform 0.2s ease;
+  z-index: 50;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+  transform: translateY(0);
+}
+
 h1 {
   font-size: 3.2em;
   line-height: 1.1;


### PR DESCRIPTION
## Summary
- add a visually-hidden skip-to-content link before the global header
- wrap layout content with a semantic main landmark targeted by the skip link
- introduce base styling so the skip link is visible when focused

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d51e3dc3348329b58c4f4053aec2f9