### PR TITLE
Apply cyan and magenta accent styling

### DIFF
--- a/bellingham-frontend/src/__tests__/Button.test.jsx
+++ b/bellingham-frontend/src/__tests__/Button.test.jsx
@@ -11,7 +11,7 @@ test('applies variant classes', () => {
       <Button variant="ghost">Ghost</Button>
     </div>
   );
-  expect(screen.getByText('Primary')).toHaveClass('bg-blue-600');
+  expect(screen.getByText('Primary')).toHaveClass('bg-[#00D1FF]');
   expect(screen.getByText('Danger')).toHaveClass('bg-red-600');
   expect(screen.getByText('Ghost')).toHaveClass('bg-gray-600');
 });

--- a/bellingham-frontend/src/components/Account.jsx
+++ b/bellingham-frontend/src/components/Account.jsx
@@ -6,7 +6,7 @@ import api from "../utils/api";
 import { AuthContext } from '../context';
 
 const inputClasses =
-    "mt-1 w-full rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-emerald-400 focus:outline-none";
+    "mt-1 w-full rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none";
 const labelClasses = "block text-xs font-semibold uppercase tracking-[0.18em] text-slate-400";
 
 const Account = () => {
@@ -96,7 +96,7 @@ const Account = () => {
         <Layout onLogout={handleLogout}>
             <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
                 <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300/80">Profile</p>
+                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Profile</p>
                     <h1 className="text-3xl font-bold text-white">Account Details</h1>
                     <p className="text-sm text-slate-400">
                         Review and maintain your organisation information used across settlements and compliance processes.

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -119,7 +119,7 @@ const Buy = () => {
             <div className="flex flex-col gap-6 xl:flex-row">
                 <section className="flex-1 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
                     <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300/80">Trading Desk</p>
+                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Trading Desk</p>
                         <h1 className="text-3xl font-bold text-white">Available Contracts</h1>
                         <p className="text-sm text-slate-400">
                             Filter by counterparty, price range, or search by keyword to identify the right purchase opportunity.
@@ -145,7 +145,7 @@ const Buy = () => {
                                 placeholder="Title or seller"
                                 value={search}
                                 onChange={(e) => setSearch(e.target.value)}
-                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-emerald-400 focus:outline-none"
+                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
                             />
                         </label>
                         <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
@@ -155,7 +155,7 @@ const Buy = () => {
                                 placeholder="0"
                                 value={minPrice}
                                 onChange={(e) => setMinPrice(e.target.value)}
-                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-emerald-400 focus:outline-none"
+                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
                             />
                         </label>
                         <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
@@ -165,7 +165,7 @@ const Buy = () => {
                                 placeholder="0"
                                 value={maxPrice}
                                 onChange={(e) => setMaxPrice(e.target.value)}
-                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-emerald-400 focus:outline-none"
+                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
                             />
                         </label>
                         <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
@@ -173,7 +173,7 @@ const Buy = () => {
                             <select
                                 value={sellerFilter}
                                 onChange={(e) => setSellerFilter(e.target.value)}
-                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-emerald-400 focus:outline-none"
+                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
                             >
                                 <option value="">All Sellers</option>
                                 {sellers.map((s) => (
@@ -204,12 +204,12 @@ const Buy = () => {
                                         {filteredContracts.map((contract) => (
                                             <tr
                                                 key={contract.id}
-                                                className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-emerald-500/10"
+                                                className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-[#00D1FF]/10"
                                                 onClick={() => setSelectedContract(contract)}
                                             >
                                                 <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
                                                 <td className="px-4 py-3">{contract.seller}</td>
-                                                <td className="px-4 py-3 font-semibold text-emerald-300">${contract.price}</td>
+                                                <td className="px-4 py-3 font-semibold text-[#FF4D9B]">${contract.price}</td>
                                                 <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
                                                 <td className="px-4 py-3">
                                                     <Button

--- a/bellingham-frontend/src/components/Calendar.jsx
+++ b/bellingham-frontend/src/components/Calendar.jsx
@@ -7,8 +7,8 @@ import api from "../utils/api";
 import { AuthContext } from '../context';
 
 const TYPE_INFO = {
-    Bought: { color: "bg-emerald-400", initial: "B" },
-    Ends: { color: "bg-amber-400", initial: "E" },
+    Bought: { color: "bg-[#00D1FF]", initial: "B" },
+    Ends: { color: "bg-[#FF4D9B]", initial: "E" },
 };
 
 const ContractCalendar = () => {
@@ -89,7 +89,7 @@ const ContractCalendar = () => {
         <Layout onLogout={handleLogout}>
             <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
                 <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300/80">Operations</p>
+                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Operations</p>
                     <h1 className="text-3xl font-bold text-white">Contract Calendar</h1>
                     <p className="text-sm text-slate-400">
                         Visualise purchase and delivery events to plan workloads, handovers, and client communications.

--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -11,10 +11,10 @@ import Button from "./ui/Button";
 import api from "../utils/api";
 
 const STATUS_STYLES = {
-    open: "border-emerald-400/50 bg-emerald-500/15 text-emerald-100",
-    purchased: "border-sky-400/40 bg-sky-500/15 text-sky-100",
+    open: "border-[#00D1FF]/50 bg-[#00D1FF]/10 text-[#00D1FF]",
+    purchased: "border-[#FF4D9B]/50 bg-[#FF4D9B]/10 text-[#FF4D9B]",
     closed: "border-slate-500/40 bg-slate-600/10 text-slate-200",
-    default: "border-amber-400/40 bg-amber-500/15 text-amber-100",
+    default: "border-[#FF4D9B]/50 bg-[#FF4D9B]/10 text-[#FF4D9B]",
 };
 
 const formatCurrency = (value) => {
@@ -298,7 +298,7 @@ const ContractDetailsPanel = ({
             <div className="mt-4 flex flex-col gap-6 text-sm text-slate-300">
                 <div className="flex flex-wrap gap-2">
                     <Button
-                        className="border border-emerald-400/50 bg-emerald-500/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-100 hover:bg-emerald-500/20"
+                        className="border border-[#FF4D9B]/50 bg-[#FF4D9B]/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-[#FF4D9B] hover:bg-[#FF4D9B]/20"
                         onClick={handleDownload}
                     >
                         Download PDF

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -85,7 +85,7 @@ const Dashboard = () => {
             <div className="flex flex-col gap-6 xl:flex-row">
                 <main className="flex-1 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
                     <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300/80">Market Overview</p>
+                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Market Overview</p>
                         <h2 className="text-3xl font-bold text-white">Open Contracts</h2>
                         <p className="text-sm text-slate-400">
                             Monitor current opportunities and select a contract to inspect the full trade details.
@@ -103,22 +103,22 @@ const Dashboard = () => {
                             <>
                                 <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4 shadow-inner">
                                     <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Open Contracts</p>
-                                    <p className="mt-3 text-3xl font-bold text-white">{formatNumber(kpis.openContracts)}</p>
+                                    <p className="mt-3 text-3xl font-bold text-[#00D1FF]">{formatNumber(kpis.openContracts)}</p>
                                     <p className="mt-1 text-xs text-slate-500">Currently listed opportunities</p>
                                 </div>
                                 <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4 shadow-inner">
                                     <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Total Ask Volume</p>
-                                    <p className="mt-3 text-3xl font-bold text-emerald-300">{formatCurrency(kpis.totalVolume)}</p>
+                                    <p className="mt-3 text-3xl font-bold text-[#FF4D9B]">{formatCurrency(kpis.totalVolume)}</p>
                                     <p className="mt-1 text-xs text-slate-500">Aggregate notional value</p>
                                 </div>
                                 <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4 shadow-inner">
                                     <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Average Ask</p>
-                                    <p className="mt-3 text-3xl font-bold text-white">{formatCurrency(kpis.averageAsk)}</p>
+                                    <p className="mt-3 text-3xl font-bold text-[#00D1FF]">{formatCurrency(kpis.averageAsk)}</p>
                                     <p className="mt-1 text-xs text-slate-500">Mean price across open listings</p>
                                 </div>
                                 <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4 shadow-inner">
                                     <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Active Sellers</p>
-                                    <p className="mt-3 text-3xl font-bold text-white">{formatNumber(kpis.activeSellers)}</p>
+                                    <p className="mt-3 text-3xl font-bold text-[#FF4D9B]">{formatNumber(kpis.activeSellers)}</p>
                                     <p className="mt-1 text-xs text-slate-500">Distinct market participants</p>
                                 </div>
                             </>
@@ -143,16 +143,16 @@ const Dashboard = () => {
                                         {contracts.map((contract) => (
                                             <tr
                                                 key={contract.id}
-                                                className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-emerald-500/10"
+                                                className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-[#00D1FF]/10"
                                                 onClick={() => setSelectedContract(contract)}
                                             >
                                                 <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
                                                 <td className="px-4 py-3">{contract.seller}</td>
-                                                <td className="px-4 py-3 font-semibold text-emerald-300">
+                                                <td className="px-4 py-3 font-semibold text-[#FF4D9B]">
                                                     ${contract.price}
                                                 </td>
                                                 <td className="px-4 py-3">
-                                                    <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-100">
+                                                    <span className="rounded-full border border-[#00D1FF]/40 bg-[#00D1FF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#00D1FF]">
                                                         {contract.status}
                                                     </span>
                                                 </td>

--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -24,7 +24,7 @@ const Header = ({ onLogout }) => {
             <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 py-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                     <Link to="/" className="flex flex-col leading-tight">
-                        <span className="text-xs font-semibold uppercase tracking-[0.4em] text-emerald-200/80">
+                        <span className="text-xs font-semibold uppercase tracking-[0.4em] text-[#00D1FF]/80">
                             Bellingham
                         </span>
                         <span className="text-lg font-semibold text-white">Markets Platform</span>
@@ -32,7 +32,7 @@ const Header = ({ onLogout }) => {
                     <div className="flex items-center gap-4">
                         <Link
                             to="/notifications"
-                            className="relative flex h-10 w-10 items-center justify-center rounded-full border border-emerald-400/40 bg-slate-900/80 text-emerald-100 shadow-[0_6px_18px_rgba(16,185,129,0.25)] transition-colors hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+                            className="relative flex h-10 w-10 items-center justify-center rounded-full border border-[#00D1FF]/40 bg-slate-900/80 text-[#00D1FF] shadow-[0_6px_18px_rgba(0,209,255,0.3)] transition-colors hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]"
                             aria-label={
                                 unreadCount > 0
                                     ? `${unreadCount} unread notifications`
@@ -42,7 +42,7 @@ const Header = ({ onLogout }) => {
                             <BellAlertIcon aria-hidden="true" className="h-5 w-5" />
                             <span className="sr-only">Open notifications</span>
                             {unreadCount > 0 && (
-                                <span className="absolute -right-1 -top-1 min-w-[1.5rem] rounded-full bg-emerald-400 px-1.5 py-0.5 text-center text-[0.65rem] font-semibold leading-none text-slate-950 shadow-lg">
+                                <span className="absolute -right-1 -top-1 min-w-[1.5rem] rounded-full bg-[#FF4D9B] px-1.5 py-0.5 text-center text-[0.65rem] font-semibold leading-none text-slate-950 shadow-lg">
                                     {unreadCount > 99 ? "99+" : unreadCount}
                                 </span>
                             )}
@@ -60,7 +60,7 @@ const Header = ({ onLogout }) => {
                                     <button
                                         type="button"
                                         onClick={onLogout}
-                                        className="rounded-lg border border-emerald-400/50 bg-emerald-500/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-emerald-100 transition-colors hover:bg-emerald-500/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+                                        className="rounded-lg border border-[#FF4D9B]/50 bg-[#FF4D9B]/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-[#FF4D9B] transition-colors hover:bg-[#FF4D9B]/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]"
                                     >
                                         Log Out
                                     </button>
@@ -80,7 +80,7 @@ const Header = ({ onLogout }) => {
                             onClick={toggleNavigation}
                             aria-expanded={isNavOpen}
                             aria-controls="primary-navigation"
-                            className="inline-flex items-center gap-2 rounded-lg border border-emerald-400/40 bg-slate-900/80 px-3 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.26em] text-emerald-100 transition-colors hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+                            className="inline-flex items-center gap-2 rounded-lg border border-[#00D1FF]/40 bg-slate-900/80 px-3 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.26em] text-[#00D1FF] transition-colors hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]"
                         >
                             <span>{isNavOpen ? "Close" : "Menu"}</span>
                             <svg

--- a/bellingham-frontend/src/components/History.jsx
+++ b/bellingham-frontend/src/components/History.jsx
@@ -36,7 +36,7 @@ const History = () => {
             <div className="flex flex-col gap-6 xl:flex-row">
                 <section className="flex-1 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
                     <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300/80">Audit Trail</p>
+                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Audit Trail</p>
                         <h1 className="text-3xl font-bold text-white">Contract History</h1>
                         <p className="text-sm text-slate-400">
                             A complete ledger of executed contracts across the platform with buyer and seller visibility.
@@ -58,13 +58,13 @@ const History = () => {
                                 {contracts.map((c) => (
                                     <tr
                                         key={c.id}
-                                        className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-emerald-500/10"
+                                        className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-[#00D1FF]/10"
                                         onClick={() => setSelectedContract(c)}
                                     >
                                         <td className="px-4 py-3 font-semibold text-slate-100">{c.title}</td>
                                         <td className="px-4 py-3">{c.seller}</td>
                                         <td className="px-4 py-3">{c.buyerUsername || "-"}</td>
-                                        <td className="px-4 py-3 font-semibold text-emerald-300">${c.price}</td>
+                                        <td className="px-4 py-3 font-semibold text-[#FF4D9B]">${c.price}</td>
                                         <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
                                     </tr>
                                 ))}

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -45,7 +45,7 @@ const Login = () => {
         "w-full rounded-lg border bg-slate-900/70 px-4 py-3 text-slate-100 placeholder:text-slate-500 transition-colors focus:outline-none focus:ring-2";
     const inputStateClasses = authError
         ? "border-red-500/70 focus:border-red-400 focus:ring-red-500/40"
-        : "border-slate-700/80 focus:border-sky-400 focus:ring-sky-500/50";
+        : "border-slate-700/80 focus:border-[#00D1FF] focus:ring-[#00D1FF]/40";
 
     return (
         <div
@@ -58,8 +58,8 @@ const Login = () => {
             <div className="mx-auto flex min-h-screen w-full max-w-6xl items-center justify-center px-6 py-16">
                 <div className="relative w-full overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/70 shadow-[0_40px_80px_-20px_rgba(15,23,42,0.9)] backdrop-blur">
                     <div className="pointer-events-none absolute inset-0 opacity-60" aria-hidden="true">
-                        <div className="absolute -left-24 -top-24 h-72 w-72 rounded-full bg-blue-600/40 blur-3xl" />
-                        <div className="absolute -bottom-32 -right-20 h-80 w-80 rounded-full bg-cyan-400/30 blur-3xl" />
+                        <div className="absolute -left-24 -top-24 h-72 w-72 rounded-full bg-[#00D1FF]/30 blur-3xl" />
+                        <div className="absolute -bottom-32 -right-20 h-80 w-80 rounded-full bg-[#FF4D9B]/25 blur-3xl" />
                     </div>
                     <div className="relative grid gap-12 p-10 md:grid-cols-2 lg:p-16">
                         <div className="flex flex-col justify-between gap-8">
@@ -78,15 +78,15 @@ const Login = () => {
                                 </p>
                                 <ul className="space-y-3 text-sm text-slate-400">
                                     <li className="flex items-start gap-3">
-                                        <span className="mt-1 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-blue-400" />
+                                        <span className="mt-1 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[#00D1FF]" />
                                         <span>Track portfolio performance with high-contrast visualisations.</span>
                                     </li>
                                     <li className="flex items-start gap-3">
-                                        <span className="mt-1 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-cyan-400" />
+                                        <span className="mt-1 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[#FF4D9B]" />
                                         <span>Coordinate bids and settlements securely from a single control room.</span>
                                     </li>
                                     <li className="flex items-start gap-3">
-                                        <span className="mt-1 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-emerald-400" />
+                                        <span className="mt-1 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-white/80" />
                                         <span>Receive proactive alerts before market deadlines hit.</span>
                                     </li>
                                 </ul>
@@ -96,7 +96,7 @@ const Login = () => {
                                 <button
                                     type="button"
                                     onClick={() => navigate("/signup")}
-                                    className="font-medium text-sky-400 transition hover:text-sky-300"
+                                    className="font-medium text-[#00D1FF] transition hover:text-[#FF4D9B]"
                                 >
                                     Request access
                                 </button>
@@ -161,13 +161,13 @@ const Login = () => {
                                     </button>
                                 </div>
                             </div>
-                            <Button type="submit" className="w-full rounded-lg py-3 text-base font-semibold shadow-lg shadow-sky-500/20" variant="primary">
+                            <Button type="submit" className="w-full rounded-lg py-3 text-base font-semibold shadow-lg shadow-[#00D1FF]/30" variant="primary">
                                 Sign In
                             </Button>
                             <Button
                                 type="button"
                                 variant="link"
-                                className="text-center text-sm text-sky-300 hover:text-sky-200"
+                                className="text-center text-sm text-[#00D1FF] hover:text-[#FF4D9B]"
                                 onClick={() => navigate("/signup")}
                             >
                                 Create Account

--- a/bellingham-frontend/src/components/NotificationBanner.jsx
+++ b/bellingham-frontend/src/components/NotificationBanner.jsx
@@ -3,7 +3,7 @@ import Button from './ui/Button';
 
 const styles = {
   info: 'bg-slate-900/80 text-slate-100 border-slate-700/80',
-  success: 'bg-emerald-900/80 text-emerald-100 border-emerald-700/80',
+  success: 'bg-[#00D1FF]/10 text-[#00D1FF] border-[#00D1FF]/40',
   error: 'bg-rose-900/80 text-rose-100 border-rose-700/80',
   warning: 'bg-amber-900/80 text-amber-100 border-amber-700/80',
 };

--- a/bellingham-frontend/src/components/Notifications.jsx
+++ b/bellingham-frontend/src/components/Notifications.jsx
@@ -33,7 +33,7 @@ const Notifications = () => {
             <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
                 <div className="flex flex-col gap-4 border-b border-slate-800 pb-4 md:flex-row md:items-center md:justify-between">
                     <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300/80">Inbox</p>
+                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Inbox</p>
                         <h1 className="text-3xl font-bold text-white">Notifications</h1>
                         <p className="text-sm text-slate-400">
                             Review trade events, approvals, and operational alerts from across the platform.

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -302,7 +302,7 @@ const Reports = () => {
             <div className="flex flex-col gap-6 xl:flex-row">
                 <section className="flex-1 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
                     <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300/80">Analytics</p>
+                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Analytics</p>
                         <h1 className="text-3xl font-bold text-white">Purchased Contracts</h1>
                         <p className="text-sm text-slate-400">
                             Track portfolio allocation, performance, and lifecycle events across your acquired contracts.
@@ -314,7 +314,7 @@ const Reports = () => {
                         <div className="rounded-2xl border border-slate-800 bg-slate-950/40 p-6">
                             {isLoading ? (
                                 <div className="flex h-72 items-center justify-center lg:h-96">
-                                    <div className="h-12 w-12 animate-spin rounded-full border-2 border-emerald-400 border-t-transparent" />
+                                    <div className="h-12 w-12 animate-spin rounded-full border-2 border-[#00D1FF] border-t-transparent" />
                                 </div>
                             ) : contracts.length ? (
                                 <div className="flex flex-col gap-6 lg:flex-row">
@@ -412,12 +412,12 @@ const Reports = () => {
                                             {contracts.map((contract) => (
                                                 <tr
                                                     key={contract.id}
-                                                    className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-emerald-500/10"
+                                                    className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-[#00D1FF]/10"
                                                     onClick={() => setSelectedContract(contract)}
                                                 >
                                                     <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
                                                     <td className="px-4 py-3">{contract.seller}</td>
-                                                    <td className="px-4 py-3 font-semibold text-emerald-300">${contract.price}</td>
+                                                    <td className="px-4 py-3 font-semibold text-[#FF4D9B]">${contract.price}</td>
                                                     <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
                                                     <td className="px-4 py-3">
                                                         <div className="flex flex-wrap gap-2">
@@ -457,7 +457,7 @@ const Reports = () => {
                             </table>
                         </div>
 
-                        <p className="text-lg font-semibold text-emerald-200">
+                        <p className="text-lg font-semibold text-[#00D1FF]">
                             Portfolio Value ${totalValue.toFixed(2)}
                         </p>
                     </div>

--- a/bellingham-frontend/src/components/Sales.jsx
+++ b/bellingham-frontend/src/components/Sales.jsx
@@ -68,7 +68,7 @@ const Sales = () => {
             <div className="flex flex-col gap-6 xl:flex-row">
                 <section className="flex-1 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
                     <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300/80">Seller Desk</p>
+                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Seller Desk</p>
                         <h1 className="text-3xl font-bold text-white">Sold Contracts</h1>
                         <p className="text-sm text-slate-400">
                             Review recently executed sales and revisit the associated contract data for compliance.
@@ -84,7 +84,7 @@ const Sales = () => {
                                 value={searchTerm}
                                 onChange={(event) => setSearchTerm(event.target.value)}
                                 placeholder="Title or buyer"
-                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-emerald-400 focus:outline-none"
+                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
                             />
                         </label>
                         <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
@@ -92,7 +92,7 @@ const Sales = () => {
                             <select
                                 value={statusFilter}
                                 onChange={(event) => setStatusFilter(event.target.value)}
-                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-emerald-400 focus:outline-none"
+                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
                             >
                                 <option value="">All Statuses</option>
                                 {statuses.map((status) => (
@@ -127,8 +127,8 @@ const Sales = () => {
                                                 key={c.id}
                                                 className={`group cursor-pointer transition-colors ${
                                                     isSelected
-                                                        ? "bg-emerald-500/15"
-                                                        : "bg-slate-950/40 hover:bg-emerald-500/10"
+                                                        ? "bg-[#00D1FF]/15"
+                                                        : "bg-slate-950/40 hover:bg-[#FF4D9B]/10"
                                                 }`}
                                                 onClick={() => setSelectedContract(c)}
                                                 aria-selected={isSelected}
@@ -136,7 +136,7 @@ const Sales = () => {
                                                 <td className="px-4 py-3 font-semibold text-slate-100">
                                                     <div className="flex items-center gap-2">
                                                         {isSelected && (
-                                                            <span className="inline-flex items-center rounded-full border border-emerald-300/70 bg-emerald-500/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-emerald-100">
+                                                            <span className="inline-flex items-center rounded-full border border-[#00D1FF]/60 bg-[#00D1FF]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-[#00D1FF]">
                                                                 Selected
                                                             </span>
                                                         )}
@@ -144,10 +144,10 @@ const Sales = () => {
                                                     </div>
                                                 </td>
                                                 <td className="px-4 py-3">{c.buyerUsername}</td>
-                                                <td className="px-4 py-3 font-semibold text-emerald-300">${c.price}</td>
+                                                <td className="px-4 py-3 font-semibold text-[#FF4D9B]">${c.price}</td>
                                                 <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
                                                 <td className="px-4 py-3">
-                                                    <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-100">
+                                                    <span className="rounded-full border border-[#00D1FF]/40 bg-[#00D1FF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#00D1FF]">
                                                         {c.status}
                                                     </span>
                                                 </td>

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -8,7 +8,7 @@ import AgreementEditorModal from "./AgreementEditorModal";
 import contractTemplate from "../config/contractTemplate";
 
 const inputClasses =
-    "mt-1 w-full rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-emerald-400 focus:outline-none";
+    "mt-1 w-full rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none";
 const labelClasses = "block text-xs font-semibold uppercase tracking-[0.18em] text-slate-400";
 
 const Sell = () => {
@@ -362,7 +362,7 @@ const Sell = () => {
                 <div className="flex flex-col gap-8">
                     <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
                         <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300/80">Primary Listing</p>
+                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Primary Listing</p>
                             <h1 className="text-3xl font-bold text-white">Sell Your Data Contract</h1>
                             <p className="text-sm text-slate-400">
                                 Provide the core commercial terms, delivery requirements, and legal agreement to list a new contract.
@@ -383,7 +383,7 @@ const Sell = () => {
                                 </div>
                                 <div className="mt-2 h-2 w-full overflow-hidden rounded-full border border-slate-800/60 bg-slate-950/60">
                                     <div
-                                        className="h-full bg-gradient-to-r from-emerald-500 to-teal-400 transition-all duration-300"
+                                        className="h-full bg-gradient-to-r from-[#00D1FF] to-[#FF4D9B] transition-all duration-300"
                                         style={{ width: `${progressPercentage}%` }}
                                     />
                                 </div>
@@ -414,7 +414,7 @@ const Sell = () => {
 
                     <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
                         <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300/80">Portfolio</p>
+                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Portfolio</p>
                             <h2 className="text-2xl font-bold text-white">My Contracts</h2>
                             <p className="text-sm text-slate-400">
                                 Manage the contracts you currently have listed on the marketplace.
@@ -437,10 +437,10 @@ const Sell = () => {
                                         <tr key={c.id} className="bg-slate-950/40">
                                             <td className="px-4 py-3 font-semibold text-slate-100">{c.title}</td>
                                             <td className="px-4 py-3">{c.buyerUsername || "-"}</td>
-                                            <td className="px-4 py-3 font-semibold text-emerald-300">${c.price}</td>
+                                            <td className="px-4 py-3 font-semibold text-[#FF4D9B]">${c.price}</td>
                                             <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
                                             <td className="px-4 py-3">
-                                                <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-100">
+                                                <span className="rounded-full border border-[#00D1FF]/40 bg-[#00D1FF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#00D1FF]">
                                                     {c.status}
                                                 </span>
                                             </td>

--- a/bellingham-frontend/src/components/Settings.jsx
+++ b/bellingham-frontend/src/components/Settings.jsx
@@ -32,7 +32,7 @@ const Settings = () => {
         <Layout onLogout={handleLogout}>
             <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
                 <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300/80">Configuration</p>
+                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Configuration</p>
                     <h1 className="text-3xl font-bold text-white">Settings</h1>
                     <p className="text-sm text-slate-400">
                         Tailor the platform to your institution’s policies. Modules below will be populated as features are rolled out.

--- a/bellingham-frontend/src/components/Sidebar.jsx
+++ b/bellingham-frontend/src/components/Sidebar.jsx
@@ -35,7 +35,7 @@ const Sidebar = ({ onLogout }) => {
             <button
                 type="button"
                 onClick={toggleMobile}
-                className="md:hidden fixed top-20 left-4 z-50 inline-flex items-center justify-center rounded-full bg-slate-900 p-3 text-white shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-950 focus:ring-emerald-400"
+                className="md:hidden fixed top-20 left-4 z-50 inline-flex items-center justify-center rounded-full bg-slate-900 p-3 text-white shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-950 focus:ring-[#00D1FF]"
                 aria-label={isMobileOpen ? "Close navigation" : "Open navigation"}
                 aria-expanded={isMobileOpen}
             >
@@ -63,7 +63,7 @@ const Sidebar = ({ onLogout }) => {
                     <button
                         type="button"
                         onClick={closeMobile}
-                        className="inline-flex items-center justify-center rounded-full bg-slate-800 p-2 text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+                        className="inline-flex items-center justify-center rounded-full bg-slate-800 p-2 text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]"
                     >
                         <span className="sr-only">Close navigation</span>
                         <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">

--- a/bellingham-frontend/src/components/SignatureModal.jsx
+++ b/bellingham-frontend/src/components/SignatureModal.jsx
@@ -113,7 +113,7 @@ const SignatureModal = ({ onConfirm, onCancel }) => {
         <div className="mt-6 flex flex-wrap justify-end gap-2">
           <Button variant="ghost" className="border border-slate-600/60 bg-slate-800 text-slate-100 hover:bg-slate-700" onClick={handleClear}>Clear</Button>
           <Button variant="danger" className="shadow-lg shadow-red-900/40" onClick={onCancel}>Cancel</Button>
-          <Button variant="success" className="font-semibold shadow-lg shadow-emerald-900/40" onClick={handleSave}>Save</Button>
+          <Button variant="success" className="font-semibold shadow-lg shadow-[#00D1FF]/25" onClick={handleSave}>Save</Button>
         </div>
       </div>
     </div>

--- a/bellingham-frontend/src/components/Signup.jsx
+++ b/bellingham-frontend/src/components/Signup.jsx
@@ -312,7 +312,7 @@ const Signup = () => {
                                         onBlur={() => handleBlur(field.name)}
                                         aria-describedby={describedBy}
                                         aria-invalid={showError ? "true" : "false"}
-                                        className={`w-full p-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                                        className={`w-full p-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#00D1FF] ${
                                             showError ? "border-red-500" : "border-gray-300"
                                         }`}
                                     />

--- a/bellingham-frontend/src/components/ui/Button.jsx
+++ b/bellingham-frontend/src/components/ui/Button.jsx
@@ -6,11 +6,13 @@ const baseClasses =
   'inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
 
 const variantClasses = {
-  primary: 'bg-blue-600 text-white hover:bg-blue-500 focus-visible:ring-blue-500',
+  primary:
+    'bg-[#00D1FF] text-slate-900 shadow-[0_10px_30px_rgba(0,209,255,0.35)] hover:bg-[#FF4D9B] hover:text-white focus-visible:ring-[#00D1FF] focus-visible:ring-offset-slate-900',
   success: 'bg-green-600 text-white hover:bg-green-500 focus-visible:ring-green-500',
   danger: 'bg-red-600 text-white hover:bg-red-500 focus-visible:ring-red-500',
   ghost: 'bg-gray-600 text-white hover:bg-gray-700 focus-visible:ring-gray-500',
-  link: 'bg-transparent px-0 py-0 text-blue-600 underline-offset-4 hover:underline focus-visible:ring-blue-500 focus-visible:ring-offset-0 rounded-none',
+  link:
+    'bg-transparent px-0 py-0 text-[#00D1FF] underline-offset-4 hover:text-[#FF4D9B] hover:underline focus-visible:ring-[#00D1FF] focus-visible:ring-offset-0 rounded-none',
 };
 
 const renderIcon = (icon, className) => {

--- a/bellingham-frontend/src/components/ui/NavMenuItem.jsx
+++ b/bellingham-frontend/src/components/ui/NavMenuItem.jsx
@@ -3,20 +3,20 @@ import { NavLink } from "react-router-dom";
 
 const baseClasses = {
     header:
-        "group relative inline-flex rounded-lg px-4 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.18em] transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400",
+        "group relative inline-flex rounded-lg px-4 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.18em] transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]",
     sidebar:
-        "group flex rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900",
+        "group flex rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900",
 };
 
 const activeClasses = {
     header:
-        "border border-emerald-400/80 bg-emerald-500/20 text-emerald-100 shadow-[0_10px_30px_rgba(16,185,129,0.25)]",
+        "border border-[#00D1FF]/80 bg-[#00D1FF]/15 text-[#00D1FF] shadow-[0_10px_30px_rgba(0,209,255,0.3)]",
     sidebar: "bg-slate-800 text-white",
 };
 
 const inactiveClasses = {
     header:
-        "border border-transparent text-slate-300 hover:border-emerald-400/50 hover:bg-slate-800/60 hover:text-white",
+        "border border-transparent text-slate-300 hover:border-[#FF4D9B]/50 hover:bg-slate-800/60 hover:text-[#FF4D9B]",
     sidebar: "text-slate-200 hover:bg-slate-800/70",
 };
 

--- a/bellingham-frontend/tailwind.config.js
+++ b/bellingham-frontend/tailwind.config.js
@@ -9,9 +9,9 @@ export default {
         base: '#0d1b2a',
         surface: '#1b263b',
         contrast: '#e0e6ed',
-        primary: '#1d4ed8',
-        secondary: '#3b82f6',
-        accent: '#ef4444'
+        primary: '#00D1FF',
+        secondary: '#FF4D9B',
+        accent: '#FF4D9B'
       },
       fontFamily: {
         sans: ['Inter', 'sans-serif']


### PR DESCRIPTION
## Summary
- replace the Tailwind primary palette with cyan and magenta accents and refresh shared button/link styles
- update dashboards, tables, and status chips to highlight key metrics and hover states with the new colors
- align authentication and settings flows with the vibrant accent scheme and refreshed focus treatments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5725cbe80832980efe925ce3665c6