### PR TITLE
Reduce form input widths

### DIFF
--- a/bellingham-frontend/src/components/Account.jsx
+++ b/bellingham-frontend/src/components/Account.jsx
@@ -6,8 +6,8 @@ import api from "../utils/api";
 import { AuthContext } from '../context';
 
 const inputClasses =
-    "mt-1 w-full rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none";
-const labelClasses = "block text-xs font-semibold uppercase tracking-[0.18em] text-slate-400";
+    "mt-1 w-full max-w-lg rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none";
+const labelClasses = "block w-full max-w-lg text-xs font-semibold uppercase tracking-[0.18em] text-slate-400";
 
 const Account = () => {
     const [profile, setProfile] = useState(null);

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -138,42 +138,42 @@ const Buy = () => {
                     {error && <p className="mt-4 text-sm text-red-400">{error}</p>}
 
                     <div className="mt-6 grid gap-4 rounded-xl border border-slate-800 bg-slate-950/40 p-4 sm:grid-cols-2 lg:grid-cols-4">
-                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
                             Search
                             <input
                                 type="text"
                                 placeholder="Title or seller"
                                 value={search}
                                 onChange={(e) => setSearch(e.target.value)}
-                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
+                                className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
                             />
                         </label>
-                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
                             Min Price
                             <input
                                 type="number"
                                 placeholder="0"
                                 value={minPrice}
                                 onChange={(e) => setMinPrice(e.target.value)}
-                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
+                                className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
                             />
                         </label>
-                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
                             Max Price
                             <input
                                 type="number"
                                 placeholder="0"
                                 value={maxPrice}
                                 onChange={(e) => setMaxPrice(e.target.value)}
-                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
+                                className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
                             />
                         </label>
-                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
                             Seller
                             <select
                                 value={sellerFilter}
                                 onChange={(e) => setSellerFilter(e.target.value)}
-                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
+                                className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
                             >
                                 <option value="">All Sellers</option>
                                 {sellers.map((s) => (

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -42,7 +42,7 @@ const Login = () => {
     };
 
     const inputBaseClasses =
-        "w-full rounded-lg border bg-slate-900/70 px-4 py-3 text-slate-100 placeholder:text-slate-500 transition-colors focus:outline-none focus:ring-2";
+        "w-full max-w-lg rounded-lg border bg-slate-900/70 px-4 py-3 text-slate-100 placeholder:text-slate-500 transition-colors focus:outline-none focus:ring-2";
     const inputStateClasses = authError
         ? "border-red-500/70 focus:border-red-400 focus:ring-red-500/40"
         : "border-slate-700/80 focus:border-[#00D1FF] focus:ring-[#00D1FF]/40";
@@ -161,7 +161,11 @@ const Login = () => {
                                     </button>
                                 </div>
                             </div>
-                            <Button type="submit" className="w-full rounded-lg py-3 text-base font-semibold shadow-lg shadow-[#00D1FF]/30" variant="primary">
+                            <Button
+                                type="submit"
+                                className="w-full max-w-lg rounded-lg py-3 text-base font-semibold shadow-lg shadow-[#00D1FF]/30"
+                                variant="primary"
+                            >
                                 Sign In
                             </Button>
                             <Button

--- a/bellingham-frontend/src/components/Sales.jsx
+++ b/bellingham-frontend/src/components/Sales.jsx
@@ -77,22 +77,22 @@ const Sales = () => {
                     {error && <p className="mt-4 text-sm text-red-400">{error}</p>}
 
                     <div className="mt-6 grid gap-4 rounded-xl border border-slate-800 bg-slate-950/40 p-4 sm:grid-cols-2 lg:grid-cols-4">
-                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
                             Search
                             <input
                                 type="text"
                                 value={searchTerm}
                                 onChange={(event) => setSearchTerm(event.target.value)}
                                 placeholder="Title or buyer"
-                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
+                                className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
                             />
                         </label>
-                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
                             Status
                             <select
                                 value={statusFilter}
                                 onChange={(event) => setStatusFilter(event.target.value)}
-                                className="rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
+                                className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
                             >
                                 <option value="">All Statuses</option>
                                 {statuses.map((status) => (

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -8,8 +8,8 @@ import AgreementEditorModal from "./AgreementEditorModal";
 import contractTemplate from "../config/contractTemplate";
 
 const inputClasses =
-    "mt-1 w-full rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none";
-const labelClasses = "block text-xs font-semibold uppercase tracking-[0.18em] text-slate-400";
+    "mt-1 w-full max-w-lg rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none";
+const labelClasses = "block w-full max-w-lg text-xs font-semibold uppercase tracking-[0.18em] text-slate-400";
 
 const Sell = () => {
     const navigate = useNavigate();

--- a/bellingham-frontend/src/components/Signup.jsx
+++ b/bellingham-frontend/src/components/Signup.jsx
@@ -298,7 +298,7 @@ const Signup = () => {
                             const describedBy = `${helpId}${showError ? ` ${errorId}` : ""}`;
 
                             return (
-                                <div key={field.name} className="flex flex-col">
+                                <div key={field.name} className="flex flex-col w-full max-w-xl">
                                     <label htmlFor={fieldId} className="font-medium text-sm text-gray-700 mb-1">
                                         {field.label}
                                     </label>
@@ -312,7 +312,7 @@ const Signup = () => {
                                         onBlur={() => handleBlur(field.name)}
                                         aria-describedby={describedBy}
                                         aria-invalid={showError ? "true" : "false"}
-                                        className={`w-full p-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#00D1FF] ${
+                                        className={`w-full max-w-xl p-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#00D1FF] ${
                                             showError ? "border-red-500" : "border-gray-300"
                                         }`}
                                     />
@@ -328,13 +328,13 @@ const Signup = () => {
                             );
                         })}
                     </div>
-                    <Button type="submit" className="w-full mt-6 rounded-lg" variant="primary">
+                    <Button type="submit" className="w-full max-w-xl mt-6 rounded-lg" variant="primary">
                         Register
                     </Button>
                     <Button
                         type="button"
                         variant="link"
-                        className="w-full mt-2"
+                        className="w-full max-w-xl mt-2"
                         onClick={() => navigate("/login")}
                     >
                         Back to Login


### PR DESCRIPTION
## Summary
- limit form field widths across account, sell, and login flows to avoid full-width inputs
- adjust signup, buy, and sales filter controls to keep entry boxes compact and aligned

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d67861f6688329858bb7a6845f5d55