### PR TITLE
Adjust dashboard panel padding

### DIFF
--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -83,7 +83,7 @@ const Dashboard = () => {
     return (
         <Layout onLogout={handleLogout}>
             <div className="grid grid-cols-1 gap-6 xl:grid-cols-[260px_minmax(0,1fr)_320px] xl:gap-8">
-                <main className="order-1 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)] xl:order-2">
+                <main className="order-1 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 lg:p-8 shadow-[0_20px_45px_rgba(2,12,32,0.55)] xl:order-2">
                     <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
                         <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Market Overview</p>
                         <h2 className="text-3xl font-bold text-white">Open Contracts</h2>
@@ -139,7 +139,7 @@ const Dashboard = () => {
                         </table>
                     </div>
                 </main>
-                <aside className="order-2 space-y-4 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.45)] xl:order-1">
+                <aside className="order-2 space-y-4 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 lg:p-8 shadow-[0_20px_45px_rgba(2,12,32,0.45)] xl:order-1">
                     <div className="border-b border-slate-800 pb-4">
                         <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#3BAEAB]/80">Analytics</p>
                         <h3 className="text-2xl font-semibold text-white">Marketplace KPIs</h3>


### PR DESCRIPTION
## Summary
- increase the large-screen padding on the dashboard main content and analytics aside panels to lg:p-8 for consistent spacing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6a2bd70d08329b3b0c6018260c1de