### PR TITLE
Add contract details placeholder state

### DIFF
--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -239,6 +239,24 @@ const ContractDetailsPanel = ({
             .filter((section) => section.fields.length > 0);
     }, [contract]);
 
+    if (!contract && inline) {
+        return (
+            <div
+                className={`${inlineWidth} flex h-full items-center justify-center rounded-2xl border border-dashed border-slate-800/70 bg-slate-900/40 p-6 text-center text-slate-400`}
+            >
+                <div className="flex flex-col items-center gap-4">
+                    <DocumentTextIcon className="h-12 w-12 text-slate-600" />
+                    <div className="space-y-2">
+                        <h2 className="text-lg font-semibold text-slate-200">Select a contract</h2>
+                        <p className="max-w-xs text-sm text-slate-400">
+                            Choose a contract from the list to see its key dates, participants, and agreement details here.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
     if (!contract && !visible) return null;
 
     return (


### PR DESCRIPTION
## Summary
- render an inline placeholder card when no contract is selected in the details pane
- provide contextual messaging that prompts users to pick a contract to view details

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d528404a208329adfff7b71bcee133