### PR TITLE
Reduce logo display size

### DIFF
--- a/bellingham-frontend/src/components/Logo.jsx
+++ b/bellingham-frontend/src/components/Logo.jsx
@@ -5,8 +5,8 @@ const Logo = () => {
     const isLogin = window.location.pathname === "/login";
     const style = isLogin ? { right: "calc(1rem + 10px)" } : {};
     const sizeClass = isLogin
-        ? "h-16 w-16 sm:h-20 sm:w-20 lg:h-24 lg:w-24"
-        : "h-10 w-10 sm:h-12 sm:w-12 lg:h-14 lg:w-14";
+        ? "h-12 w-12 sm:h-16 sm:w-16 lg:h-20 lg:w-20"
+        : "h-8 w-8 sm:h-10 sm:w-10 lg:h-12 lg:w-12";
     const positionClass = isLogin ? "bottom-6 right-6" : "bottom-4 right-4";
 
     return (


### PR DESCRIPTION
## Summary
- decrease default logo sizing for login and authenticated views to reduce on-screen footprint

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d53555a0188329993789379b3e5971