### PR TITLE
feat: apply deep navy base theme

### DIFF
--- a/bellingham-frontend/src/components/Layout.jsx
+++ b/bellingham-frontend/src/components/Layout.jsx
@@ -3,7 +3,13 @@ import Header from "./Header";
 import NotificationPopup from "./NotificationPopup";
 
 const Layout = ({ children, onLogout }) => (
-    <div className="flex min-h-screen flex-col bg-slate-950 font-sans text-slate-100">
+    <div
+        className="flex min-h-screen flex-col font-sans text-contrast"
+        style={{
+            backgroundColor: 'var(--bg-color)',
+            backgroundImage: 'var(--bg-gradient)',
+        }}
+    >
         <a href="#main-content" className="skip-link">
             Skip to main content
         </a>

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -48,7 +48,13 @@ const Login = () => {
         : "border-slate-700/80 focus:border-sky-400 focus:ring-sky-500/50";
 
     return (
-        <div className="min-h-screen bg-slate-950 text-slate-100">
+        <div
+            className="min-h-screen text-contrast"
+            style={{
+                backgroundColor: 'var(--bg-color)',
+                backgroundImage: 'var(--bg-gradient)',
+            }}
+        >
             <div className="mx-auto flex min-h-screen w-full max-w-6xl items-center justify-center px-6 py-16">
                 <div className="relative w-full overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/70 shadow-[0_40px_80px_-20px_rgba(15,23,42,0.9)] backdrop-blur">
                     <div className="pointer-events-none absolute inset-0 opacity-60" aria-hidden="true">

--- a/bellingham-frontend/src/components/Signup.jsx
+++ b/bellingham-frontend/src/components/Signup.jsx
@@ -269,7 +269,13 @@ const Signup = () => {
     };
 
     return (
-        <div className="flex flex-col min-h-screen bg-base text-contrast font-sans">
+        <div
+            className="flex flex-col min-h-screen text-contrast font-sans"
+            style={{
+                backgroundColor: 'var(--bg-color)',
+                backgroundImage: 'var(--bg-gradient)',
+            }}
+        >
             <Header />
             <div className="relative flex flex-col flex-1 items-center justify-center">
                 <Button

--- a/bellingham-frontend/src/index.css
+++ b/bellingham-frontend/src/index.css
@@ -3,8 +3,11 @@
 @tailwind utilities;
 
 :root {
-  --bg-color: #000;
-  --text-color: #fff;
+  --bg-color: #0d1b2a;
+  --bg-surface: #1b263b;
+  --bg-gradient: linear-gradient(160deg, #0d1b2a 0%, #1b263b 100%);
+  --text-color: #e0e6ed;
+  --focus-ring: rgba(119, 141, 169, 0.65);
 }
 
 a {
@@ -18,6 +21,8 @@ body {
   min-width: 320px;
   min-height: 100vh;
   background-color: var(--bg-color);
+  background-image: var(--bg-gradient);
+  background-attachment: fixed;
   color: var(--text-color);
   font-family: 'Inter', sans-serif;
   line-height: 1.5;
@@ -34,11 +39,11 @@ body {
   left: 0;
   transform: translateY(-120%);
   padding: 0.75rem 1.25rem;
-  background-color: #0f172a;
-  color: #f8fafc;
+  background-color: rgba(27, 38, 59, 0.95);
+  color: var(--text-color);
   font-weight: 600;
   border-bottom-right-radius: 0.75rem;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.45);
+  box-shadow: 0 10px 30px rgba(13, 27, 42, 0.45);
   transition: transform 0.2s ease;
   z-index: 50;
 }
@@ -55,34 +60,41 @@ h1 {
 
 button {
   border-radius: 8px;
-  border: 1px solid transparent;
+  border: 1px solid rgba(119, 141, 169, 0.35);
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
-  color: #fff;
+  background-color: rgba(27, 38, 59, 0.85);
+  color: var(--text-color);
+  box-shadow: 0 15px 35px rgba(13, 27, 42, 0.35);
   cursor: pointer;
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: #778da9;
+  background-color: rgba(27, 38, 59, 0.95);
 }
 button:focus,
 button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 @media (prefers-color-scheme: light) {
   :root {
-    --bg-color: #ffffff;
-    --text-color: #213547;
+    --bg-color: #f5f7fa;
+    --bg-surface: #e4ebf7;
+    --bg-gradient: linear-gradient(160deg, #f5f7fa 0%, #dfe7f5 100%);
+    --text-color: #1b263b;
+    --focus-ring: rgba(29, 78, 216, 0.55);
   }
   a:hover {
-    color: #747bff;
+    color: #1d4ed8;
   }
   button {
-    background-color: #f9f9f9;
-    color: #fff;
+    background-color: #1b263b;
+    color: #e0e6ed;
+    border-color: rgba(119, 141, 169, 0.45);
   }
 }

--- a/bellingham-frontend/tailwind.config.js
+++ b/bellingham-frontend/tailwind.config.js
@@ -6,8 +6,9 @@ export default {
   theme: {
     extend: {
       colors: {
-        base: '#000',
-        contrast: '#fff',
+        base: '#0d1b2a',
+        surface: '#1b263b',
+        contrast: '#e0e6ed',
         primary: '#1d4ed8',
         secondary: '#3b82f6',
         accent: '#ef4444'


### PR DESCRIPTION
## Summary
- establish a deep navy-to-slate base palette in Tailwind to support the nighttime trading-floor aesthetic
- update global styles with a gradient background, refreshed contrasts, and complementary control treatments
- ensure layout and auth screens pull from the shared background variables for consistent ambience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d570fa6fac8329bf4f80cd99472f46