### PR TITLE
Standardize panel spacing across panels

### DIFF
--- a/bellingham-frontend/src/components/Account.jsx
+++ b/bellingham-frontend/src/components/Account.jsx
@@ -95,171 +95,173 @@ const Account = () => {
     return (
         <Layout onLogout={handleLogout}>
             <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
-                <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Profile</p>
-                    <h1 className="text-3xl font-bold text-white">Account Details</h1>
-                    <p className="text-sm text-slate-400">
-                        Review and maintain your organisation information used across settlements and compliance processes.
-                    </p>
-                </div>
+                <div className="space-y-6">
+                    <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
+                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Profile</p>
+                        <h1 className="text-3xl font-bold text-white">Account Details</h1>
+                        <p className="text-sm text-slate-400">
+                            Review and maintain your organisation information used across settlements and compliance processes.
+                        </p>
+                    </div>
 
-                {editing ? (
-                    <div className="mt-6 grid gap-4 md:grid-cols-2">
-                        <label className={labelClasses}>
-                            Username
-                            <input value={profile.username} disabled className={`${inputClasses} cursor-not-allowed opacity-60`} />
-                        </label>
-                        <label className={labelClasses}>
-                            Legal Business Name
-                            <input
-                                className={inputClasses}
-                                name="legalBusinessName"
-                                value={formData.legalBusinessName || ""}
-                                onChange={handleChange}
-                                placeholder="Legal Business Name"
-                            />
-                        </label>
-                        <label className={labelClasses}>
-                            Name
-                            <input
-                                className={inputClasses}
-                                name="name"
-                                value={formData.name || ""}
-                                onChange={handleChange}
-                                placeholder="Name"
-                            />
-                        </label>
-                        <label className={labelClasses}>
-                            Country of Incorporation
-                            <input
-                                className={inputClasses}
-                                name="countryOfIncorporation"
-                                value={formData.countryOfIncorporation || ""}
-                                onChange={handleChange}
-                                placeholder="Country of Incorporation"
-                            />
-                        </label>
-                        <label className={labelClasses}>
-                            Tax ID
-                            <input
-                                className={inputClasses}
-                                name="taxId"
-                                value={formData.taxId || ""}
-                                onChange={handleChange}
-                                placeholder="Tax ID"
-                            />
-                        </label>
-                        <label className={labelClasses}>
-                            Company Registration Number
-                            <input
-                                className={inputClasses}
-                                name="companyRegistrationNumber"
-                                value={formData.companyRegistrationNumber || ""}
-                                onChange={handleChange}
-                                placeholder="Company Registration Number"
-                            />
-                        </label>
-                        <label className={labelClasses}>
-                            Primary Contact Name
-                            <input
-                                className={inputClasses}
-                                name="primaryContactName"
-                                value={formData.primaryContactName || ""}
-                                onChange={handleChange}
-                                placeholder="Primary Contact Name"
-                            />
-                        </label>
-                        <label className={labelClasses}>
-                            Primary Contact Email
-                            <input
-                                className={inputClasses}
-                                name="primaryContactEmail"
-                                value={formData.primaryContactEmail || ""}
-                                onChange={handleChange}
-                                placeholder="Primary Contact Email"
-                            />
-                        </label>
-                        <label className={labelClasses}>
-                            Primary Contact Phone
-                            <input
-                                className={inputClasses}
-                                name="primaryContactPhone"
-                                value={formData.primaryContactPhone || ""}
-                                onChange={handleChange}
-                                placeholder="Primary Contact Phone"
-                            />
-                        </label>
-                        <label className={labelClasses}>
-                            Technical Contact Name
-                            <input
-                                className={inputClasses}
-                                name="technicalContactName"
-                                value={formData.technicalContactName || ""}
-                                onChange={handleChange}
-                                placeholder="Technical Contact Name"
-                            />
-                        </label>
-                        <label className={labelClasses}>
-                            Technical Contact Email
-                            <input
-                                className={inputClasses}
-                                name="technicalContactEmail"
-                                value={formData.technicalContactEmail || ""}
-                                onChange={handleChange}
-                                placeholder="Technical Contact Email"
-                            />
-                        </label>
-                        <label className={labelClasses}>
-                            Technical Contact Phone
-                            <input
-                                className={inputClasses}
-                                name="technicalContactPhone"
-                                value={formData.technicalContactPhone || ""}
-                                onChange={handleChange}
-                                placeholder="Technical Contact Phone"
-                            />
-                        </label>
-                        <label className={`${labelClasses} md:col-span-2`}>
-                            Company Description
-                            <textarea
-                                className={`${inputClasses} min-h-[120px]`}
-                                name="companyDescription"
-                                value={formData.companyDescription || ""}
-                                onChange={handleChange}
-                                placeholder="Company Description"
-                            />
-                        </label>
-                        <div className="md:col-span-2 flex flex-wrap items-center gap-3">
-                            <Button variant="success" onClick={handleSave} className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]">
-                                Save
-                            </Button>
-                            <Button
-                                variant="ghost"
-                                onClick={() => {
-                                    setEditing(false);
-                                    setFormData(profile);
-                                }}
-                                className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
-                            >
-                                Cancel
-                            </Button>
-                        </div>
-                    </div>
-                ) : (
-                    <div className="mt-6 grid gap-4 md:grid-cols-2">
-                        {details.map((detail) => (
-                            <div key={detail.label} className="rounded-xl border border-slate-800/80 bg-slate-950/50 px-4 py-3">
-                                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">{detail.label}</p>
-                                <p className="mt-1 text-sm font-semibold text-slate-200">{detail.value || "-"}</p>
+                    {editing ? (
+                        <div className="grid gap-4 md:grid-cols-2">
+                            <label className={labelClasses}>
+                                Username
+                                <input value={profile.username} disabled className={`${inputClasses} cursor-not-allowed opacity-60`} />
+                            </label>
+                            <label className={labelClasses}>
+                                Legal Business Name
+                                <input
+                                    className={inputClasses}
+                                    name="legalBusinessName"
+                                    value={formData.legalBusinessName || ""}
+                                    onChange={handleChange}
+                                    placeholder="Legal Business Name"
+                                />
+                            </label>
+                            <label className={labelClasses}>
+                                Name
+                                <input
+                                    className={inputClasses}
+                                    name="name"
+                                    value={formData.name || ""}
+                                    onChange={handleChange}
+                                    placeholder="Name"
+                                />
+                            </label>
+                            <label className={labelClasses}>
+                                Country of Incorporation
+                                <input
+                                    className={inputClasses}
+                                    name="countryOfIncorporation"
+                                    value={formData.countryOfIncorporation || ""}
+                                    onChange={handleChange}
+                                    placeholder="Country of Incorporation"
+                                />
+                            </label>
+                            <label className={labelClasses}>
+                                Tax ID
+                                <input
+                                    className={inputClasses}
+                                    name="taxId"
+                                    value={formData.taxId || ""}
+                                    onChange={handleChange}
+                                    placeholder="Tax ID"
+                                />
+                            </label>
+                            <label className={labelClasses}>
+                                Company Registration Number
+                                <input
+                                    className={inputClasses}
+                                    name="companyRegistrationNumber"
+                                    value={formData.companyRegistrationNumber || ""}
+                                    onChange={handleChange}
+                                    placeholder="Company Registration Number"
+                                />
+                            </label>
+                            <label className={labelClasses}>
+                                Primary Contact Name
+                                <input
+                                    className={inputClasses}
+                                    name="primaryContactName"
+                                    value={formData.primaryContactName || ""}
+                                    onChange={handleChange}
+                                    placeholder="Primary Contact Name"
+                                />
+                            </label>
+                            <label className={labelClasses}>
+                                Primary Contact Email
+                                <input
+                                    className={inputClasses}
+                                    name="primaryContactEmail"
+                                    value={formData.primaryContactEmail || ""}
+                                    onChange={handleChange}
+                                    placeholder="Primary Contact Email"
+                                />
+                            </label>
+                            <label className={labelClasses}>
+                                Primary Contact Phone
+                                <input
+                                    className={inputClasses}
+                                    name="primaryContactPhone"
+                                    value={formData.primaryContactPhone || ""}
+                                    onChange={handleChange}
+                                    placeholder="Primary Contact Phone"
+                                />
+                            </label>
+                            <label className={labelClasses}>
+                                Technical Contact Name
+                                <input
+                                    className={inputClasses}
+                                    name="technicalContactName"
+                                    value={formData.technicalContactName || ""}
+                                    onChange={handleChange}
+                                    placeholder="Technical Contact Name"
+                                />
+                            </label>
+                            <label className={labelClasses}>
+                                Technical Contact Email
+                                <input
+                                    className={inputClasses}
+                                    name="technicalContactEmail"
+                                    value={formData.technicalContactEmail || ""}
+                                    onChange={handleChange}
+                                    placeholder="Technical Contact Email"
+                                />
+                            </label>
+                            <label className={labelClasses}>
+                                Technical Contact Phone
+                                <input
+                                    className={inputClasses}
+                                    name="technicalContactPhone"
+                                    value={formData.technicalContactPhone || ""}
+                                    onChange={handleChange}
+                                    placeholder="Technical Contact Phone"
+                                />
+                            </label>
+                            <label className={`${labelClasses} md:col-span-2`}>
+                                Company Description
+                                <textarea
+                                    className={`${inputClasses} min-h-[120px]`}
+                                    name="companyDescription"
+                                    value={formData.companyDescription || ""}
+                                    onChange={handleChange}
+                                    placeholder="Company Description"
+                                />
+                            </label>
+                            <div className="md:col-span-2 flex flex-wrap items-center gap-3">
+                                <Button variant="success" onClick={handleSave} className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]">
+                                    Save
+                                </Button>
+                                <Button
+                                    variant="ghost"
+                                    onClick={() => {
+                                        setEditing(false);
+                                        setFormData(profile);
+                                    }}
+                                    className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
+                                >
+                                    Cancel
+                                </Button>
                             </div>
-                        ))}
-                        <div className="md:col-span-2 flex justify-end">
-                            <Button onClick={() => setEditing(true)} className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]">
-                                Edit Profile
-                            </Button>
                         </div>
-                    </div>
-                )}
+                    ) : (
+                        <div className="grid gap-4 md:grid-cols-2">
+                            {details.map((detail) => (
+                                <div key={detail.label} className="rounded-xl border border-slate-800/80 bg-slate-950/50 px-4 py-3">
+                                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">{detail.label}</p>
+                                    <p className="mt-1 text-sm font-semibold text-slate-200">{detail.value || "-"}</p>
+                                </div>
+                            ))}
+                            <div className="md:col-span-2 flex justify-end">
+                                <Button onClick={() => setEditing(true)} className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]">
+                                    Edit Profile
+                                </Button>
+                            </div>
+                        </div>
+                    )}
+                </div>
             </section>
         </Layout>
     );

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -118,113 +118,112 @@ const Buy = () => {
         <Layout onLogout={handleLogout}>
             <div className="flex flex-col gap-6 xl:flex-row">
                 <section className="flex-1 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
-                    <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Trading Desk</p>
-                        <h1 className="text-3xl font-bold text-white">Available Contracts</h1>
-                        <p className="text-sm text-slate-400">
-                            Filter by counterparty, price range, or search by keyword to identify the right purchase opportunity.
-                        </p>
-                    </div>
+                    <div className="space-y-6">
+                        <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
+                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Trading Desk</p>
+                            <h1 className="text-3xl font-bold text-white">Available Contracts</h1>
+                            <p className="text-sm text-slate-400">
+                                Filter by counterparty, price range, or search by keyword to identify the right purchase opportunity.
+                            </p>
+                        </div>
 
-                    {notification && (
-                        <div className="mt-6">
+                        {notification && (
                             <NotificationBanner
                                 type={notification.type}
                                 message={notification.message}
                                 onDismiss={() => setNotification(null)}
                             />
+                        )}
+                        {error && <p className="text-sm text-red-400">{error}</p>}
+
+                        <div className="grid gap-4 rounded-xl border border-slate-800 bg-slate-950/40 p-4 sm:grid-cols-2 lg:grid-cols-4">
+                            <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
+                                Search
+                                <input
+                                    type="text"
+                                    placeholder="Title or seller"
+                                    value={search}
+                                    onChange={(e) => setSearch(e.target.value)}
+                                    className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
+                                />
+                            </label>
+                            <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
+                                Min Price
+                                <input
+                                    type="number"
+                                    placeholder="0"
+                                    value={minPrice}
+                                    onChange={(e) => setMinPrice(e.target.value)}
+                                    className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
+                                />
+                            </label>
+                            <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
+                                Max Price
+                                <input
+                                    type="number"
+                                    placeholder="0"
+                                    value={maxPrice}
+                                    onChange={(e) => setMaxPrice(e.target.value)}
+                                    className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
+                                />
+                            </label>
+                            <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
+                                Seller
+                                <select
+                                    value={sellerFilter}
+                                    onChange={(e) => setSellerFilter(e.target.value)}
+                                    className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
+                                >
+                                    <option value="">All Sellers</option>
+                                    {sellers.map((s) => (
+                                        <option key={s} value={s}>
+                                            {s}
+                                        </option>
+                                    ))}
+                                </select>
+                            </label>
                         </div>
-                    )}
-                    {error && <p className="mt-4 text-sm text-red-400">{error}</p>}
 
-                    <div className="mt-6 grid gap-4 rounded-xl border border-slate-800 bg-slate-950/40 p-4 sm:grid-cols-2 lg:grid-cols-4">
-                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
-                            Search
-                            <input
-                                type="text"
-                                placeholder="Title or seller"
-                                value={search}
-                                onChange={(e) => setSearch(e.target.value)}
-                                className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
-                            />
-                        </label>
-                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
-                            Min Price
-                            <input
-                                type="number"
-                                placeholder="0"
-                                value={minPrice}
-                                onChange={(e) => setMinPrice(e.target.value)}
-                                className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
-                            />
-                        </label>
-                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
-                            Max Price
-                            <input
-                                type="number"
-                                placeholder="0"
-                                value={maxPrice}
-                                onChange={(e) => setMaxPrice(e.target.value)}
-                                className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
-                            />
-                        </label>
-                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
-                            Seller
-                            <select
-                                value={sellerFilter}
-                                onChange={(e) => setSellerFilter(e.target.value)}
-                                className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
-                            >
-                                <option value="">All Sellers</option>
-                                {sellers.map((s) => (
-                                    <option key={s} value={s}>
-                                        {s}
-                                    </option>
-                                ))}
-                            </select>
-                        </label>
-                    </div>
-
-                    <div className="mt-6 overflow-hidden rounded-xl border border-slate-800/80">
-                        <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
-                            <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
-                                <tr>
-                                    <th className="px-4 py-3">Title</th>
-                                    <th className="px-4 py-3">Seller</th>
-                                    <th className="px-4 py-3">Ask Price</th>
-                                    <th className="px-4 py-3">Delivery</th>
-                                    <th className="px-4 py-3">Actions</th>
-                                </tr>
-                            </thead>
-                            <tbody className="divide-y divide-slate-800/70">
-                                {isLoading ? (
-                                    <TableSkeleton columns={5} rows={5} />
-                                ) : (
-                                    <>
-                                        {filteredContracts.map((contract) => (
-                                            <tr
-                                                key={contract.id}
-                                                className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-[#00D1FF]/10"
-                                                onClick={() => setSelectedContract(contract)}
-                                            >
-                                                <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
-                                                <td className="px-4 py-3">{contract.seller}</td>
-                                                <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${contract.price}</td>
-                                                <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
-                                                <td className="px-4 py-3">
-                                                    <Button
-                                                        variant="success"
-                                                        onClick={(e) => {
-                                                            e.stopPropagation();
-                                                            openSignatureModal(contract.id);
-                                                        }}
-                                                        className="px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
-                                                    >
-                                                        Buy
-                                                    </Button>
-                                                </td>
-                                            </tr>
-                                        ))}
+                        <div className="overflow-hidden rounded-xl border border-slate-800/80">
+                            <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
+                                <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
+                                    <tr>
+                                        <th className="px-4 py-3">Title</th>
+                                        <th className="px-4 py-3">Seller</th>
+                                        <th className="px-4 py-3">Ask Price</th>
+                                        <th className="px-4 py-3">Delivery</th>
+                                        <th className="px-4 py-3">Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-slate-800/70">
+                                    {isLoading ? (
+                                        <TableSkeleton columns={5} rows={5} />
+                                    ) : (
+                                        <>
+                                            {filteredContracts.map((contract) => (
+                                                <tr
+                                                    key={contract.id}
+                                                    className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-[#00D1FF]/10"
+                                                    onClick={() => setSelectedContract(contract)}
+                                                >
+                                                    <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
+                                                    <td className="px-4 py-3">{contract.seller}</td>
+                                                    <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${contract.price}</td>
+                                                    <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
+                                                    <td className="px-4 py-3">
+                                                        <Button
+                                                            variant="success"
+                                                            onClick={(e) => {
+                                                                e.stopPropagation();
+                                                                openSignatureModal(contract.id);
+                                                            }}
+                                                            className="px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
+                                                        >
+                                                            Buy
+                                                        </Button>
+                                                    </td>
+                                                </tr>
+                                            ))}
                                         {filteredContracts.length === 0 && (
                                             <tr>
                                                 <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
@@ -236,6 +235,7 @@ const Buy = () => {
                                 )}
                             </tbody>
                         </table>
+                        </div>
                     </div>
                 </section>
 

--- a/bellingham-frontend/src/components/Calendar.jsx
+++ b/bellingham-frontend/src/components/Calendar.jsx
@@ -88,49 +88,51 @@ const ContractCalendar = () => {
     return (
         <Layout onLogout={handleLogout}>
             <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
-                <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Operations</p>
-                    <h1 className="text-3xl font-bold text-white">Contract Calendar</h1>
-                    <p className="text-sm text-slate-400">
-                        Visualise purchase and delivery events to plan workloads, handovers, and client communications.
-                    </p>
-                </div>
-                <div className="mt-6 grid gap-6 lg:grid-cols-[2fr,1fr]">
-                    <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4">
-                        <Calendar
-                            onChange={setSelectedDate}
-                            value={selectedDate}
-                            tileContent={tileContent}
-                            tileClassName={tileClassName}
-                        />
-                        <div className="mt-4 flex flex-wrap items-center gap-4 text-sm text-slate-300">
-                            {Object.entries(TYPE_INFO).map(([type, info]) => (
-                                <div key={type} className="flex items-center gap-2">
-                                    <span className={`h-3 w-3 rounded-full ${info.color}`} aria-hidden="true" />
-                                    <span>{type}</span>
-                                </div>
-                            ))}
-                        </div>
+                <div className="space-y-6">
+                    <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
+                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Operations</p>
+                        <h1 className="text-3xl font-bold text-white">Contract Calendar</h1>
+                        <p className="text-sm text-slate-400">
+                            Visualise purchase and delivery events to plan workloads, handovers, and client communications.
+                        </p>
                     </div>
-                    <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4">
-                        <h2 className="text-lg font-semibold text-white">Events on {formattedSelected}</h2>
-                        {events.length === 0 ? (
-                            <p className="mt-3 text-sm text-slate-400">No scheduled milestones for this date.</p>
-                        ) : (
-                            <ul className="mt-3 space-y-2 text-sm">
-                                {events.map((ev, idx) => (
-                                    <li key={`${ev.title}-${idx}`} className="flex items-center gap-2">
-                                        <span
-                                            className={`inline-flex h-6 w-6 items-center justify-center rounded-full text-[0.65rem] font-semibold text-slate-900 ${TYPE_INFO[ev.type]?.color ?? "bg-slate-400"}`}
-                                        >
-                                            {TYPE_INFO[ev.type]?.initial ?? "?"}
-                                        </span>
-                                        <span className="text-slate-200">{ev.type}:</span>
-                                        <span className="font-semibold text-white">{ev.title}</span>
-                                    </li>
+                    <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+                        <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4 space-y-4">
+                            <Calendar
+                                onChange={setSelectedDate}
+                                value={selectedDate}
+                                tileContent={tileContent}
+                                tileClassName={tileClassName}
+                            />
+                            <div className="flex flex-wrap items-center gap-4 text-sm text-slate-300">
+                                {Object.entries(TYPE_INFO).map(([type, info]) => (
+                                    <div key={type} className="flex items-center gap-2">
+                                        <span className={`h-3 w-3 rounded-full ${info.color}`} aria-hidden="true" />
+                                        <span>{type}</span>
+                                    </div>
                                 ))}
-                            </ul>
-                        )}
+                            </div>
+                        </div>
+                        <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4 space-y-3">
+                            <h2 className="text-lg font-semibold text-white">Events on {formattedSelected}</h2>
+                            {events.length === 0 ? (
+                                <p className="text-sm text-slate-400">No scheduled milestones for this date.</p>
+                            ) : (
+                                <ul className="space-y-2 text-sm">
+                                    {events.map((ev, idx) => (
+                                        <li key={`${ev.title}-${idx}`} className="flex items-center gap-2">
+                                            <span
+                                                className={`inline-flex h-6 w-6 items-center justify-center rounded-full text-[0.65rem] font-semibold text-slate-900 ${TYPE_INFO[ev.type]?.color ?? "bg-slate-400"}`}
+                                            >
+                                                {TYPE_INFO[ev.type]?.initial ?? "?"}
+                                            </span>
+                                            <span className="text-slate-200">{ev.type}:</span>
+                                            <span className="font-semibold text-white">{ev.title}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+                        </div>
                     </div>
                 </div>
             </section>

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -84,84 +84,87 @@ const Dashboard = () => {
         <Layout onLogout={handleLogout}>
             <div className="grid grid-cols-1 gap-6 xl:grid-cols-[260px_minmax(0,1fr)_320px] xl:gap-8">
                 <main className="order-1 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 lg:p-8 shadow-[0_20px_45px_rgba(2,12,32,0.55)] xl:order-2">
-                    <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Market Overview</p>
-                        <h2 className="text-3xl font-bold text-white">Open Contracts</h2>
-                        <p className="text-sm text-slate-400">
-                            Monitor current opportunities and select a contract to inspect the full trade details.
-                        </p>
-                    </div>
-                    <div className="mt-6 overflow-hidden rounded-xl border border-slate-800/80">
-                        <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
-                            <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
-                                <tr>
-                                    <th className="px-4 py-3">Title</th>
-                                    <th className="px-4 py-3">Seller</th>
-                                    <th className="px-4 py-3">Ask Price</th>
-                                    <th className="px-4 py-3">Status</th>
-                                    <th className="px-4 py-3">Delivery</th>
-                                </tr>
-                            </thead>
-                            <tbody className="divide-y divide-slate-800/70">
-                                {isLoading ? (
-                                    <TableSkeleton columns={5} rows={5} />
-                                ) : (
-                                    <>
-                                        {contracts.map((contract) => (
-                                            <tr
-                                                key={contract.id}
-                                                className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-[#00D1FF]/10"
-                                                onClick={() => setSelectedContract(contract)}
-                                            >
-                                                <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
-                                                <td className="px-4 py-3">{contract.seller}</td>
-                                                <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">
-                                                    ${contract.price}
-                                                </td>
-                                                <td className="px-4 py-3">
-                                                    <span className="rounded-full border border-[#00D1FF]/40 bg-[#00D1FF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#00D1FF]">
-                                                        {contract.status}
-                                                    </span>
-                                                </td>
-                                                <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
-                                            </tr>
-                                        ))}
-                                        {contracts.length === 0 && (
-                                            <tr>
-                                                <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
-                                                    No contracts available at the moment.
-                                                </td>
-                                            </tr>
-                                        )}
-                                    </>
-                                )}
-                            </tbody>
-                        </table>
+                    <div className="space-y-6">
+                        <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
+                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Market Overview</p>
+                            <h2 className="text-3xl font-bold text-white">Open Contracts</h2>
+                            <p className="text-sm text-slate-400">
+                                Monitor current opportunities and select a contract to inspect the full trade details.
+                            </p>
+                        </div>
+                        <div className="overflow-hidden rounded-xl border border-slate-800/80">
+                            <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
+                                <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
+                                    <tr>
+                                        <th className="px-4 py-3">Title</th>
+                                        <th className="px-4 py-3">Seller</th>
+                                        <th className="px-4 py-3">Ask Price</th>
+                                        <th className="px-4 py-3">Status</th>
+                                        <th className="px-4 py-3">Delivery</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-slate-800/70">
+                                    {isLoading ? (
+                                        <TableSkeleton columns={5} rows={5} />
+                                    ) : (
+                                        <>
+                                            {contracts.map((contract) => (
+                                                <tr
+                                                    key={contract.id}
+                                                    className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-[#00D1FF]/10"
+                                                    onClick={() => setSelectedContract(contract)}
+                                                >
+                                                    <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
+                                                    <td className="px-4 py-3">{contract.seller}</td>
+                                                    <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">
+                                                        ${contract.price}
+                                                    </td>
+                                                    <td className="px-4 py-3">
+                                                        <span className="rounded-full border border-[#00D1FF]/40 bg-[#00D1FF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#00D1FF]">
+                                                            {contract.status}
+                                                        </span>
+                                                    </td>
+                                                    <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
+                                                </tr>
+                                            ))}
+                                            {contracts.length === 0 && (
+                                                <tr>
+                                                    <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
+                                                        No contracts available at the moment.
+                                                    </td>
+                                                </tr>
+                                            )}
+                                        </>
+                                    )}
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
                 </main>
-                <aside className="order-2 space-y-4 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 lg:p-8 shadow-[0_20px_45px_rgba(2,12,32,0.45)] xl:order-1">
-                    <div className="border-b border-slate-800 pb-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#3BAEAB]/80">Analytics</p>
-                        <h3 className="text-2xl font-semibold text-white">Marketplace KPIs</h3>
-                        <p className="mt-2 text-sm text-slate-400">
-                            Track headline performance metrics alongside the live order book.
-                        </p>
-                    </div>
-                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-1">
-                        {isLoading ? (
-                            Array.from({ length: 4 }).map((_, index) => (
-                                <div
-                                    key={`kpi-skeleton-${index}`}
-                                    className="h-24 animate-pulse rounded-xl border border-slate-800/70 bg-slate-950/40"
-                                />
-                            ))
-                        ) : (
-                            <>
-                                <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4 shadow-inner">
-                                    <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Open Contracts</p>
-                                    <p className="numeric-text mt-3 text-3xl font-bold text-[#00D1FF]">{formatNumber(kpis.openContracts)}</p>
-                                    <p className="mt-1 text-xs text-slate-500">Currently listed opportunities</p>
-                                </div>
+                <aside className="order-2 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 lg:p-8 shadow-[0_20px_45px_rgba(2,12,32,0.45)] xl:order-1">
+                    <div className="space-y-6">
+                        <div className="border-b border-slate-800 pb-4">
+                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#3BAEAB]/80">Analytics</p>
+                            <h3 className="text-2xl font-semibold text-white">Marketplace KPIs</h3>
+                            <p className="mt-2 text-sm text-slate-400">
+                                Track headline performance metrics alongside the live order book.
+                            </p>
+                        </div>
+                        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-1">
+                            {isLoading ? (
+                                Array.from({ length: 4 }).map((_, index) => (
+                                    <div
+                                        key={`kpi-skeleton-${index}`}
+                                        className="h-24 animate-pulse rounded-xl border border-slate-800/70 bg-slate-950/40"
+                                    />
+                                ))
+                            ) : (
+                                <>
+                                    <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4 shadow-inner">
+                                        <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Open Contracts</p>
+                                        <p className="numeric-text mt-3 text-3xl font-bold text-[#00D1FF]">{formatNumber(kpis.openContracts)}</p>
+                                        <p className="mt-1 text-xs text-slate-500">Currently listed opportunities</p>
+                                    </div>
                                 <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4 shadow-inner">
                                     <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Total Ask Volume</p>
                                     <p className="numeric-text mt-3 text-3xl font-bold text-[#3BAEAB]">{formatCurrency(kpis.totalVolume)}</p>
@@ -177,8 +180,9 @@ const Dashboard = () => {
                                     <p className="numeric-text mt-3 text-3xl font-bold text-[#7465A8]">{formatNumber(kpis.activeSellers)}</p>
                                     <p className="mt-1 text-xs text-slate-500">Distinct market participants</p>
                                 </div>
-                            </>
-                        )}
+                                </>
+                            )}
+                        </div>
                     </div>
                 </aside>
                 <aside className="order-3 xl:order-3">

--- a/bellingham-frontend/src/components/History.jsx
+++ b/bellingham-frontend/src/components/History.jsx
@@ -35,48 +35,50 @@ const History = () => {
         <Layout onLogout={handleLogout}>
             <div className="flex flex-col gap-6 xl:flex-row">
                 <section className="flex-1 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
-                    <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Audit Trail</p>
-                        <h1 className="text-3xl font-bold text-white">Contract History</h1>
-                        <p className="text-sm text-slate-400">
-                            A complete ledger of executed contracts across the platform with buyer and seller visibility.
-                        </p>
-                    </div>
-                    {error && <p className="mt-4 text-sm text-red-400">{error}</p>}
-                    <div className="mt-6 overflow-hidden rounded-xl border border-slate-800/80">
-                        <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
-                            <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
-                                <tr>
-                                    <th className="px-4 py-3">Title</th>
-                                    <th className="px-4 py-3">Seller</th>
-                                    <th className="px-4 py-3">Buyer</th>
-                                    <th className="px-4 py-3">Price</th>
-                                    <th className="px-4 py-3">Delivery</th>
-                                </tr>
-                            </thead>
-                            <tbody className="divide-y divide-slate-800/70">
-                                {contracts.map((c) => (
-                                    <tr
-                                        key={c.id}
-                                        className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-[#00D1FF]/10"
-                                        onClick={() => setSelectedContract(c)}
-                                    >
-                                        <td className="px-4 py-3 font-semibold text-slate-100">{c.title}</td>
-                                        <td className="px-4 py-3">{c.seller}</td>
-                                        <td className="px-4 py-3">{c.buyerUsername || "-"}</td>
-                                        <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
-                                        <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
-                                    </tr>
-                                ))}
-                                {contracts.length === 0 && (
+                    <div className="space-y-6">
+                        <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
+                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Audit Trail</p>
+                            <h1 className="text-3xl font-bold text-white">Contract History</h1>
+                            <p className="text-sm text-slate-400">
+                                A complete ledger of executed contracts across the platform with buyer and seller visibility.
+                            </p>
+                        </div>
+                        {error && <p className="text-sm text-red-400">{error}</p>}
+                        <div className="overflow-hidden rounded-xl border border-slate-800/80">
+                            <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
+                                <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
                                     <tr>
-                                        <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
-                                            No historical contracts are available right now.
-                                        </td>
+                                        <th className="px-4 py-3">Title</th>
+                                        <th className="px-4 py-3">Seller</th>
+                                        <th className="px-4 py-3">Buyer</th>
+                                        <th className="px-4 py-3">Price</th>
+                                        <th className="px-4 py-3">Delivery</th>
                                     </tr>
-                                )}
-                            </tbody>
-                        </table>
+                                </thead>
+                                <tbody className="divide-y divide-slate-800/70">
+                                    {contracts.map((c) => (
+                                        <tr
+                                            key={c.id}
+                                            className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-[#00D1FF]/10"
+                                            onClick={() => setSelectedContract(c)}
+                                        >
+                                            <td className="px-4 py-3 font-semibold text-slate-100">{c.title}</td>
+                                            <td className="px-4 py-3">{c.seller}</td>
+                                            <td className="px-4 py-3">{c.buyerUsername || "-"}</td>
+                                            <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
+                                            <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
+                                        </tr>
+                                    ))}
+                                    {contracts.length === 0 && (
+                                        <tr>
+                                            <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
+                                                No historical contracts are available right now.
+                                            </td>
+                                        </tr>
+                                    )}
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
                 </section>
                 <div className="xl:w-[360px]">

--- a/bellingham-frontend/src/components/Notifications.jsx
+++ b/bellingham-frontend/src/components/Notifications.jsx
@@ -31,84 +31,86 @@ const Notifications = () => {
     return (
         <Layout onLogout={handleLogout}>
             <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
-                <div className="flex flex-col gap-4 border-b border-slate-800 pb-4 md:flex-row md:items-center md:justify-between">
-                    <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Inbox</p>
-                        <h1 className="text-3xl font-bold text-white">Notifications</h1>
-                        <p className="text-sm text-slate-400">
-                            Review trade events, approvals, and operational alerts from across the platform.
-                        </p>
+                <div className="space-y-6">
+                    <div className="flex flex-col gap-4 border-b border-slate-800 pb-4 md:flex-row md:items-center md:justify-between">
+                        <div>
+                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Inbox</p>
+                            <h1 className="text-3xl font-bold text-white">Notifications</h1>
+                            <p className="text-sm text-slate-400">
+                                Review trade events, approvals, and operational alerts from across the platform.
+                            </p>
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                            <Button
+                                variant="ghost"
+                                className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
+                                onClick={refreshNotifications}
+                            >
+                                Refresh
+                            </Button>
+                            <Button
+                                variant="success"
+                                className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
+                                onClick={markAllRead}
+                                disabled={unreadCount === 0}
+                            >
+                                Mark all read
+                            </Button>
+                        </div>
                     </div>
-                    <div className="flex flex-wrap gap-2">
-                        <Button
-                            variant="ghost"
-                            className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
-                            onClick={refreshNotifications}
-                        >
-                            Refresh
-                        </Button>
-                        <Button
-                            variant="success"
-                            className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
-                            onClick={markAllRead}
-                            disabled={unreadCount === 0}
-                        >
-                            Mark all read
-                        </Button>
+                    <div className="space-y-4">
+                        {loading ? (
+                            <p className="text-sm text-slate-300">Loading notifications…</p>
+                        ) : error ? (
+                            <p className="text-sm text-red-400">{error}</p>
+                        ) : notifications.length === 0 ? (
+                            <p className="text-sm text-slate-300">You do not have any notifications yet.</p>
+                        ) : (
+                            <ul className="space-y-4">
+                                {notifications.map((notification) => (
+                                    <li
+                                        key={notification.id}
+                                        className="rounded-xl border border-slate-800/80 bg-slate-950/60 p-4 shadow-sm"
+                                    >
+                                        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                                            <div>
+                                                <p className="text-sm font-semibold text-white">
+                                                    {notification.title || "Notification"}
+                                                </p>
+                                                {notification.message && (
+                                                    <p className="text-sm text-slate-300">
+                                                        {notification.message}
+                                                    </p>
+                                                )}
+                                                {(notification.timestamp || notification.createdAt) && (
+                                                    <p className="text-xs text-slate-500">
+                                                        {new Date(
+                                                            notification.timestamp || notification.createdAt
+                                                        ).toLocaleString()}
+                                                    </p>
+                                                )}
+                                            </div>
+                                            <div className="flex flex-wrap gap-2">
+                                                {!notification.readFlag ? (
+                                                    <Button
+                                                        variant="success"
+                                                        className="px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
+                                                        onClick={() => markRead(notification.id)}
+                                                    >
+                                                        Mark read
+                                                    </Button>
+                                                ) : (
+                                                    <span className="rounded-full border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-300">
+                                                        Read
+                                                    </span>
+                                                )}
+                                            </div>
+                                        </div>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
                     </div>
-                </div>
-                <div className="mt-6 space-y-4">
-                    {loading ? (
-                        <p className="text-sm text-slate-300">Loading notifications…</p>
-                    ) : error ? (
-                        <p className="text-sm text-red-400">{error}</p>
-                    ) : notifications.length === 0 ? (
-                        <p className="text-sm text-slate-300">You do not have any notifications yet.</p>
-                    ) : (
-                        <ul className="space-y-4">
-                            {notifications.map((notification) => (
-                                <li
-                                    key={notification.id}
-                                    className="rounded-xl border border-slate-800/80 bg-slate-950/60 p-4 shadow-sm"
-                                >
-                                    <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                                        <div>
-                                            <p className="text-sm font-semibold text-white">
-                                                {notification.title || "Notification"}
-                                            </p>
-                                            {notification.message && (
-                                                <p className="text-sm text-slate-300">
-                                                    {notification.message}
-                                                </p>
-                                            )}
-                                            {(notification.timestamp || notification.createdAt) && (
-                                                <p className="text-xs text-slate-500">
-                                                    {new Date(
-                                                        notification.timestamp || notification.createdAt
-                                                    ).toLocaleString()}
-                                                </p>
-                                            )}
-                                        </div>
-                                        <div className="flex flex-wrap gap-2">
-                                            {!notification.readFlag ? (
-                                                <Button
-                                                    variant="success"
-                                                    className="px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
-                                                    onClick={() => markRead(notification.id)}
-                                                >
-                                                    Mark read
-                                                </Button>
-                                            ) : (
-                                                <span className="rounded-full border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-300">
-                                                    Read
-                                                </span>
-                                            )}
-                                        </div>
-                                    </div>
-                                </li>
-                            ))}
-                        </ul>
-                    )}
                 </div>
             </section>
         </Layout>

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -301,21 +301,22 @@ const Reports = () => {
         <Layout onLogout={handleLogout}>
             <div className="flex flex-col gap-6 xl:flex-row">
                 <section className="flex-1 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
-                    <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Analytics</p>
-                        <h1 className="text-3xl font-bold text-white">Purchased Contracts</h1>
-                        <p className="text-sm text-slate-400">
-                            Track portfolio allocation, performance, and lifecycle events across your acquired contracts.
-                        </p>
-                    </div>
-                    {error && <p className="mt-4 text-sm text-red-400">{error}</p>}
+                    <div className="space-y-6">
+                        <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
+                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Analytics</p>
+                            <h1 className="text-3xl font-bold text-white">Purchased Contracts</h1>
+                            <p className="text-sm text-slate-400">
+                                Track portfolio allocation, performance, and lifecycle events across your acquired contracts.
+                            </p>
+                        </div>
+                        {error && <p className="text-sm text-red-400">{error}</p>}
 
-                    <div className="mt-6 grid gap-6">
-                        <div className="rounded-2xl border border-slate-800 bg-slate-950/40 p-6">
-                            {isLoading ? (
-                                <div className="flex h-72 items-center justify-center lg:h-96">
-                                    <div className="h-12 w-12 animate-spin rounded-full border-2 border-[#00D1FF] border-t-transparent" />
-                                </div>
+                        <div className="grid gap-6">
+                            <div className="rounded-2xl border border-slate-800 bg-slate-950/40 p-6">
+                                {isLoading ? (
+                                    <div className="flex h-72 items-center justify-center lg:h-96">
+                                        <div className="h-12 w-12 animate-spin rounded-full border-2 border-[#00D1FF] border-t-transparent" />
+                                    </div>
                             ) : contracts.length ? (
                                 <div className="flex flex-col gap-6 lg:flex-row">
                                     <div className="flex w-full flex-col gap-4 lg:flex-1">
@@ -399,73 +400,76 @@ const Reports = () => {
                             )}
                         </div>
 
-                        <div className="overflow-hidden rounded-2xl border border-slate-800/80">
-                            <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
-                                <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
-                                    <tr>
-                                        <th className="px-4 py-3">Title</th>
-                                        <th className="px-4 py-3">Seller</th>
-                                        <th className="px-4 py-3">Ask Price</th>
-                                        <th className="px-4 py-3">Delivery</th>
-                                        <th className="px-4 py-3">Actions</th>
-                                    </tr>
-                                </thead>
-                                <tbody className="divide-y divide-slate-800/70">
-                                    {isLoading ? (
-                                        <TableSkeleton columns={5} rows={5} />
-                                    ) : (
-                                        <>
-                                            {contracts.map((contract) => (
-                                                <tr
-                                                    key={contract.id}
-                                                    className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-[#00D1FF]/10"
-                                                    onClick={() => setSelectedContract(contract)}
-                                                >
-                                                    <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
-                                                    <td className="px-4 py-3">{contract.seller}</td>
-                                                    <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${contract.price}</td>
-                                                    <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
-                                                    <td className="px-4 py-3">
-                                                        <div className="flex flex-wrap gap-2">
-                                                            <Button
-                                                                onClick={(e) => {
-                                                                    e.stopPropagation();
-                                                                    handleListForSale(contract.id);
-                                                                }}
-                                                                className="px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
-                                                            >
-                                                                List for Sale
-                                                            </Button>
-                                                            <Button
-                                                                variant="danger"
-                                                                onClick={(e) => {
-                                                                    e.stopPropagation();
-                                                                    handleCloseout(contract.id);
-                                                                }}
-                                                                className="px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
-                                                            >
-                                                                Closeout
-                                                            </Button>
-                                                        </div>
-                                                    </td>
-                                                </tr>
-                                            ))}
-                                            {contracts.length === 0 && (
-                                                <tr>
-                                                    <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
-                                                        No purchased contracts available.
-                                                    </td>
-                                                </tr>
-                                            )}
-                                        </>
-                                    )}
-                                </tbody>
-                            </table>
-                        </div>
+                        <div className="space-y-6">
+                            <div className="overflow-hidden rounded-2xl border border-slate-800/80">
+                                <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
+                                    <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
+                                        <tr>
+                                            <th className="px-4 py-3">Title</th>
+                                            <th className="px-4 py-3">Seller</th>
+                                            <th className="px-4 py-3">Ask Price</th>
+                                            <th className="px-4 py-3">Delivery</th>
+                                            <th className="px-4 py-3">Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody className="divide-y divide-slate-800/70">
+                                        {isLoading ? (
+                                            <TableSkeleton columns={5} rows={5} />
+                                        ) : (
+                                            <>
+                                                {contracts.map((contract) => (
+                                                    <tr
+                                                        key={contract.id}
+                                                        className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-[#00D1FF]/10"
+                                                        onClick={() => setSelectedContract(contract)}
+                                                    >
+                                                        <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
+                                                        <td className="px-4 py-3">{contract.seller}</td>
+                                                        <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${contract.price}</td>
+                                                        <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
+                                                        <td className="px-4 py-3">
+                                                            <div className="flex flex-wrap gap-2">
+                                                                <Button
+                                                                    onClick={(e) => {
+                                                                        e.stopPropagation();
+                                                                        handleListForSale(contract.id);
+                                                                    }}
+                                                                    className="px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
+                                                                >
+                                                                    List for Sale
+                                                                </Button>
+                                                                <Button
+                                                                    variant="danger"
+                                                                    onClick={(e) => {
+                                                                        e.stopPropagation();
+                                                                        handleCloseout(contract.id);
+                                                                    }}
+                                                                    className="px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em]"
+                                                                >
+                                                                    Closeout
+                                                                </Button>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                ))}
+                                                {contracts.length === 0 && (
+                                                    <tr>
+                                                        <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
+                                                            No purchased contracts available.
+                                                        </td>
+                                                    </tr>
+                                                )}
+                                            </>
+                                        )}
+                                    </tbody>
+                                </table>
+                            </div>
 
-                        <p className="text-lg font-semibold text-[#00D1FF]">
-                            Portfolio Value <span className="numeric-text">${totalValue.toFixed(2)}</span>
-                        </p>
+                            <p className="text-lg font-semibold text-[#00D1FF]">
+                                Portfolio Value <span className="numeric-text">${totalValue.toFixed(2)}</span>
+                            </p>
+                        </div>
+                        </div>
                     </div>
                 </section>
                 <div className="xl:w-[360px]">

--- a/bellingham-frontend/src/components/Sales.jsx
+++ b/bellingham-frontend/src/components/Sales.jsx
@@ -67,103 +67,105 @@ const Sales = () => {
         <Layout onLogout={handleLogout}>
             <div className="flex flex-col gap-6 xl:flex-row">
                 <section className="flex-1 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
-                    <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Seller Desk</p>
-                        <h1 className="text-3xl font-bold text-white">Sold Contracts</h1>
-                        <p className="text-sm text-slate-400">
-                            Review recently executed sales and revisit the associated contract data for compliance.
-                        </p>
-                    </div>
-                    {error && <p className="mt-4 text-sm text-red-400">{error}</p>}
+                    <div className="space-y-6">
+                        <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
+                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Seller Desk</p>
+                            <h1 className="text-3xl font-bold text-white">Sold Contracts</h1>
+                            <p className="text-sm text-slate-400">
+                                Review recently executed sales and revisit the associated contract data for compliance.
+                            </p>
+                        </div>
+                        {error && <p className="text-sm text-red-400">{error}</p>}
 
-                    <div className="mt-6 grid gap-4 rounded-xl border border-slate-800 bg-slate-950/40 p-4 sm:grid-cols-2 lg:grid-cols-4">
-                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
-                            Search
-                            <input
-                                type="text"
-                                value={searchTerm}
-                                onChange={(event) => setSearchTerm(event.target.value)}
-                                placeholder="Title or buyer"
-                                className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
-                            />
-                        </label>
-                        <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
-                            Status
-                            <select
-                                value={statusFilter}
-                                onChange={(event) => setStatusFilter(event.target.value)}
-                                className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
-                            >
-                                <option value="">All Statuses</option>
-                                {statuses.map((status) => (
-                                    <option key={status} value={status}>
-                                        {status}
-                                    </option>
-                                ))}
-                            </select>
-                        </label>
-                    </div>
+                        <div className="grid gap-4 rounded-xl border border-slate-800 bg-slate-950/40 p-4 sm:grid-cols-2 lg:grid-cols-4">
+                            <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
+                                Search
+                                <input
+                                    type="text"
+                                    value={searchTerm}
+                                    onChange={(event) => setSearchTerm(event.target.value)}
+                                    placeholder="Title or buyer"
+                                    className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
+                                />
+                            </label>
+                            <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 max-w-xs">
+                                Status
+                                <select
+                                    value={statusFilter}
+                                    onChange={(event) => setStatusFilter(event.target.value)}
+                                    className="w-full max-w-xs rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none"
+                                >
+                                    <option value="">All Statuses</option>
+                                    {statuses.map((status) => (
+                                        <option key={status} value={status}>
+                                            {status}
+                                        </option>
+                                    ))}
+                                </select>
+                            </label>
+                        </div>
 
-                    <div className="mt-6 overflow-hidden rounded-xl border border-slate-800/80">
-                        <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
-                            <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
-                                <tr>
-                                    <th className="px-4 py-3">Title</th>
-                                    <th className="px-4 py-3">Buyer</th>
-                                    <th className="px-4 py-3">Price</th>
-                                    <th className="px-4 py-3">Delivery Date</th>
-                                    <th className="px-4 py-3">Status</th>
-                                </tr>
-                            </thead>
-                            <tbody className="divide-y divide-slate-800/70">
-                                {isLoading ? (
-                                    <TableSkeleton columns={5} rows={5} />
-                                ) : (
-                                    filteredContracts.map((c) => {
-                                        const isSelected = selectedContract?.id === c.id;
-
-                                        return (
-                                            <tr
-                                                key={c.id}
-                                                className={`group cursor-pointer transition-colors ${
-                                                    isSelected
-                                                        ? "bg-[#00D1FF]/15"
-                                                        : "bg-slate-950/40 hover:bg-[#7465A8]/12"
-                                                }`}
-                                                onClick={() => setSelectedContract(c)}
-                                                aria-selected={isSelected}
-                                            >
-                                                <td className="px-4 py-3 font-semibold text-slate-100">
-                                                    <div className="flex items-center gap-2">
-                                                        {isSelected && (
-                                                            <span className="inline-flex items-center rounded-full border border-[#00D1FF]/60 bg-[#00D1FF]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-[#00D1FF]">
-                                                                Selected
-                                                            </span>
-                                                        )}
-                                                        <span>{c.title}</span>
-                                                    </div>
-                                                </td>
-                                                <td className="px-4 py-3">{c.buyerUsername}</td>
-                                                <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
-                                                <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
-                                                <td className="px-4 py-3">
-                                                    <span className="rounded-full border border-[#00D1FF]/40 bg-[#00D1FF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#00D1FF]">
-                                                        {c.status}
-                                                    </span>
-                                                </td>
-                                            </tr>
-                                        );
-                                    })
-                                )}
-                                {!isLoading && filteredContracts.length === 0 && (
+                        <div className="overflow-hidden rounded-xl border border-slate-800/80">
+                            <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
+                                <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
                                     <tr>
-                                        <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
-                                            No contracts match your current filters.
-                                        </td>
+                                        <th className="px-4 py-3">Title</th>
+                                        <th className="px-4 py-3">Buyer</th>
+                                        <th className="px-4 py-3">Price</th>
+                                        <th className="px-4 py-3">Delivery Date</th>
+                                        <th className="px-4 py-3">Status</th>
                                     </tr>
-                                )}
-                            </tbody>
-                        </table>
+                                </thead>
+                                <tbody className="divide-y divide-slate-800/70">
+                                    {isLoading ? (
+                                        <TableSkeleton columns={5} rows={5} />
+                                    ) : (
+                                        filteredContracts.map((c) => {
+                                            const isSelected = selectedContract?.id === c.id;
+
+                                            return (
+                                                <tr
+                                                    key={c.id}
+                                                    className={`group cursor-pointer transition-colors ${
+                                                        isSelected
+                                                            ? "bg-[#00D1FF]/15"
+                                                            : "bg-slate-950/40 hover:bg-[#7465A8]/12"
+                                                    }`}
+                                                    onClick={() => setSelectedContract(c)}
+                                                    aria-selected={isSelected}
+                                                >
+                                                    <td className="px-4 py-3 font-semibold text-slate-100">
+                                                        <div className="flex items-center gap-2">
+                                                            {isSelected && (
+                                                                <span className="inline-flex items-center rounded-full border border-[#00D1FF]/60 bg-[#00D1FF]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-[#00D1FF]">
+                                                                    Selected
+                                                                </span>
+                                                            )}
+                                                            <span>{c.title}</span>
+                                                        </div>
+                                                    </td>
+                                                    <td className="px-4 py-3">{c.buyerUsername}</td>
+                                                    <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
+                                                    <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
+                                                    <td className="px-4 py-3">
+                                                        <span className="rounded-full border border-[#00D1FF]/40 bg-[#00D1FF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#00D1FF]">
+                                                            {c.status}
+                                                        </span>
+                                                    </td>
+                                                </tr>
+                                            );
+                                        })
+                                    )}
+                                    {!isLoading && filteredContracts.length === 0 && (
+                                        <tr>
+                                            <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
+                                                No contracts match your current filters.
+                                            </td>
+                                        </tr>
+                                    )}
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
                 </section>
                 <div className="xl:w-[360px]">

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -361,101 +361,105 @@ const Sell = () => {
             <Layout onLogout={handleLogout}>
                 <div className="flex flex-col gap-8">
                     <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
-                        <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Primary Listing</p>
-                            <h1 className="text-3xl font-bold text-white">Sell Your Data Contract</h1>
-                            <p className="text-sm text-slate-400">
-                                Provide the core commercial terms, delivery requirements, and legal agreement to list a new contract.
-                            </p>
+                        <div className="space-y-6">
+                            <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
+                                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Primary Listing</p>
+                                <h1 className="text-3xl font-bold text-white">Sell Your Data Contract</h1>
+                                <p className="text-sm text-slate-400">
+                                    Provide the core commercial terms, delivery requirements, and legal agreement to list a new contract.
+                                </p>
+                            </div>
+                            {message && (
+                                <p className="rounded-lg border border-slate-700 bg-slate-950/50 px-4 py-3 text-sm text-slate-200">
+                                    {message}
+                                </p>
+                            )}
+                            <form onSubmit={handleSubmit} className="space-y-6">
+                                <div>
+                                    <div className="flex flex-wrap items-center justify-between gap-3">
+                                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+                                            Step <span className="numeric-text">{currentStep + 1}</span> of{' '}
+                                            <span className="numeric-text">{steps.length}</span>
+                                        </p>
+                                        <span className="text-sm font-semibold text-white">{steps[currentStep].title}</span>
+                                    </div>
+                                    <div className="mt-2 h-2 w-full overflow-hidden rounded-full border border-slate-800/60 bg-slate-950/60">
+                                        <div
+                                            className="h-full bg-gradient-to-r from-[#3BAEAB] to-[#7465A8] transition-all duration-300"
+                                            style={{ width: `${progressPercentage}%` }}
+                                        />
+                                    </div>
+                                </div>
+
+                                {renderStepContent()}
+
+                                <div className="flex flex-wrap items-center justify-between gap-3 pt-4">
+                                    {currentStep > 0 ? (
+                                        <Button type="button" variant="ghost" onClick={goToPreviousStep} className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]">
+                                            Back
+                                        </Button>
+                                    ) : (
+                                        <span />
+                                    )}
+                                    {currentStep < steps.length - 1 ? (
+                                        <Button type="button" onClick={goToNextStep} className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]">
+                                            Next
+                                        </Button>
+                                    ) : (
+                                        <Button type="submit" variant="success" disabled={isSubmitting} className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]">
+                                            {isSubmitting ? "Submitting..." : "Submit Contract"}
+                                        </Button>
+                                    )}
+                                </div>
+                            </form>
                         </div>
-                        {message && (
-                            <p className="mt-4 rounded-lg border border-slate-700 bg-slate-950/50 px-4 py-3 text-sm text-slate-200">
-                                {message}
-                            </p>
-                        )}
-                        <form onSubmit={handleSubmit} className="mt-6 space-y-6">
-                            <div>
-                                <div className="flex flex-wrap items-center justify-between gap-3">
-                                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
-                                        Step <span className="numeric-text">{currentStep + 1}</span> of{' '}
-                                        <span className="numeric-text">{steps.length}</span>
-                                    </p>
-                                    <span className="text-sm font-semibold text-white">{steps[currentStep].title}</span>
-                                </div>
-                                <div className="mt-2 h-2 w-full overflow-hidden rounded-full border border-slate-800/60 bg-slate-950/60">
-                                    <div
-                                        className="h-full bg-gradient-to-r from-[#3BAEAB] to-[#7465A8] transition-all duration-300"
-                                        style={{ width: `${progressPercentage}%` }}
-                                    />
-                                </div>
-                            </div>
-
-                            {renderStepContent()}
-
-                            <div className="flex flex-wrap items-center justify-between gap-3 pt-4">
-                                {currentStep > 0 ? (
-                                    <Button type="button" variant="ghost" onClick={goToPreviousStep} className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]">
-                                        Back
-                                    </Button>
-                                ) : (
-                                    <span />
-                                )}
-                                {currentStep < steps.length - 1 ? (
-                                    <Button type="button" onClick={goToNextStep} className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]">
-                                        Next
-                                    </Button>
-                                ) : (
-                                    <Button type="submit" variant="success" disabled={isSubmitting} className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]">
-                                        {isSubmitting ? "Submitting..." : "Submit Contract"}
-                                    </Button>
-                                )}
-                            </div>
-                        </form>
                     </section>
 
                     <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
-                        <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Portfolio</p>
-                            <h2 className="text-2xl font-bold text-white">My Contracts</h2>
-                            <p className="text-sm text-slate-400">
-                                Manage the contracts you currently have listed on the marketplace.
-                            </p>
-                        </div>
-                        {error && <p className="mt-4 text-sm text-red-400">{error}</p>}
-                        <div className="mt-6 overflow-hidden rounded-xl border border-slate-800/80">
-                            <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
-                                <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
-                                    <tr>
-                                        <th className="px-4 py-3">Title</th>
-                                        <th className="px-4 py-3">Buyer</th>
-                                        <th className="px-4 py-3">Ask Price</th>
-                                        <th className="px-4 py-3">Delivery</th>
-                                        <th className="px-4 py-3">Status</th>
-                                    </tr>
-                                </thead>
-                                <tbody className="divide-y divide-slate-800/70">
-                                    {contracts.map((c) => (
-                                        <tr key={c.id} className="bg-slate-950/40">
-                                            <td className="px-4 py-3 font-semibold text-slate-100">{c.title}</td>
-                                            <td className="px-4 py-3">{c.buyerUsername || "-"}</td>
-                                            <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
-                                            <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
-                                            <td className="px-4 py-3">
-                                                <span className="rounded-full border border-[#00D1FF]/40 bg-[#00D1FF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#00D1FF]">
-                                                    {c.status}
-                                                </span>
-                                            </td>
-                                        </tr>
-                                    ))}
-                                    {contracts.length === 0 && (
+                        <div className="space-y-6">
+                            <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
+                                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Portfolio</p>
+                                <h2 className="text-2xl font-bold text-white">My Contracts</h2>
+                                <p className="text-sm text-slate-400">
+                                    Manage the contracts you currently have listed on the marketplace.
+                                </p>
+                            </div>
+                            {error && <p className="text-sm text-red-400">{error}</p>}
+                            <div className="overflow-hidden rounded-xl border border-slate-800/80">
+                                <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
+                                    <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
                                         <tr>
-                                            <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
-                                                You have not listed any contracts yet.
-                                            </td>
+                                            <th className="px-4 py-3">Title</th>
+                                            <th className="px-4 py-3">Buyer</th>
+                                            <th className="px-4 py-3">Ask Price</th>
+                                            <th className="px-4 py-3">Delivery</th>
+                                            <th className="px-4 py-3">Status</th>
                                         </tr>
-                                    )}
-                                </tbody>
-                            </table>
+                                    </thead>
+                                    <tbody className="divide-y divide-slate-800/70">
+                                        {contracts.map((c) => (
+                                            <tr key={c.id} className="bg-slate-950/40">
+                                                <td className="px-4 py-3 font-semibold text-slate-100">{c.title}</td>
+                                                <td className="px-4 py-3">{c.buyerUsername || "-"}</td>
+                                                <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
+                                                <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
+                                                <td className="px-4 py-3">
+                                                    <span className="rounded-full border border-[#00D1FF]/40 bg-[#00D1FF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#00D1FF]">
+                                                        {c.status}
+                                                    </span>
+                                                </td>
+                                            </tr>
+                                        ))}
+                                        {contracts.length === 0 && (
+                                            <tr>
+                                                <td colSpan="5" className="px-4 py-10 text-center text-slate-500">
+                                                    You have not listed any contracts yet.
+                                                </td>
+                                            </tr>
+                                        )}
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
                     </section>
                 </div>

--- a/bellingham-frontend/src/components/Settings.jsx
+++ b/bellingham-frontend/src/components/Settings.jsx
@@ -31,22 +31,24 @@ const Settings = () => {
     return (
         <Layout onLogout={handleLogout}>
             <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-[0_20px_45px_rgba(2,12,32,0.55)]">
-                <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
-                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Configuration</p>
-                    <h1 className="text-3xl font-bold text-white">Settings</h1>
-                    <p className="text-sm text-slate-400">
-                        Tailor the platform to your institution’s policies. Modules below will be populated as features are rolled out.
-                    </p>
-                </div>
-                <div className="mt-6 grid gap-4 md:grid-cols-2">
-                    {settings.map((item) => (
-                        <div key={item.title} className="rounded-xl border border-slate-800/80 bg-slate-950/50 px-4 py-3">
-                            <p className="text-base font-semibold text-white">{item.title}</p>
-                            <p className="mt-2 text-sm text-slate-300">{item.description}</p>
+                <div className="space-y-6">
+                    <div className="flex flex-col gap-2 border-b border-slate-800 pb-4">
+                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#00D1FF]/80">Configuration</p>
+                        <h1 className="text-3xl font-bold text-white">Settings</h1>
+                        <p className="text-sm text-slate-400">
+                            Tailor the platform to your institution’s policies. Modules below will be populated as features are rolled out.
+                        </p>
+                    </div>
+                    <div className="grid gap-4 md:grid-cols-2">
+                        {settings.map((item) => (
+                            <div key={item.title} className="rounded-xl border border-slate-800/80 bg-slate-950/50 px-4 py-3">
+                                <p className="text-base font-semibold text-white">{item.title}</p>
+                                <p className="mt-2 text-sm text-slate-300">{item.description}</p>
+                            </div>
+                        ))}
+                        <div className="md:col-span-2 rounded-xl border border-dashed border-slate-700/60 bg-slate-950/40 px-4 py-6 text-sm text-slate-400">
+                            Additional configuration options will appear here as new services come online.
                         </div>
-                    ))}
-                    <div className="md:col-span-2 rounded-xl border border-dashed border-slate-700/60 bg-slate-950/40 px-4 py-6 text-sm text-slate-400">
-                        Additional configuration options will appear here as new services come online.
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
## Summary
- Wrap dashboard, list, and notification panels in `space-y-6` containers to replace bespoke margin stacking.
- Align account, reporting, selling, and settings forms with the same spacing pattern for consistent maintenance.

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6a5b2b910832993c73ce7e413e4f6