### PR TITLE
Remove temporary logo usage

### DIFF
--- a/bellingham-frontend/src/__tests__/Logo.test.jsx
+++ b/bellingham-frontend/src/__tests__/Logo.test.jsx
@@ -1,10 +1,9 @@
 /* eslint-env jest */
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Logo from '../components/Logo';
 
-test('renders logo image', () => {
-  render(<Logo />);
-  const img = screen.getByAltText(/logo/i);
-  expect(img).toBeInTheDocument();
+test('renders nothing while logo is disabled', () => {
+  const { container } = render(<Logo />);
+  expect(container.firstChild).toBeNull();
 });

--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -2,7 +2,6 @@ import React, { useContext, useState } from "react";
 import { Link } from "react-router-dom";
 import { BellAlertIcon } from "@heroicons/react/24/outline";
 
-import logoImage from "../assets/login.png";
 import { AuthContext, useNotifications } from "../context";
 import navItems from "../config/navItems";
 import NavMenuItem from "./ui/NavMenuItem";
@@ -24,18 +23,11 @@ const Header = ({ onLogout }) => {
         <header className="relative z-20 border-b border-slate-800/70 bg-slate-950/95 shadow-[0_16px_40px_rgba(8,20,45,0.65)]">
             <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 py-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">
-                    <Link to="/" className="flex items-center gap-3">
-                        <img
-                            src={logoImage}
-                            alt="Bellingham Data Futures logo"
-                            className="h-8 w-8 rounded-full border border-emerald-400/40 bg-slate-900/80 p-1.5 shadow-[0_6px_18px_rgba(16,185,129,0.25)] sm:h-9 sm:w-9"
-                        />
-                        <div className="hidden flex-col leading-tight sm:flex">
-                            <span className="text-xs font-semibold uppercase tracking-[0.4em] text-emerald-200/80">
-                                Bellingham
-                            </span>
-                            <span className="text-lg font-semibold text-white">Markets Platform</span>
-                        </div>
+                    <Link to="/" className="flex flex-col leading-tight">
+                        <span className="text-xs font-semibold uppercase tracking-[0.4em] text-emerald-200/80">
+                            Bellingham
+                        </span>
+                        <span className="text-lg font-semibold text-white">Markets Platform</span>
                     </Link>
                     <div className="flex items-center gap-4">
                         <Link

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
-import LoginImage from "../assets/login.png";
 import Button from "./ui/Button";
 import api from "../utils/api";
 import { AuthContext } from "../context";
@@ -58,23 +57,13 @@ const Login = () => {
                     </div>
                     <div className="relative grid gap-12 p-10 md:grid-cols-2 lg:p-16">
                         <div className="flex flex-col justify-between gap-8">
-                            <div className="flex items-center gap-4">
-                                <img
-                                    src={LoginImage}
-                                    alt="Bellingham Data Futures logo"
-                                    className={[
-                                        "h-8 w-8 rounded-xl border border-slate-700/70 bg-slate-950/60 p-1.5 shadow-lg",
-                                        "sm:h-9 sm:w-9",
-                                    ].join(" ")}
-                                />
-                                <div>
-                                    <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">
-                                        Bellingham Data Futures
-                                    </p>
-                                    <h1 className="text-3xl font-semibold text-slate-50 sm:text-4xl">
-                                        Welcome back.
-                                    </h1>
-                                </div>
+                            <div>
+                                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">
+                                    Bellingham Data Futures
+                                </p>
+                                <h1 className="text-3xl font-semibold text-slate-50 sm:text-4xl">
+                                    Welcome back.
+                                </h1>
                             </div>
                             <div className="space-y-4 text-slate-300">
                                 <p className="text-base leading-relaxed">

--- a/bellingham-frontend/src/components/Logo.jsx
+++ b/bellingham-frontend/src/components/Logo.jsx
@@ -1,22 +1,4 @@
 import React from "react";
-import logoImage from "../assets/login.png";
-
-const Logo = () => {
-    const isLogin = window.location.pathname === "/login";
-    const style = isLogin ? { right: "calc(1rem + 10px)" } : {};
-    const sizeClass = isLogin
-        ? "h-8 w-8 sm:h-10 sm:w-10 lg:h-12 lg:w-12"
-        : "h-6 w-6 sm:h-8 sm:w-8 lg:h-9 lg:w-9";
-    const positionClass = isLogin ? "bottom-5 right-5" : "bottom-3 right-3";
-
-    return (
-        <img
-            src={logoImage}
-            alt="Bellingham Data Futures logo"
-            className={`fixed ${positionClass} ${sizeClass} pointer-events-none rounded-xl object-contain drop-shadow-lg`}
-            style={style}
-        />
-    );
-};
+const Logo = () => null;
 
 export default Logo;


### PR DESCRIPTION
## Summary
- remove the logo image from the login screen header copy to avoid displaying outdated branding
- update the shared Logo component to render nothing while disabled and adjust its test coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d557e53b4c8329a103e2786f59b5e6