### PR TITLE
Shrink logo sizing across header and login

### DIFF
--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -28,7 +28,7 @@ const Header = ({ onLogout }) => {
                         <img
                             src={logoImage}
                             alt="Bellingham Data Futures logo"
-                            className="h-10 w-10 rounded-full border border-emerald-400/40 bg-slate-900/80 p-2 shadow-[0_6px_18px_rgba(16,185,129,0.25)] sm:h-11 sm:w-11 lg:h-12 lg:w-12"
+                            className="h-9 w-9 rounded-full border border-emerald-400/40 bg-slate-900/80 p-2 shadow-[0_6px_18px_rgba(16,185,129,0.25)] sm:h-10 sm:w-10"
                         />
                         <div className="hidden flex-col leading-tight sm:flex">
                             <span className="text-xs font-semibold uppercase tracking-[0.4em] text-emerald-200/80">

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -63,8 +63,8 @@ const Login = () => {
                                     src={LoginImage}
                                     alt="Bellingham Data Futures logo"
                                     className={[
-                                        "h-12 w-12 rounded-xl border border-slate-700/70 bg-slate-950/60 p-2 shadow-lg",
-                                        "sm:h-14 sm:w-14",
+                                        "h-9 w-9 rounded-xl border border-slate-700/70 bg-slate-950/60 p-2 shadow-lg",
+                                        "sm:h-10 sm:w-10",
                                     ].join(" ")}
                                 />
                                 <div>


### PR DESCRIPTION
## Summary
- reduce the authenticated header logo dimensions to the new smaller Tailwind sizes
- apply the same scaled-down sizing to the login badge image for visual consistency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d53911a888832997bf3eab8d3bb619