### PR TITLE
Add monospace font styling for numeric data

### DIFF
--- a/bellingham-frontend/index.html
+++ b/bellingham-frontend/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Roboto+Mono:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <title>Bellingham Data Futures</title>
   </head>
   <body>

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -209,7 +209,7 @@ const Buy = () => {
                                             >
                                                 <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
                                                 <td className="px-4 py-3">{contract.seller}</td>
-                                                <td className="px-4 py-3 font-semibold text-[#3BAEAB]">${contract.price}</td>
+                                                <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${contract.price}</td>
                                                 <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
                                                 <td className="px-4 py-3">
                                                     <Button

--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -21,11 +21,13 @@ const formatCurrency = (value) => {
     if (value === null || value === undefined || value === "") return null;
     const numericValue = Number(value);
     if (Number.isNaN(numericValue)) return String(value);
-    return new Intl.NumberFormat("en-US", {
+    const formatted = new Intl.NumberFormat("en-US", {
         style: "currency",
         currency: "USD",
         maximumFractionDigits: 2,
     }).format(numericValue);
+
+    return <span className="numeric-text">{formatted}</span>;
 };
 
 const formatDate = (value) => {

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -103,22 +103,22 @@ const Dashboard = () => {
                             <>
                                 <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4 shadow-inner">
                                     <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Open Contracts</p>
-                                    <p className="mt-3 text-3xl font-bold text-[#00D1FF]">{formatNumber(kpis.openContracts)}</p>
+                                    <p className="numeric-text mt-3 text-3xl font-bold text-[#00D1FF]">{formatNumber(kpis.openContracts)}</p>
                                     <p className="mt-1 text-xs text-slate-500">Currently listed opportunities</p>
                                 </div>
                                 <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4 shadow-inner">
                                     <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Total Ask Volume</p>
-                                    <p className="mt-3 text-3xl font-bold text-[#3BAEAB]">{formatCurrency(kpis.totalVolume)}</p>
+                                    <p className="numeric-text mt-3 text-3xl font-bold text-[#3BAEAB]">{formatCurrency(kpis.totalVolume)}</p>
                                     <p className="mt-1 text-xs text-slate-500">Aggregate notional value</p>
                                 </div>
                                 <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4 shadow-inner">
                                     <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Average Ask</p>
-                                    <p className="mt-3 text-3xl font-bold text-[#00D1FF]">{formatCurrency(kpis.averageAsk)}</p>
+                                    <p className="numeric-text mt-3 text-3xl font-bold text-[#00D1FF]">{formatCurrency(kpis.averageAsk)}</p>
                                     <p className="mt-1 text-xs text-slate-500">Mean price across open listings</p>
                                 </div>
                                 <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4 shadow-inner">
                                     <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Active Sellers</p>
-                                    <p className="mt-3 text-3xl font-bold text-[#7465A8]">{formatNumber(kpis.activeSellers)}</p>
+                                    <p className="numeric-text mt-3 text-3xl font-bold text-[#7465A8]">{formatNumber(kpis.activeSellers)}</p>
                                     <p className="mt-1 text-xs text-slate-500">Distinct market participants</p>
                                 </div>
                             </>
@@ -148,7 +148,7 @@ const Dashboard = () => {
                                             >
                                                 <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
                                                 <td className="px-4 py-3">{contract.seller}</td>
-                                                <td className="px-4 py-3 font-semibold text-[#3BAEAB]">
+                                                <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">
                                                     ${contract.price}
                                                 </td>
                                                 <td className="px-4 py-3">

--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -42,7 +42,7 @@ const Header = ({ onLogout }) => {
                             <BellAlertIcon aria-hidden="true" className="h-5 w-5" />
                             <span className="sr-only">Open notifications</span>
                             {unreadCount > 0 && (
-                                <span className="absolute -right-1 -top-1 min-w-[1.5rem] rounded-full bg-[#7465A8] px-1.5 py-0.5 text-center text-[0.65rem] font-semibold leading-none text-white shadow-lg">
+                                <span className="numeric-text absolute -right-1 -top-1 min-w-[1.5rem] rounded-full bg-[#7465A8] px-1.5 py-0.5 text-center text-[0.65rem] font-semibold leading-none text-white shadow-lg">
                                     {unreadCount > 99 ? "99+" : unreadCount}
                                 </span>
                             )}

--- a/bellingham-frontend/src/components/History.jsx
+++ b/bellingham-frontend/src/components/History.jsx
@@ -64,7 +64,7 @@ const History = () => {
                                         <td className="px-4 py-3 font-semibold text-slate-100">{c.title}</td>
                                         <td className="px-4 py-3">{c.seller}</td>
                                         <td className="px-4 py-3">{c.buyerUsername || "-"}</td>
-                                        <td className="px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
+                                        <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
                                         <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
                                     </tr>
                                 ))}

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -344,8 +344,12 @@ const Reports = () => {
                                                                 <span className="sr-only">Slice {index + 1}: </span>
                                                                 {contract.title || "Untitled Contract"}
                                                             </p>
-                                                            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">{allocation}% of portfolio</p>
-                                                            <p className="text-xs text-slate-300">Value ${price.toFixed(2)}</p>
+                                                            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+                                                                <span className="numeric-text">{allocation}%</span> of portfolio
+                                                            </p>
+                                                            <p className="text-xs text-slate-300">
+                                                                Value <span className="numeric-text">${price.toFixed(2)}</span>
+                                                            </p>
                                                         </div>
                                                     </div>
                                                 );
@@ -376,9 +380,11 @@ const Reports = () => {
                                                         <p className="text-base font-semibold text-white">{contract.title}</p>
                                                     </div>
                                                     <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
-                                                        Allocation {allocation}%
+                                                        Allocation <span className="numeric-text">{allocation}%</span>
                                                     </p>
-                                                    <p className="text-sm text-slate-300">Value ${price.toFixed(2)}</p>
+                                                    <p className="text-sm text-slate-300">
+                                                        Value <span className="numeric-text">${price.toFixed(2)}</span>
+                                                    </p>
                                                     <p className="text-sm text-slate-300">Purchased {formatDate(contract.purchaseDate)}</p>
                                                     <p className="text-sm text-slate-300">Delivery {formatDate(contract.deliveryDate)}</p>
                                                 </div>
@@ -417,7 +423,7 @@ const Reports = () => {
                                                 >
                                                     <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
                                                     <td className="px-4 py-3">{contract.seller}</td>
-                                                    <td className="px-4 py-3 font-semibold text-[#3BAEAB]">${contract.price}</td>
+                                                    <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${contract.price}</td>
                                                     <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
                                                     <td className="px-4 py-3">
                                                         <div className="flex flex-wrap gap-2">
@@ -458,7 +464,7 @@ const Reports = () => {
                         </div>
 
                         <p className="text-lg font-semibold text-[#00D1FF]">
-                            Portfolio Value ${totalValue.toFixed(2)}
+                            Portfolio Value <span className="numeric-text">${totalValue.toFixed(2)}</span>
                         </p>
                     </div>
                 </section>

--- a/bellingham-frontend/src/components/Sales.jsx
+++ b/bellingham-frontend/src/components/Sales.jsx
@@ -144,7 +144,7 @@ const Sales = () => {
                                                     </div>
                                                 </td>
                                                 <td className="px-4 py-3">{c.buyerUsername}</td>
-                                                <td className="px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
+                                                <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
                                                 <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
                                                 <td className="px-4 py-3">
                                                     <span className="rounded-full border border-[#00D1FF]/40 bg-[#00D1FF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#00D1FF]">

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -377,7 +377,8 @@ const Sell = () => {
                             <div>
                                 <div className="flex flex-wrap items-center justify-between gap-3">
                                     <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
-                                        Step {currentStep + 1} of {steps.length}
+                                        Step <span className="numeric-text">{currentStep + 1}</span> of{' '}
+                                        <span className="numeric-text">{steps.length}</span>
                                     </p>
                                     <span className="text-sm font-semibold text-white">{steps[currentStep].title}</span>
                                 </div>
@@ -437,7 +438,7 @@ const Sell = () => {
                                         <tr key={c.id} className="bg-slate-950/40">
                                             <td className="px-4 py-3 font-semibold text-slate-100">{c.title}</td>
                                             <td className="px-4 py-3">{c.buyerUsername || "-"}</td>
-                                            <td className="px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
+                                            <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
                                             <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
                                             <td className="px-4 py-3">
                                                 <span className="rounded-full border border-[#00D1FF]/40 bg-[#00D1FF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#00D1FF]">

--- a/bellingham-frontend/src/index.css
+++ b/bellingham-frontend/src/index.css
@@ -33,6 +33,11 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+.numeric-text {
+  font-family: 'Roboto Mono', 'JetBrains Mono', monospace;
+  font-variant-numeric: tabular-nums;
+}
+
 .skip-link {
   position: absolute;
   top: 0;

--- a/bellingham-frontend/tailwind.config.js
+++ b/bellingham-frontend/tailwind.config.js
@@ -18,7 +18,8 @@ export default {
         }
       },
       fontFamily: {
-        sans: ['Inter', 'sans-serif']
+        sans: ['Inter', 'sans-serif'],
+        mono: ['Roboto Mono', 'JetBrains Mono', 'monospace']
       }
     }
   },


### PR DESCRIPTION
## Summary
- load Roboto Mono alongside Inter and introduce a numeric-text utility class for tabular number rendering
- apply the numeric font styling to KPIs, tables, and contract details so currency and counts use Roboto Mono
- extend the Tailwind theme with the paired mono family for consistent typography options

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d64a72c2d08329b4ef0b9998504861