### PR TITLE
Reduce logo footprint across UI

### DIFF
--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -28,7 +28,7 @@ const Header = ({ onLogout }) => {
                         <img
                             src={logoImage}
                             alt="Bellingham Data Futures logo"
-                            className="h-9 w-9 rounded-full border border-emerald-400/40 bg-slate-900/80 p-2 shadow-[0_6px_18px_rgba(16,185,129,0.25)] sm:h-10 sm:w-10"
+                            className="h-8 w-8 rounded-full border border-emerald-400/40 bg-slate-900/80 p-1.5 shadow-[0_6px_18px_rgba(16,185,129,0.25)] sm:h-9 sm:w-9"
                         />
                         <div className="hidden flex-col leading-tight sm:flex">
                             <span className="text-xs font-semibold uppercase tracking-[0.4em] text-emerald-200/80">

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -63,8 +63,8 @@ const Login = () => {
                                     src={LoginImage}
                                     alt="Bellingham Data Futures logo"
                                     className={[
-                                        "h-9 w-9 rounded-xl border border-slate-700/70 bg-slate-950/60 p-2 shadow-lg",
-                                        "sm:h-10 sm:w-10",
+                                        "h-8 w-8 rounded-xl border border-slate-700/70 bg-slate-950/60 p-1.5 shadow-lg",
+                                        "sm:h-9 sm:w-9",
                                     ].join(" ")}
                                 />
                                 <div>

--- a/bellingham-frontend/src/components/Logo.jsx
+++ b/bellingham-frontend/src/components/Logo.jsx
@@ -5,9 +5,9 @@ const Logo = () => {
     const isLogin = window.location.pathname === "/login";
     const style = isLogin ? { right: "calc(1rem + 10px)" } : {};
     const sizeClass = isLogin
-        ? "h-12 w-12 sm:h-16 sm:w-16 lg:h-20 lg:w-20"
-        : "h-8 w-8 sm:h-10 sm:w-10 lg:h-12 lg:w-12";
-    const positionClass = isLogin ? "bottom-6 right-6" : "bottom-4 right-4";
+        ? "h-8 w-8 sm:h-10 sm:w-10 lg:h-12 lg:w-12"
+        : "h-6 w-6 sm:h-8 sm:w-8 lg:h-9 lg:w-9";
+    const positionClass = isLogin ? "bottom-5 right-5" : "bottom-3 right-3";
 
     return (
         <img


### PR DESCRIPTION
## Summary
- shrink the floating Logo component so it occupies less space across screen sizes
- reduce the header brand avatar footprint to better balance the navigation bar
- tighten the login welcome badge styling to match the smaller branding assets

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5540268e88329a22fa7d4991c6d58