### PR TITLE
Remove heroicons usage from the frontend

### DIFF
--- a/bellingham-frontend/package-lock.json
+++ b/bellingham-frontend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "bellingham-frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@heroicons/react": "^2.2.0",
         "axios": "^1.8.4",
         "chart.js": "^4.5.0",
         "react": "^19.0.0",
@@ -1088,15 +1087,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@heroicons/react": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
-      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/bellingham-frontend/package.json
+++ b/bellingham-frontend/package.json
@@ -11,7 +11,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@heroicons/react": "^2.2.0",
     "axios": "^1.8.4",
     "chart.js": "^4.5.0",
     "react": "^19.0.0",

--- a/bellingham-frontend/src/components/ContractDetailsPanel.jsx
+++ b/bellingham-frontend/src/components/ContractDetailsPanel.jsx
@@ -1,7 +1,21 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { ChevronDownIcon } from "@heroicons/react/24/outline";
 import Button from "./ui/Button";
 import api from "../utils/api";
+
+const SectionToggleIcon = ({ className = "", ...props }) => (
+    <svg
+        aria-hidden="true"
+        className={className}
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        {...props}
+    >
+        <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
+    </svg>
+);
 
 const STATUS_STYLES = {
     open: "border-[#00D1FF]/50 bg-[#00D1FF]/10 text-[#00D1FF]",
@@ -316,7 +330,7 @@ const ContractDetailsPanel = ({
                                     <span className="text-sm font-semibold uppercase tracking-[0.2em]">
                                         {section.title}
                                     </span>
-                                    <ChevronDownIcon
+                                    <SectionToggleIcon
                                         className={`h-4 w-4 flex-shrink-0 transition-transform ${
                                             isOpen ? "rotate-180" : "rotate-0"
                                         }`}

--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -1,10 +1,29 @@
 import React, { useContext, useState } from "react";
 import { Link } from "react-router-dom";
-import { BellAlertIcon } from "@heroicons/react/24/outline";
 
 import { AuthContext, useNotifications } from "../context";
 import navItems from "../config/navItems";
 import NavMenuItem from "./ui/NavMenuItem";
+
+const NotificationBellIcon = ({ className = "", ...props }) => (
+    <svg
+        aria-hidden="true"
+        className={className}
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        {...props}
+    >
+        <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M6.75 9.5a5.25 5.25 0 1 1 10.5 0v4.21l1.27 1.9c.58.86-.04 2.04-1.07 2.04H6.55c-1.03 0-1.65-1.18-1.07-2.04l1.27-1.9z"
+        />
+        <path strokeLinecap="round" d="M9.75 18.75a2.25 2.25 0 0 0 4.5 0" />
+    </svg>
+);
 
 const Header = ({ onLogout }) => {
     const { username } = useContext(AuthContext);
@@ -39,7 +58,7 @@ const Header = ({ onLogout }) => {
                                     : "Notifications"
                             }
                         >
-                            <BellAlertIcon aria-hidden="true" className="h-5 w-5" />
+                            <NotificationBellIcon className="h-5 w-5" />
                             <span className="sr-only">Open notifications</span>
                             {unreadCount > 0 && (
                                 <span className="numeric-text absolute -right-1 -top-1 min-w-[1.5rem] rounded-full bg-[#7465A8] px-1.5 py-0.5 text-center text-[0.65rem] font-semibold leading-none text-white shadow-lg">


### PR DESCRIPTION
## Summary
- remove the @heroicons/react dependency from the frontend build
- replace heroicon components in the header and contract panel with inline SVG icons

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d658e7e7b88329807a043497c77948