### PR TITLE
Reduce logo footprint across UI

### DIFF
--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -62,7 +62,10 @@ const Login = () => {
                                 <img
                                     src={LoginImage}
                                     alt="Bellingham Data Futures logo"
-                                    className="h-16 w-16 rounded-xl border border-slate-700/70 bg-slate-950/60 p-3 shadow-lg"
+                                    className={[
+                                        "h-12 w-12 rounded-xl border border-slate-700/70 bg-slate-950/60 p-2 shadow-lg",
+                                        "sm:h-14 sm:w-14",
+                                    ].join(" ")}
                                 />
                                 <div>
                                     <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">

--- a/bellingham-frontend/src/components/Logo.jsx
+++ b/bellingham-frontend/src/components/Logo.jsx
@@ -4,13 +4,16 @@ import logoImage from "../assets/login.png";
 const Logo = () => {
     const isLogin = window.location.pathname === "/login";
     const style = isLogin ? { right: "calc(1rem + 10px)" } : {};
-    const sizeClass = isLogin ? "w-[180px] h-[180px]" : "w-[220px] h-[220px]";
+    const sizeClass = isLogin
+        ? "h-16 w-16 sm:h-20 sm:w-20 lg:h-24 lg:w-24"
+        : "h-10 w-10 sm:h-12 sm:w-12 lg:h-14 lg:w-14";
+    const positionClass = isLogin ? "bottom-6 right-6" : "bottom-4 right-4";
 
     return (
         <img
             src={logoImage}
-            alt="Logo"
-            className={`fixed bottom-4 right-4 ${sizeClass} pointer-events-none`}
+            alt="Bellingham Data Futures logo"
+            className={`fixed ${positionClass} ${sizeClass} pointer-events-none rounded-xl object-contain drop-shadow-lg`}
             style={style}
         />
     );


### PR DESCRIPTION
## Summary
- shrink the floating logo component so it uses responsive Tailwind sizing classes instead of large fixed dimensions
- lighten the login header logo with smaller default sizing while keeping responsive scaling and existing styling

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d530b54c9c832994472059b25f18fd