### PR TITLE
Adjust table padding for responsive tables

### DIFF
--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -188,11 +188,11 @@ const Buy = () => {
                             <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
                                 <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
                                     <tr>
-                                        <th className="px-4 py-3">Title</th>
-                                        <th className="px-4 py-3">Seller</th>
-                                        <th className="px-4 py-3">Ask Price</th>
-                                        <th className="px-4 py-3">Delivery</th>
-                                        <th className="px-4 py-3">Actions</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Title</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Seller</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Ask Price</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Delivery</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Actions</th>
                                     </tr>
                                 </thead>
                                 <tbody className="divide-y divide-slate-800/70">
@@ -206,11 +206,11 @@ const Buy = () => {
                                                     className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-[#00D1FF]/10"
                                                     onClick={() => setSelectedContract(contract)}
                                                 >
-                                                    <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
-                                                    <td className="px-4 py-3">{contract.seller}</td>
-                                                    <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${contract.price}</td>
-                                                    <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
-                                                    <td className="px-4 py-3">
+                                                    <td className="px-4 py-3 md:px-5 md:py-3.5 font-semibold text-slate-100">{contract.title}</td>
+                                                    <td className="px-4 py-3 md:px-5 md:py-3.5">{contract.seller}</td>
+                                                    <td className="numeric-text px-4 py-3 md:px-5 md:py-3.5 font-semibold text-[#3BAEAB]">${contract.price}</td>
+                                                    <td className="px-4 py-3 md:px-5 md:py-3.5 text-slate-300">{contract.deliveryDate}</td>
+                                                    <td className="px-4 py-3 md:px-5 md:py-3.5">
                                                         <Button
                                                             variant="success"
                                                             onClick={(e) => {

--- a/bellingham-frontend/src/components/Dashboard.jsx
+++ b/bellingham-frontend/src/components/Dashboard.jsx
@@ -96,11 +96,11 @@ const Dashboard = () => {
                             <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
                                 <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
                                     <tr>
-                                        <th className="px-4 py-3">Title</th>
-                                        <th className="px-4 py-3">Seller</th>
-                                        <th className="px-4 py-3">Ask Price</th>
-                                        <th className="px-4 py-3">Status</th>
-                                        <th className="px-4 py-3">Delivery</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Title</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Seller</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Ask Price</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Status</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Delivery</th>
                                     </tr>
                                 </thead>
                                 <tbody className="divide-y divide-slate-800/70">
@@ -114,17 +114,17 @@ const Dashboard = () => {
                                                     className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-[#00D1FF]/10"
                                                     onClick={() => setSelectedContract(contract)}
                                                 >
-                                                    <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
-                                                    <td className="px-4 py-3">{contract.seller}</td>
-                                                    <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">
+                                                    <td className="px-4 py-3 md:px-5 md:py-3.5 font-semibold text-slate-100">{contract.title}</td>
+                                                    <td className="px-4 py-3 md:px-5 md:py-3.5">{contract.seller}</td>
+                                                    <td className="numeric-text px-4 py-3 md:px-5 md:py-3.5 font-semibold text-[#3BAEAB]">
                                                         ${contract.price}
                                                     </td>
-                                                    <td className="px-4 py-3">
+                                                    <td className="px-4 py-3 md:px-5 md:py-3.5">
                                                         <span className="rounded-full border border-[#00D1FF]/40 bg-[#00D1FF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#00D1FF]">
                                                             {contract.status}
                                                         </span>
                                                     </td>
-                                                    <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
+                                                    <td className="px-4 py-3 md:px-5 md:py-3.5 text-slate-300">{contract.deliveryDate}</td>
                                                 </tr>
                                             ))}
                                             {contracts.length === 0 && (

--- a/bellingham-frontend/src/components/History.jsx
+++ b/bellingham-frontend/src/components/History.jsx
@@ -48,11 +48,11 @@ const History = () => {
                             <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
                                 <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
                                     <tr>
-                                        <th className="px-4 py-3">Title</th>
-                                        <th className="px-4 py-3">Seller</th>
-                                        <th className="px-4 py-3">Buyer</th>
-                                        <th className="px-4 py-3">Price</th>
-                                        <th className="px-4 py-3">Delivery</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Title</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Seller</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Buyer</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Price</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Delivery</th>
                                     </tr>
                                 </thead>
                                 <tbody className="divide-y divide-slate-800/70">
@@ -62,11 +62,11 @@ const History = () => {
                                             className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-[#00D1FF]/10"
                                             onClick={() => setSelectedContract(c)}
                                         >
-                                            <td className="px-4 py-3 font-semibold text-slate-100">{c.title}</td>
-                                            <td className="px-4 py-3">{c.seller}</td>
-                                            <td className="px-4 py-3">{c.buyerUsername || "-"}</td>
-                                            <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
-                                            <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
+                                            <td className="px-4 py-3 md:px-5 md:py-3.5 font-semibold text-slate-100">{c.title}</td>
+                                            <td className="px-4 py-3 md:px-5 md:py-3.5">{c.seller}</td>
+                                            <td className="px-4 py-3 md:px-5 md:py-3.5">{c.buyerUsername || "-"}</td>
+                                            <td className="numeric-text px-4 py-3 md:px-5 md:py-3.5 font-semibold text-[#3BAEAB]">${c.price}</td>
+                                            <td className="px-4 py-3 md:px-5 md:py-3.5 text-slate-300">{c.deliveryDate}</td>
                                         </tr>
                                     ))}
                                     {contracts.length === 0 && (

--- a/bellingham-frontend/src/components/Reports.jsx
+++ b/bellingham-frontend/src/components/Reports.jsx
@@ -405,11 +405,11 @@ const Reports = () => {
                                 <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
                                     <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
                                         <tr>
-                                            <th className="px-4 py-3">Title</th>
-                                            <th className="px-4 py-3">Seller</th>
-                                            <th className="px-4 py-3">Ask Price</th>
-                                            <th className="px-4 py-3">Delivery</th>
-                                            <th className="px-4 py-3">Actions</th>
+                                            <th className="px-4 py-3 md:px-5 md:py-3.5">Title</th>
+                                            <th className="px-4 py-3 md:px-5 md:py-3.5">Seller</th>
+                                            <th className="px-4 py-3 md:px-5 md:py-3.5">Ask Price</th>
+                                            <th className="px-4 py-3 md:px-5 md:py-3.5">Delivery</th>
+                                            <th className="px-4 py-3 md:px-5 md:py-3.5">Actions</th>
                                         </tr>
                                     </thead>
                                     <tbody className="divide-y divide-slate-800/70">
@@ -423,11 +423,11 @@ const Reports = () => {
                                                         className="cursor-pointer bg-slate-950/40 transition-colors hover:bg-[#00D1FF]/10"
                                                         onClick={() => setSelectedContract(contract)}
                                                     >
-                                                        <td className="px-4 py-3 font-semibold text-slate-100">{contract.title}</td>
-                                                        <td className="px-4 py-3">{contract.seller}</td>
-                                                        <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${contract.price}</td>
-                                                        <td className="px-4 py-3 text-slate-300">{contract.deliveryDate}</td>
-                                                        <td className="px-4 py-3">
+                                                        <td className="px-4 py-3 md:px-5 md:py-3.5 font-semibold text-slate-100">{contract.title}</td>
+                                                        <td className="px-4 py-3 md:px-5 md:py-3.5">{contract.seller}</td>
+                                                        <td className="numeric-text px-4 py-3 md:px-5 md:py-3.5 font-semibold text-[#3BAEAB]">${contract.price}</td>
+                                                        <td className="px-4 py-3 md:px-5 md:py-3.5 text-slate-300">{contract.deliveryDate}</td>
+                                                        <td className="px-4 py-3 md:px-5 md:py-3.5">
                                                             <div className="flex flex-wrap gap-2">
                                                                 <Button
                                                                     onClick={(e) => {

--- a/bellingham-frontend/src/components/Sales.jsx
+++ b/bellingham-frontend/src/components/Sales.jsx
@@ -109,11 +109,11 @@ const Sales = () => {
                             <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
                                 <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
                                     <tr>
-                                        <th className="px-4 py-3">Title</th>
-                                        <th className="px-4 py-3">Buyer</th>
-                                        <th className="px-4 py-3">Price</th>
-                                        <th className="px-4 py-3">Delivery Date</th>
-                                        <th className="px-4 py-3">Status</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Title</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Buyer</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Price</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Delivery Date</th>
+                                        <th className="px-4 py-3 md:px-5 md:py-3.5">Status</th>
                                     </tr>
                                 </thead>
                                 <tbody className="divide-y divide-slate-800/70">
@@ -134,7 +134,7 @@ const Sales = () => {
                                                     onClick={() => setSelectedContract(c)}
                                                     aria-selected={isSelected}
                                                 >
-                                                    <td className="px-4 py-3 font-semibold text-slate-100">
+                                                    <td className="px-4 py-3 md:px-5 md:py-3.5 font-semibold text-slate-100">
                                                         <div className="flex items-center gap-2">
                                                             {isSelected && (
                                                                 <span className="inline-flex items-center rounded-full border border-[#00D1FF]/60 bg-[#00D1FF]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-[#00D1FF]">
@@ -144,10 +144,10 @@ const Sales = () => {
                                                             <span>{c.title}</span>
                                                         </div>
                                                     </td>
-                                                    <td className="px-4 py-3">{c.buyerUsername}</td>
-                                                    <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
-                                                    <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
-                                                    <td className="px-4 py-3">
+                                                    <td className="px-4 py-3 md:px-5 md:py-3.5">{c.buyerUsername}</td>
+                                                    <td className="numeric-text px-4 py-3 md:px-5 md:py-3.5 font-semibold text-[#3BAEAB]">${c.price}</td>
+                                                    <td className="px-4 py-3 md:px-5 md:py-3.5 text-slate-300">{c.deliveryDate}</td>
+                                                    <td className="px-4 py-3 md:px-5 md:py-3.5">
                                                         <span className="rounded-full border border-[#00D1FF]/40 bg-[#00D1FF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#00D1FF]">
                                                             {c.status}
                                                         </span>

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -429,21 +429,21 @@ const Sell = () => {
                                 <table className="w-full table-auto divide-y divide-slate-800 text-left text-sm text-slate-200">
                                     <thead className="sticky top-0 z-10 bg-slate-900/90 text-xs uppercase tracking-[0.18em] text-slate-400 backdrop-blur">
                                         <tr>
-                                            <th className="px-4 py-3">Title</th>
-                                            <th className="px-4 py-3">Buyer</th>
-                                            <th className="px-4 py-3">Ask Price</th>
-                                            <th className="px-4 py-3">Delivery</th>
-                                            <th className="px-4 py-3">Status</th>
+                                            <th className="px-4 py-3 md:px-5 md:py-3.5">Title</th>
+                                            <th className="px-4 py-3 md:px-5 md:py-3.5">Buyer</th>
+                                            <th className="px-4 py-3 md:px-5 md:py-3.5">Ask Price</th>
+                                            <th className="px-4 py-3 md:px-5 md:py-3.5">Delivery</th>
+                                            <th className="px-4 py-3 md:px-5 md:py-3.5">Status</th>
                                         </tr>
                                     </thead>
                                     <tbody className="divide-y divide-slate-800/70">
                                         {contracts.map((c) => (
                                             <tr key={c.id} className="bg-slate-950/40">
-                                                <td className="px-4 py-3 font-semibold text-slate-100">{c.title}</td>
-                                                <td className="px-4 py-3">{c.buyerUsername || "-"}</td>
-                                                <td className="numeric-text px-4 py-3 font-semibold text-[#3BAEAB]">${c.price}</td>
-                                                <td className="px-4 py-3 text-slate-300">{c.deliveryDate}</td>
-                                                <td className="px-4 py-3">
+                                                <td className="px-4 py-3 md:px-5 md:py-3.5 font-semibold text-slate-100">{c.title}</td>
+                                                <td className="px-4 py-3 md:px-5 md:py-3.5">{c.buyerUsername || "-"}</td>
+                                                <td className="numeric-text px-4 py-3 md:px-5 md:py-3.5 font-semibold text-[#3BAEAB]">${c.price}</td>
+                                                <td className="px-4 py-3 md:px-5 md:py-3.5 text-slate-300">{c.deliveryDate}</td>
+                                                <td className="px-4 py-3 md:px-5 md:py-3.5">
                                                     <span className="rounded-full border border-[#00D1FF]/40 bg-[#00D1FF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#00D1FF]">
                                                         {c.status}
                                                     </span>

--- a/bellingham-frontend/src/components/ui/TableSkeleton.jsx
+++ b/bellingham-frontend/src/components/ui/TableSkeleton.jsx
@@ -11,7 +11,7 @@ const TableSkeleton = ({ columns = 4, rows = 5 }) => {
                     className="animate-pulse bg-slate-950/30"
                 >
                     {Array.from({ length: columns }).map((__, columnIndex) => (
-                        <td key={`skeleton-cell-${rowIndex}-${columnIndex}`} className="px-4 py-3">
+                        <td key={`skeleton-cell-${rowIndex}-${columnIndex}`} className="px-4 py-3 md:px-5 md:py-3.5">
                             <div
                                 className={`h-4 rounded-full bg-slate-800/80 ${widths[columnIndex % widths.length]}`}
                             />


### PR DESCRIPTION
## Summary
- increase table header and cell padding across dashboard, sales, buy, sell, history, and reports views for roomier layouts on larger screens while preserving mobile density
- update the shared table skeleton component to mirror the responsive padding change

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6b3cd2fa483299afc9d4ec080ca70