### PR TITLE
feat: refresh secondary highlight palette

### DIFF
--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -209,7 +209,7 @@ const Buy = () => {
                                             >
                                                 <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
                                                 <td className="px-4 py-3">{contract.seller}</td>
-                                                <td className="px-4 py-3 font-semibold text-[#FF4D9B]">${contract.price}</td>
+                                                <td className="px-4 py-3 font-semibold text-[#3BAEAB]">${contract.price}</td>
                                                 <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
                                                 <td className="px-4 py-3">
                                                     <Button

--- a/bellingham-frontend/src/components/Calendar.jsx
+++ b/bellingham-frontend/src/components/Calendar.jsx
@@ -8,7 +8,7 @@ import { AuthContext } from '../context';
 
 const TYPE_INFO = {
     Bought: { color: "bg-[#00D1FF]", initial: "B" },
-    Ends: { color: "bg-[#FF4D9B]", initial: "E" },
+    Ends: { color: "bg-[#7465A8]", initial: "E" },
 };
 
 const ContractCalendar = () => {

--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -12,9 +12,9 @@ import api from "../utils/api";
 
 const STATUS_STYLES = {
     open: "border-[#00D1FF]/50 bg-[#00D1FF]/10 text-[#00D1FF]",
-    purchased: "border-[#FF4D9B]/50 bg-[#FF4D9B]/10 text-[#FF4D9B]",
+    purchased: "border-[#7465A8]/50 bg-[#7465A8]/12 text-[#C5BEE4]",
     closed: "border-slate-500/40 bg-slate-600/10 text-slate-200",
-    default: "border-[#FF4D9B]/50 bg-[#FF4D9B]/10 text-[#FF4D9B]",
+    default: "border-[#3BAEAB]/50 bg-[#3BAEAB]/12 text-[#9CD8D6]",
 };
 
 const formatCurrency = (value) => {
@@ -298,7 +298,7 @@ const ContractDetailsPanel = ({
             <div className="mt-4 flex flex-col gap-6 text-sm text-slate-300">
                 <div className="flex flex-wrap gap-2">
                     <Button
-                        className="border border-[#FF4D9B]/50 bg-[#FF4D9B]/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-[#FF4D9B] hover:bg-[#FF4D9B]/20"
+                        className="border border-[#7465A8]/50 bg-[#7465A8]/12 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-[#C5BEE4] hover:bg-[#7465A8]/20"
                         onClick={handleDownload}
                     >
                         Download PDF

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -108,7 +108,7 @@ const Dashboard = () => {
                                 </div>
                                 <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4 shadow-inner">
                                     <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Total Ask Volume</p>
-                                    <p className="mt-3 text-3xl font-bold text-[#FF4D9B]">{formatCurrency(kpis.totalVolume)}</p>
+                                    <p className="mt-3 text-3xl font-bold text-[#3BAEAB]">{formatCurrency(kpis.totalVolume)}</p>
                                     <p className="mt-1 text-xs text-slate-500">Aggregate notional value</p>
                                 </div>
                                 <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4 shadow-inner">
@@ -118,7 +118,7 @@ const Dashboard = () => {
                                 </div>
                                 <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4 shadow-inner">
                                     <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Active Sellers</p>
-                                    <p className="mt-3 text-3xl font-bold text-[#FF4D9B]">{formatNumber(kpis.activeSellers)}</p>
+                                    <p className="mt-3 text-3xl font-bold text-[#7465A8]">{formatNumber(kpis.activeSellers)}</p>
                                     <p className="mt-1 text-xs text-slate-500">Distinct market participants</p>
                                 </div>
                             </>
@@ -148,7 +148,7 @@ const Dashboard = () => {
                                             >
                                                 <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
                                                 <td className="px-4 py-3">{contract.seller}</td>
-                                                <td className="px-4 py-3 font-semibold text-[#FF4D9B]">
+                                                <td className="px-4 py-3 font-semibold text-[#3BAEAB]">
                                                     ${contract.price}
                                                 </td>
                                                 <td className="px-4 py-3">

--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -42,7 +42,7 @@ const Header = ({ onLogout }) => {
                             <BellAlertIcon aria-hidden="true" className="h-5 w-5" />
                             <span className="sr-only">Open notifications</span>
                             {unreadCount > 0 && (
-                                <span className="absolute -right-1 -top-1 min-w-[1.5rem] rounded-full bg-[#FF4D9B] px-1.5 py-0.5 text-center text-[0.65rem] font-semibold leading-none text-slate-950 shadow-lg">
+                                <span className="absolute -right-1 -top-1 min-w-[1.5rem] rounded-full bg-[#7465A8] px-1.5 py-0.5 text-center text-[0.65rem] font-semibold leading-none text-white shadow-lg">
                                     {unreadCount > 99 ? "99+" : unreadCount}
                                 </span>
                             )}
@@ -60,7 +60,7 @@ const Header = ({ onLogout }) => {
                                     <button
                                         type="button"
                                         onClick={onLogout}
-                                        className="rounded-lg border border-[#FF4D9B]/50 bg-[#FF4D9B]/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-[#FF4D9B] transition-colors hover:bg-[#FF4D9B]/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]"
+                                        className="rounded-lg border border-[#3BAEAB]/60 bg-[#3BAEAB]/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-[#9CD8D6] transition-colors hover:bg-[#3BAEAB]/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]"
                                     >
                                         Log Out
                                     </button>

--- a/bellingham-frontend/src/components/History.jsx
+++ b/bellingham-frontend/src/components/History.jsx
@@ -64,7 +64,7 @@ const History = () => {
                                         <td className="px-4 py-3 font-semibold text-slate-100">{c.title}</td>
                                         <td className="px-4 py-3">{c.seller}</td>
                                         <td className="px-4 py-3">{c.buyerUsername || "-"}</td>
-                                        <td className="px-4 py-3 font-semibold text-[#FF4D9B]">${c.price}</td>
+                                        <td className="px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
                                         <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
                                     </tr>
                                 ))}

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -59,7 +59,7 @@ const Login = () => {
                 <div className="relative w-full overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/70 shadow-[0_40px_80px_-20px_rgba(15,23,42,0.9)] backdrop-blur">
                     <div className="pointer-events-none absolute inset-0 opacity-60" aria-hidden="true">
                         <div className="absolute -left-24 -top-24 h-72 w-72 rounded-full bg-[#00D1FF]/30 blur-3xl" />
-                        <div className="absolute -bottom-32 -right-20 h-80 w-80 rounded-full bg-[#FF4D9B]/25 blur-3xl" />
+                        <div className="absolute -bottom-32 -right-20 h-80 w-80 rounded-full bg-[#7465A8]/25 blur-3xl" />
                     </div>
                     <div className="relative grid gap-12 p-10 md:grid-cols-2 lg:p-16">
                         <div className="flex flex-col justify-between gap-8">
@@ -82,7 +82,7 @@ const Login = () => {
                                         <span>Track portfolio performance with high-contrast visualisations.</span>
                                     </li>
                                     <li className="flex items-start gap-3">
-                                        <span className="mt-1 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[#FF4D9B]" />
+                                        <span className="mt-1 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[#7465A8]" />
                                         <span>Coordinate bids and settlements securely from a single control room.</span>
                                     </li>
                                     <li className="flex items-start gap-3">
@@ -96,7 +96,7 @@ const Login = () => {
                                 <button
                                     type="button"
                                     onClick={() => navigate("/signup")}
-                                    className="font-medium text-[#00D1FF] transition hover:text-[#FF4D9B]"
+                                    className="font-medium text-[#00D1FF] transition hover:text-[#3BAEAB]"
                                 >
                                     Request access
                                 </button>
@@ -167,7 +167,7 @@ const Login = () => {
                             <Button
                                 type="button"
                                 variant="link"
-                                className="text-center text-sm text-[#00D1FF] hover:text-[#FF4D9B]"
+                                className="text-center text-sm text-[#00D1FF] hover:text-[#3BAEAB]"
                                 onClick={() => navigate("/signup")}
                             >
                                 Create Account

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -417,7 +417,7 @@ const Reports = () => {
                                                 >
                                                     <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
                                                     <td className="px-4 py-3">{contract.seller}</td>
-                                                    <td className="px-4 py-3 font-semibold text-[#FF4D9B]">${contract.price}</td>
+                                                    <td className="px-4 py-3 font-semibold text-[#3BAEAB]">${contract.price}</td>
                                                     <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
                                                     <td className="px-4 py-3">
                                                         <div className="flex flex-wrap gap-2">

--- a/bellingham-frontend/src/components/Sales.jsx
+++ b/bellingham-frontend/src/components/Sales.jsx
@@ -128,7 +128,7 @@ const Sales = () => {
                                                 className={`group cursor-pointer transition-colors ${
                                                     isSelected
                                                         ? "bg-[#00D1FF]/15"
-                                                        : "bg-slate-950/40 hover:bg-[#FF4D9B]/10"
+                                                        : "bg-slate-950/40 hover:bg-[#7465A8]/12"
                                                 }`}
                                                 onClick={() => setSelectedContract(c)}
                                                 aria-selected={isSelected}
@@ -144,7 +144,7 @@ const Sales = () => {
                                                     </div>
                                                 </td>
                                                 <td className="px-4 py-3">{c.buyerUsername}</td>
-                                                <td className="px-4 py-3 font-semibold text-[#FF4D9B]">${c.price}</td>
+                                                <td className="px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
                                                 <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
                                                 <td className="px-4 py-3">
                                                     <span className="rounded-full border border-[#00D1FF]/40 bg-[#00D1FF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#00D1FF]">

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -383,7 +383,7 @@ const Sell = () => {
                                 </div>
                                 <div className="mt-2 h-2 w-full overflow-hidden rounded-full border border-slate-800/60 bg-slate-950/60">
                                     <div
-                                        className="h-full bg-gradient-to-r from-[#00D1FF] to-[#FF4D9B] transition-all duration-300"
+                                        className="h-full bg-gradient-to-r from-[#3BAEAB] to-[#7465A8] transition-all duration-300"
                                         style={{ width: `${progressPercentage}%` }}
                                     />
                                 </div>
@@ -437,7 +437,7 @@ const Sell = () => {
                                         <tr key={c.id} className="bg-slate-950/40">
                                             <td className="px-4 py-3 font-semibold text-slate-100">{c.title}</td>
                                             <td className="px-4 py-3">{c.buyerUsername || "-"}</td>
-                                            <td className="px-4 py-3 font-semibold text-[#FF4D9B]">${c.price}</td>
+                                            <td className="px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
                                             <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
                                             <td className="px-4 py-3">
                                                 <span className="rounded-full border border-[#00D1FF]/40 bg-[#00D1FF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#00D1FF]">

--- a/bellingham-frontend/src/components/ui/Button.jsx
+++ b/bellingham-frontend/src/components/ui/Button.jsx
@@ -7,12 +7,12 @@ const baseClasses =
 
 const variantClasses = {
   primary:
-    'bg-[#00D1FF] text-slate-900 shadow-[0_10px_30px_rgba(0,209,255,0.35)] hover:bg-[#FF4D9B] hover:text-white focus-visible:ring-[#00D1FF] focus-visible:ring-offset-slate-900',
+    'bg-[#00D1FF] text-slate-900 shadow-[0_10px_30px_rgba(0,209,255,0.35)] hover:bg-[#7465A8] hover:text-white focus-visible:ring-[#00D1FF] focus-visible:ring-offset-slate-900',
   success: 'bg-green-600 text-white hover:bg-green-500 focus-visible:ring-green-500',
   danger: 'bg-red-600 text-white hover:bg-red-500 focus-visible:ring-red-500',
   ghost: 'bg-gray-600 text-white hover:bg-gray-700 focus-visible:ring-gray-500',
   link:
-    'bg-transparent px-0 py-0 text-[#00D1FF] underline-offset-4 hover:text-[#FF4D9B] hover:underline focus-visible:ring-[#00D1FF] focus-visible:ring-offset-0 rounded-none',
+    'bg-transparent px-0 py-0 text-[#00D1FF] underline-offset-4 hover:text-[#3BAEAB] hover:underline focus-visible:ring-[#00D1FF] focus-visible:ring-offset-0 rounded-none',
 };
 
 const renderIcon = (icon, className) => {

--- a/bellingham-frontend/src/components/ui/NavMenuItem.jsx
+++ b/bellingham-frontend/src/components/ui/NavMenuItem.jsx
@@ -16,7 +16,7 @@ const activeClasses = {
 
 const inactiveClasses = {
     header:
-        "border border-transparent text-slate-300 hover:border-[#FF4D9B]/50 hover:bg-slate-800/60 hover:text-[#FF4D9B]",
+        "border border-transparent text-slate-300 hover:border-[#7465A8]/50 hover:bg-slate-800/60 hover:text-[#3BAEAB]",
     sidebar: "text-slate-200 hover:bg-slate-800/70",
 };
 

--- a/bellingham-frontend/tailwind.config.js
+++ b/bellingham-frontend/tailwind.config.js
@@ -10,8 +10,12 @@ export default {
         surface: '#1b263b',
         contrast: '#e0e6ed',
         primary: '#00D1FF',
-        secondary: '#FF4D9B',
-        accent: '#FF4D9B'
+        secondary: '#3BAEAB',
+        accent: '#7465A8',
+        highlight: {
+          teal: '#3BAEAB',
+          purple: '#7465A8'
+        }
       },
       fontFamily: {
         sans: ['Inter', 'sans-serif']


### PR DESCRIPTION
## Summary
- introduce muted teal and purple highlight tokens in the Tailwind theme for secondary accents
- update labels, tags, and secondary data displays across the app to use the new highlight treatments

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d63f529438832994a504d94852d852