### PR TITLE
Standardize notification popup spacing

### DIFF
--- a/bellingham-frontend/src/components/NotificationPopup.jsx
+++ b/bellingham-frontend/src/components/NotificationPopup.jsx
@@ -72,19 +72,21 @@ const NotificationPopup = () => {
                 {unreadNotifications.map((notification) => (
                     <li key={notification.id} role="listitem" className="pointer-events-auto">
                         <article
-                            className="rounded-lg bg-gray-800 p-4 text-white shadow-xl ring-1 ring-black/10"
+                            className="flex flex-col space-y-4 rounded-lg bg-gray-800 p-5 text-white shadow-xl ring-1 ring-black/10 lg:p-6"
                             role="status"
                             aria-atomic="true"
                         >
-                            <p className="text-sm font-semibold">
-                                {notification.title || "New activity"}
-                            </p>
-                            {notification.message && (
-                                <p className="mt-1 text-sm text-gray-300">
-                                    {notification.message}
+                            <div className="space-y-2">
+                                <p className="text-sm font-semibold">
+                                    {notification.title || "New activity"}
                                 </p>
-                            )}
-                            <div className="mt-3 flex flex-wrap gap-2">
+                                {notification.message && (
+                                    <p className="text-sm text-gray-300">
+                                        {notification.message}
+                                    </p>
+                                )}
+                            </div>
+                            <div className="flex flex-wrap gap-2">
                                 <Button
                                     variant="success"
                                     className="px-3 py-1 text-sm"


### PR DESCRIPTION
## Summary
- update the notification popup card padding to use the shared p-5 lg:p-6 spacing
- replace individual margin classes with space-y-2 groupings for message content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6baabd3fc83299ce86661d89f2ac1