### PR TITLE
Remove icons from main navigation

### DIFF
--- a/bellingham-frontend/src/components/ui/NavMenuItem.jsx
+++ b/bellingham-frontend/src/components/ui/NavMenuItem.jsx
@@ -3,9 +3,9 @@ import { NavLink } from "react-router-dom";
 
 const baseClasses = {
     header:
-        "group relative inline-flex items-center gap-2 rounded-lg px-4 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.18em] transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400",
+        "group relative inline-flex rounded-lg px-4 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.18em] transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400",
     sidebar:
-        "group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900",
+        "group flex rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900",
 };
 
 const activeClasses = {
@@ -20,21 +20,8 @@ const inactiveClasses = {
     sidebar: "text-slate-200 hover:bg-slate-800/70",
 };
 
-const iconClasses = {
-    header: {
-        base: "h-4 w-4 transition-colors duration-200",
-        active: "text-emerald-200",
-        inactive: "text-emerald-300/80",
-    },
-    sidebar: {
-        base: "h-5 w-5 text-emerald-300",
-        active: "",
-        inactive: "",
-    },
-};
-
 const NavMenuItem = ({ item, layout = "header", onNavigate }) => {
-    const { path, label, icon: Icon } = item;
+    const { path, label } = item;
 
     return (
         <NavLink
@@ -46,17 +33,7 @@ const NavMenuItem = ({ item, layout = "header", onNavigate }) => {
                 `${baseClasses[layout]} ${isActive ? activeClasses[layout] : inactiveClasses[layout]}`
             }
         >
-            {({ isActive }) => (
-                <>
-                    {Icon && (
-                        <Icon
-                            aria-hidden="true"
-                            className={`${iconClasses[layout].base} ${isActive ? iconClasses[layout].active : iconClasses[layout].inactive}`}
-                        />
-                    )}
-                    <span>{label}</span>
-                </>
-            )}
+            {() => <span>{label}</span>}
         </NavLink>
     );
 };

--- a/bellingham-frontend/src/config/navItems.js
+++ b/bellingham-frontend/src/config/navItems.js
@@ -1,27 +1,14 @@
-import {
-    BellAlertIcon,
-    CalendarDaysIcon,
-    ChartBarIcon,
-    ClockIcon,
-    Cog6ToothIcon,
-    CurrencyDollarIcon,
-    DocumentMagnifyingGlassIcon,
-    HomeIcon,
-    ShoppingCartIcon,
-    UserCircleIcon,
-} from "@heroicons/react/24/outline";
-
 const navItems = [
-    { path: "/", label: "Home", icon: HomeIcon },
-    { path: "/buy", label: "Buy", icon: ShoppingCartIcon },
-    { path: "/reports", label: "Reports", icon: DocumentMagnifyingGlassIcon },
-    { path: "/sell", label: "Sell", icon: CurrencyDollarIcon },
-    { path: "/sales", label: "Sales", icon: ChartBarIcon },
-    { path: "/calendar", label: "Calendar", icon: CalendarDaysIcon },
-    { path: "/history", label: "History", icon: ClockIcon },
-    { path: "/settings", label: "Settings", icon: Cog6ToothIcon },
-    { path: "/account", label: "Account", icon: UserCircleIcon },
-    { path: "/notifications", label: "Notifications", icon: BellAlertIcon },
+    { path: "/", label: "Home" },
+    { path: "/buy", label: "Buy" },
+    { path: "/reports", label: "Reports" },
+    { path: "/sell", label: "Sell" },
+    { path: "/sales", label: "Sales" },
+    { path: "/calendar", label: "Calendar" },
+    { path: "/history", label: "History" },
+    { path: "/settings", label: "Settings" },
+    { path: "/account", label: "Account" },
+    { path: "/notifications", label: "Notifications" },
 ];
 
 export default navItems;


### PR DESCRIPTION
## Summary
- remove icon references from the navigation item configuration so the main menu no longer displays logos
- simplify the shared navigation menu item component to render text-only links across the header and sidebar

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d56b5603c88329821beddec9e227aa