### PR TITLE
Add search controls to sold contracts table

### DIFF
--- a/bellingham-frontend/src/components/Sales.jsx
+++ b/bellingham-frontend/src/components/Sales.jsx
@@ -1,26 +1,33 @@
-import React, { useEffect, useState, useContext } from "react";
+import React, { useEffect, useState, useContext, useMemo } from "react";
 import Layout from "./Layout";
 import ContractDetailsPanel from "./ContractDetailsPanel";
 import { useNavigate } from "react-router-dom";
 import api from "../utils/api";
 import { AuthContext } from '../context';
+import TableSkeleton from "./ui/TableSkeleton";
 
 const Sales = () => {
     const navigate = useNavigate();
     const [contracts, setContracts] = useState([]);
     const [error, setError] = useState("");
     const [selectedContract, setSelectedContract] = useState(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [searchTerm, setSearchTerm] = useState("");
+    const [statusFilter, setStatusFilter] = useState("");
 
     const { logout } = useContext(AuthContext);
 
     useEffect(() => {
         const fetchSales = async () => {
             try {
+                setIsLoading(true);
                 const res = await api.get(`/api/contracts/sold`);
                 setContracts(res.data.content);
             } catch (err) {
                 console.error(err);
                 setError("Failed to load sold contracts.");
+            } finally {
+                setIsLoading(false);
             }
         };
         fetchSales();
@@ -30,6 +37,31 @@ const Sales = () => {
         logout();
         navigate("/login");
     };
+
+    const statuses = useMemo(
+        () =>
+            Array.from(
+                new Set(contracts.map((contract) => contract.status).filter(Boolean))
+            ),
+        [contracts]
+    );
+
+    const filteredContracts = useMemo(() => {
+        const normalizedSearch = searchTerm.trim().toLowerCase();
+
+        return contracts.filter((contract) => {
+            const matchesSearch =
+                !normalizedSearch ||
+                contract.title.toLowerCase().includes(normalizedSearch) ||
+                (contract.buyerUsername || "")
+                    .toLowerCase()
+                    .includes(normalizedSearch);
+
+            const matchesStatus = !statusFilter || contract.status === statusFilter;
+
+            return matchesSearch && matchesStatus;
+        });
+    }, [contracts, searchTerm, statusFilter]);
 
     return (
         <Layout onLogout={handleLogout}>
@@ -43,6 +75,35 @@ const Sales = () => {
                         </p>
                     </div>
                     {error && <p className="mt-4 text-sm text-red-400">{error}</p>}
+
+                    <div className="mt-6 grid gap-4 rounded-xl border border-slate-800 bg-slate-950/40 p-4 sm:grid-cols-2 lg:grid-cols-4">
+                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                            Search
+                            <input
+                                type="text"
+                                value={searchTerm}
+                                onChange={(event) => setSearchTerm(event.target.value)}
+                                placeholder="Title or buyer"
+                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-emerald-400 focus:outline-none"
+                            />
+                        </label>
+                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                            Status
+                            <select
+                                value={statusFilter}
+                                onChange={(event) => setStatusFilter(event.target.value)}
+                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-emerald-400 focus:outline-none"
+                            >
+                                <option value="">All Statuses</option>
+                                {statuses.map((status) => (
+                                    <option key={status} value={status}>
+                                        {status}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+                    </div>
+
                     <div className="mt-6 overflow-hidden rounded-xl border border-slate-800/80">
                         <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
                             <thead className="bg-slate-900/80 text-xs uppercase tracking-[0.18em] text-slate-400">
@@ -55,41 +116,49 @@ const Sales = () => {
                                 </tr>
                             </thead>
                             <tbody className="divide-y divide-slate-800/70">
-                                {contracts.map((c) => {
-                                    const isSelected = selectedContract?.id === c.id;
+                                {isLoading ? (
+                                    <TableSkeleton columns={5} rows={5} />
+                                ) : (
+                                    filteredContracts.map((c) => {
+                                        const isSelected = selectedContract?.id === c.id;
 
-                                    return (
-                                        <tr
-                                            key={c.id}
-                                            className={`group cursor-pointer transition-colors ${isSelected ? "bg-emerald-500/15" : "bg-slate-950/40 hover:bg-emerald-500/10"}`}
-                                            onClick={() => setSelectedContract(c)}
-                                            aria-selected={isSelected}
-                                        >
-                                            <td className="px-4 py-3 font-semibold text-slate-100">
-                                                <div className="flex items-center gap-2">
-                                                    {isSelected && (
-                                                        <span className="inline-flex items-center rounded-full border border-emerald-300/70 bg-emerald-500/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-emerald-100">
-                                                            Selected
-                                                        </span>
-                                                    )}
-                                                    <span>{c.title}</span>
-                                                </div>
-                                            </td>
-                                            <td className="px-4 py-3">{c.buyerUsername}</td>
-                                            <td className="px-4 py-3 font-semibold text-emerald-300">${c.price}</td>
-                                            <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
-                                            <td className="px-4 py-3">
-                                                <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-100">
-                                                    {c.status}
-                                                </span>
-                                            </td>
-                                        </tr>
-                                    );
-                                })}
-                                {contracts.length === 0 && (
+                                        return (
+                                            <tr
+                                                key={c.id}
+                                                className={`group cursor-pointer transition-colors ${
+                                                    isSelected
+                                                        ? "bg-emerald-500/15"
+                                                        : "bg-slate-950/40 hover:bg-emerald-500/10"
+                                                }`}
+                                                onClick={() => setSelectedContract(c)}
+                                                aria-selected={isSelected}
+                                            >
+                                                <td className="px-4 py-3 font-semibold text-slate-100">
+                                                    <div className="flex items-center gap-2">
+                                                        {isSelected && (
+                                                            <span className="inline-flex items-center rounded-full border border-emerald-300/70 bg-emerald-500/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-emerald-100">
+                                                                Selected
+                                                            </span>
+                                                        )}
+                                                        <span>{c.title}</span>
+                                                    </div>
+                                                </td>
+                                                <td className="px-4 py-3">{c.buyerUsername}</td>
+                                                <td className="px-4 py-3 font-semibold text-emerald-300">${c.price}</td>
+                                                <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
+                                                <td className="px-4 py-3">
+                                                    <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-100">
+                                                        {c.status}
+                                                    </span>
+                                                </td>
+                                            </tr>
+                                        );
+                                    })
+                                )}
+                                {!isLoading && filteredContracts.length === 0 && (
                                     <tr>
                                         <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
-                                            No sales have been recorded yet.
+                                            No contracts match your current filters.
                                         </td>
                                     </tr>
                                 )}


### PR DESCRIPTION
## Summary
- add quick search input and status dropdown to the sold contracts view
- derive available status options and filter the table rows based on the selected criteria
- show a loading skeleton while sales data is being fetched and update the empty state message

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5204eeddc8329973b7f084280fe76