### PR TITLE
Apply consistent form spacing

### DIFF
--- a/bellingham-frontend/src/components/Account.jsx
+++ b/bellingham-frontend/src/components/Account.jsx
@@ -6,8 +6,10 @@ import api from "../utils/api";
 import { AuthContext } from '../context';
 
 const inputClasses =
-    "mt-1 w-full max-w-lg rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none";
+    "w-full max-w-lg rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none";
 const labelClasses = "block w-full max-w-lg text-xs font-semibold uppercase tracking-[0.18em] text-slate-400";
+const fieldGroupClasses = "space-y-4";
+const controlStackClasses = "space-y-2";
 
 const Account = () => {
     const [profile, setProfile] = useState(null);
@@ -106,130 +108,199 @@ const Account = () => {
 
                     {editing ? (
                         <div className="grid gap-4 md:grid-cols-2">
-                            <label className={labelClasses}>
-                                Username
-                                <input value={profile.username} disabled className={`${inputClasses} cursor-not-allowed opacity-60`} />
-                            </label>
-                            <label className={labelClasses}>
-                                Legal Business Name
-                                <input
-                                    className={inputClasses}
-                                    name="legalBusinessName"
-                                    value={formData.legalBusinessName || ""}
-                                    onChange={handleChange}
-                                    placeholder="Legal Business Name"
-                                />
-                            </label>
-                            <label className={labelClasses}>
-                                Name
-                                <input
-                                    className={inputClasses}
-                                    name="name"
-                                    value={formData.name || ""}
-                                    onChange={handleChange}
-                                    placeholder="Name"
-                                />
-                            </label>
-                            <label className={labelClasses}>
-                                Country of Incorporation
-                                <input
-                                    className={inputClasses}
-                                    name="countryOfIncorporation"
-                                    value={formData.countryOfIncorporation || ""}
-                                    onChange={handleChange}
-                                    placeholder="Country of Incorporation"
-                                />
-                            </label>
-                            <label className={labelClasses}>
-                                Tax ID
-                                <input
-                                    className={inputClasses}
-                                    name="taxId"
-                                    value={formData.taxId || ""}
-                                    onChange={handleChange}
-                                    placeholder="Tax ID"
-                                />
-                            </label>
-                            <label className={labelClasses}>
-                                Company Registration Number
-                                <input
-                                    className={inputClasses}
-                                    name="companyRegistrationNumber"
-                                    value={formData.companyRegistrationNumber || ""}
-                                    onChange={handleChange}
-                                    placeholder="Company Registration Number"
-                                />
-                            </label>
-                            <label className={labelClasses}>
-                                Primary Contact Name
-                                <input
-                                    className={inputClasses}
-                                    name="primaryContactName"
-                                    value={formData.primaryContactName || ""}
-                                    onChange={handleChange}
-                                    placeholder="Primary Contact Name"
-                                />
-                            </label>
-                            <label className={labelClasses}>
-                                Primary Contact Email
-                                <input
-                                    className={inputClasses}
-                                    name="primaryContactEmail"
-                                    value={formData.primaryContactEmail || ""}
-                                    onChange={handleChange}
-                                    placeholder="Primary Contact Email"
-                                />
-                            </label>
-                            <label className={labelClasses}>
-                                Primary Contact Phone
-                                <input
-                                    className={inputClasses}
-                                    name="primaryContactPhone"
-                                    value={formData.primaryContactPhone || ""}
-                                    onChange={handleChange}
-                                    placeholder="Primary Contact Phone"
-                                />
-                            </label>
-                            <label className={labelClasses}>
-                                Technical Contact Name
-                                <input
-                                    className={inputClasses}
-                                    name="technicalContactName"
-                                    value={formData.technicalContactName || ""}
-                                    onChange={handleChange}
-                                    placeholder="Technical Contact Name"
-                                />
-                            </label>
-                            <label className={labelClasses}>
-                                Technical Contact Email
-                                <input
-                                    className={inputClasses}
-                                    name="technicalContactEmail"
-                                    value={formData.technicalContactEmail || ""}
-                                    onChange={handleChange}
-                                    placeholder="Technical Contact Email"
-                                />
-                            </label>
-                            <label className={labelClasses}>
-                                Technical Contact Phone
-                                <input
-                                    className={inputClasses}
-                                    name="technicalContactPhone"
-                                    value={formData.technicalContactPhone || ""}
-                                    onChange={handleChange}
-                                    placeholder="Technical Contact Phone"
-                                />
-                            </label>
-                            <label className={`${labelClasses} md:col-span-2`}>
-                                Company Description
-                                <textarea
-                                    className={`${inputClasses} min-h-[120px]`}
-                                    name="companyDescription"
-                                    value={formData.companyDescription || ""}
-                                    onChange={handleChange}
-                                    placeholder="Company Description"
-                                />
-                            </label>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="account-username" className={labelClasses}>
+                                        Username
+                                    </label>
+                                    <input
+                                        id="account-username"
+                                        value={profile.username}
+                                        disabled
+                                        className={`${inputClasses} cursor-not-allowed opacity-60`}
+                                    />
+                                </div>
+                            </div>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="account-legalBusinessName" className={labelClasses}>
+                                        Legal Business Name
+                                    </label>
+                                    <input
+                                        id="account-legalBusinessName"
+                                        className={inputClasses}
+                                        name="legalBusinessName"
+                                        value={formData.legalBusinessName || ""}
+                                        onChange={handleChange}
+                                        placeholder="Legal Business Name"
+                                    />
+                                </div>
+                            </div>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="account-name" className={labelClasses}>
+                                        Name
+                                    </label>
+                                    <input
+                                        id="account-name"
+                                        className={inputClasses}
+                                        name="name"
+                                        value={formData.name || ""}
+                                        onChange={handleChange}
+                                        placeholder="Name"
+                                    />
+                                </div>
+                            </div>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="account-countryOfIncorporation" className={labelClasses}>
+                                        Country of Incorporation
+                                    </label>
+                                    <input
+                                        id="account-countryOfIncorporation"
+                                        className={inputClasses}
+                                        name="countryOfIncorporation"
+                                        value={formData.countryOfIncorporation || ""}
+                                        onChange={handleChange}
+                                        placeholder="Country of Incorporation"
+                                    />
+                                </div>
+                            </div>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="account-taxId" className={labelClasses}>
+                                        Tax ID
+                                    </label>
+                                    <input
+                                        id="account-taxId"
+                                        className={inputClasses}
+                                        name="taxId"
+                                        value={formData.taxId || ""}
+                                        onChange={handleChange}
+                                        placeholder="Tax ID"
+                                    />
+                                </div>
+                            </div>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="account-companyRegistrationNumber" className={labelClasses}>
+                                        Company Registration Number
+                                    </label>
+                                    <input
+                                        id="account-companyRegistrationNumber"
+                                        className={inputClasses}
+                                        name="companyRegistrationNumber"
+                                        value={formData.companyRegistrationNumber || ""}
+                                        onChange={handleChange}
+                                        placeholder="Company Registration Number"
+                                    />
+                                </div>
+                            </div>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="account-primaryContactName" className={labelClasses}>
+                                        Primary Contact Name
+                                    </label>
+                                    <input
+                                        id="account-primaryContactName"
+                                        className={inputClasses}
+                                        name="primaryContactName"
+                                        value={formData.primaryContactName || ""}
+                                        onChange={handleChange}
+                                        placeholder="Primary Contact Name"
+                                    />
+                                </div>
+                            </div>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="account-primaryContactEmail" className={labelClasses}>
+                                        Primary Contact Email
+                                    </label>
+                                    <input
+                                        id="account-primaryContactEmail"
+                                        className={inputClasses}
+                                        name="primaryContactEmail"
+                                        value={formData.primaryContactEmail || ""}
+                                        onChange={handleChange}
+                                        placeholder="Primary Contact Email"
+                                    />
+                                </div>
+                            </div>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="account-primaryContactPhone" className={labelClasses}>
+                                        Primary Contact Phone
+                                    </label>
+                                    <input
+                                        id="account-primaryContactPhone"
+                                        className={inputClasses}
+                                        name="primaryContactPhone"
+                                        value={formData.primaryContactPhone || ""}
+                                        onChange={handleChange}
+                                        placeholder="Primary Contact Phone"
+                                    />
+                                </div>
+                            </div>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="account-technicalContactName" className={labelClasses}>
+                                        Technical Contact Name
+                                    </label>
+                                    <input
+                                        id="account-technicalContactName"
+                                        className={inputClasses}
+                                        name="technicalContactName"
+                                        value={formData.technicalContactName || ""}
+                                        onChange={handleChange}
+                                        placeholder="Technical Contact Name"
+                                    />
+                                </div>
+                            </div>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="account-technicalContactEmail" className={labelClasses}>
+                                        Technical Contact Email
+                                    </label>
+                                    <input
+                                        id="account-technicalContactEmail"
+                                        className={inputClasses}
+                                        name="technicalContactEmail"
+                                        value={formData.technicalContactEmail || ""}
+                                        onChange={handleChange}
+                                        placeholder="Technical Contact Email"
+                                    />
+                                </div>
+                            </div>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="account-technicalContactPhone" className={labelClasses}>
+                                        Technical Contact Phone
+                                    </label>
+                                    <input
+                                        id="account-technicalContactPhone"
+                                        className={inputClasses}
+                                        name="technicalContactPhone"
+                                        value={formData.technicalContactPhone || ""}
+                                        onChange={handleChange}
+                                        placeholder="Technical Contact Phone"
+                                    />
+                                </div>
+                            </div>
+                            <div className={`${fieldGroupClasses} md:col-span-2`}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="account-companyDescription" className={labelClasses}>
+                                        Company Description
+                                    </label>
+                                    <textarea
+                                        id="account-companyDescription"
+                                        className={`${inputClasses} min-h-[120px]`}
+                                        name="companyDescription"
+                                        value={formData.companyDescription || ""}
+                                        onChange={handleChange}
+                                        placeholder="Company Description"
+                                    />
+                                </div>
+                            </div>
                             <div className="md:col-span-2 flex flex-wrap items-center gap-3">
                                 <Button variant="success" onClick={handleSave} className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]">
                                     Save
@@ -249,9 +320,12 @@ const Account = () => {
                     ) : (
                         <div className="grid gap-4 md:grid-cols-2">
                             {details.map((detail) => (
-                                <div key={detail.label} className="rounded-xl border border-slate-800/80 bg-slate-950/50 px-4 py-3">
+                                <div
+                                    key={detail.label}
+                                    className="space-y-3 rounded-xl border border-slate-800/80 bg-slate-950/50 px-4 py-3"
+                                >
                                     <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">{detail.label}</p>
-                                    <p className="mt-1 text-sm font-semibold text-slate-200">{detail.value || "-"}</p>
+                                    <p className="text-sm font-semibold text-slate-200">{detail.value || "-"}</p>
                                 </div>
                             ))}
                             <div className="md:col-span-2 flex justify-end">

--- a/bellingham-frontend/src/components/BidModal.jsx
+++ b/bellingham-frontend/src/components/BidModal.jsx
@@ -43,34 +43,38 @@ const BidModal = ({ onConfirm, onCancel, initialBid = '' }) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
       <div className="w-full max-w-md rounded bg-white p-6 shadow-md">
-        <h2 className="text-lg font-semibold">Submit a Bid</h2>
-        <label htmlFor="bid-amount" className="mt-4 block text-sm font-medium text-gray-700">
-          Bid Amount
-        </label>
-        <input
-          id="bid-amount"
-          type="number"
-          inputMode="decimal"
-          min="0"
-          step="0.01"
-          value={bidAmount}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          className="mt-1 w-full rounded border border-gray-300 p-2"
-          placeholder="Enter your bid"
-        />
-        {error && (
-          <p className="mt-2 text-sm text-red-600" role="alert">
-            {error}
-          </p>
-        )}
-        <div className="mt-4 flex justify-end gap-2">
-          <Button variant="ghost" onClick={onCancel}>
-            Cancel
-          </Button>
-          <Button variant="success" onClick={handleSubmit}>
-            Submit Bid
-          </Button>
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold">Submit a Bid</h2>
+          <div className="space-y-2">
+            <label htmlFor="bid-amount" className="block text-sm font-medium text-gray-700">
+              Bid Amount
+            </label>
+            <input
+              id="bid-amount"
+              type="number"
+              inputMode="decimal"
+              min="0"
+              step="0.01"
+              value={bidAmount}
+              onChange={handleChange}
+              onKeyDown={handleKeyDown}
+              className="w-full rounded border border-gray-300 p-2"
+              placeholder="Enter your bid"
+            />
+          </div>
+          {error && (
+            <p className="text-sm text-red-600" role="alert">
+              {error}
+            </p>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button variant="success" onClick={handleSubmit}>
+              Submit Bid
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -8,8 +8,10 @@ import AgreementEditorModal from "./AgreementEditorModal";
 import contractTemplate from "../config/contractTemplate";
 
 const inputClasses =
-    "mt-1 w-full max-w-lg rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none";
+    "w-full max-w-lg rounded-lg border border-slate-800/60 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 focus:border-[#00D1FF] focus:outline-none";
 const labelClasses = "block w-full max-w-lg text-xs font-semibold uppercase tracking-[0.18em] text-slate-400";
+const fieldGroupClasses = "space-y-4";
+const controlStackClasses = "space-y-2";
 
 const Sell = () => {
     const navigate = useNavigate();
@@ -175,172 +177,242 @@ const Sell = () => {
                 return (
                     <div className="space-y-6">
                         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                            <label className={labelClasses}>
-                                Effective Date
-                                <input
-                                    type="date"
-                                    name="effectiveDate"
-                                    value={form.effectiveDate}
-                                    onChange={handleChange}
-                                    className={inputClasses}
-                                    required
-                                />
-                            </label>
-                            <label className={labelClasses}>
-                                Platform Name
-                                <input
-                                    type="text"
-                                    name="platformName"
-                                    value={form.platformName}
-                                    onChange={handleChange}
-                                    className={inputClasses}
-                                    required
-                                />
-                            </label>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="effectiveDate" className={labelClasses}>
+                                        Effective Date
+                                    </label>
+                                    <input
+                                        id="effectiveDate"
+                                        type="date"
+                                        name="effectiveDate"
+                                        value={form.effectiveDate}
+                                        onChange={handleChange}
+                                        className={inputClasses}
+                                        required
+                                    />
+                                </div>
+                            </div>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="platformName" className={labelClasses}>
+                                        Platform Name
+                                    </label>
+                                    <input
+                                        id="platformName"
+                                        type="text"
+                                        name="platformName"
+                                        value={form.platformName}
+                                        onChange={handleChange}
+                                        className={inputClasses}
+                                        required
+                                    />
+                                </div>
+                            </div>
                         </div>
                         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                            <label className={labelClasses}>
-                                Listing Title
-                                <input
-                                    type="text"
-                                    name="title"
-                                    value={form.title}
-                                    onChange={handleChange}
-                                    className={inputClasses}
-                                    required
-                                />
-                            </label>
-                            <label className={labelClasses}>
-                                Asking Price
-                                <input
-                                    type="number"
-                                    min="0"
-                                    step="0.01"
-                                    name="price"
-                                    value={form.price}
-                                    onChange={handleChange}
-                                    className={inputClasses}
-                                    required
-                                />
-                            </label>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="title" className={labelClasses}>
+                                        Listing Title
+                                    </label>
+                                    <input
+                                        id="title"
+                                        type="text"
+                                        name="title"
+                                        value={form.title}
+                                        onChange={handleChange}
+                                        className={inputClasses}
+                                        required
+                                    />
+                                </div>
+                            </div>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="price" className={labelClasses}>
+                                        Asking Price
+                                    </label>
+                                    <input
+                                        id="price"
+                                        type="number"
+                                        min="0"
+                                        step="0.01"
+                                        name="price"
+                                        value={form.price}
+                                        onChange={handleChange}
+                                        className={inputClasses}
+                                        required
+                                    />
+                                </div>
+                            </div>
                         </div>
                         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                            <label className={labelClasses}>
-                                Seller Full Name
-                                <input
-                                    type="text"
-                                    name="sellerFullName"
-                                    value={form.sellerFullName}
-                                    onChange={handleChange}
-                                    className={inputClasses}
-                                    required
-                                />
-                            </label>
-                            <label className={labelClasses}>
-                                Seller Entity Type
-                                <input
-                                    type="text"
-                                    name="sellerEntityType"
-                                    value={form.sellerEntityType}
-                                    onChange={handleChange}
-                                    className={inputClasses}
-                                />
-                            </label>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="sellerFullName" className={labelClasses}>
+                                        Seller Full Name
+                                    </label>
+                                    <input
+                                        id="sellerFullName"
+                                        type="text"
+                                        name="sellerFullName"
+                                        value={form.sellerFullName}
+                                        onChange={handleChange}
+                                        className={inputClasses}
+                                        required
+                                    />
+                                </div>
+                            </div>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="sellerEntityType" className={labelClasses}>
+                                        Seller Entity Type
+                                    </label>
+                                    <input
+                                        id="sellerEntityType"
+                                        type="text"
+                                        name="sellerEntityType"
+                                        value={form.sellerEntityType}
+                                        onChange={handleChange}
+                                        className={inputClasses}
+                                    />
+                                </div>
+                            </div>
                         </div>
-                        <label className={labelClasses}>
-                            Seller Address
-                            <textarea
-                                name="sellerAddress"
-                                value={form.sellerAddress}
-                                onChange={handleChange}
-                                className={`${inputClasses} min-h-[100px]`}
-                            />
-                        </label>
+                        <div className={fieldGroupClasses}>
+                            <div className={controlStackClasses}>
+                                <label htmlFor="sellerAddress" className={labelClasses}>
+                                    Seller Address
+                                </label>
+                                <textarea
+                                    id="sellerAddress"
+                                    name="sellerAddress"
+                                    value={form.sellerAddress}
+                                    onChange={handleChange}
+                                    className={`${inputClasses} min-h-[100px]`}
+                                />
+                            </div>
+                        </div>
                     </div>
                 );
             case "buyer":
                 return (
                     <div className="space-y-6">
                         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                            <label className={labelClasses}>
-                                Buyer Full Name
-                                <input
-                                    type="text"
-                                    name="buyerFullName"
-                                    value={form.buyerFullName}
-                                    onChange={handleChange}
-                                    className={inputClasses}
-                                />
-                            </label>
-                            <label className={labelClasses}>
-                                Buyer Entity Type
-                                <input
-                                    type="text"
-                                    name="buyerEntityType"
-                                    value={form.buyerEntityType}
-                                    onChange={handleChange}
-                                    className={inputClasses}
-                                />
-                            </label>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="buyerFullName" className={labelClasses}>
+                                        Buyer Full Name
+                                    </label>
+                                    <input
+                                        id="buyerFullName"
+                                        type="text"
+                                        name="buyerFullName"
+                                        value={form.buyerFullName}
+                                        onChange={handleChange}
+                                        className={inputClasses}
+                                    />
+                                </div>
+                            </div>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="buyerEntityType" className={labelClasses}>
+                                        Buyer Entity Type
+                                    </label>
+                                    <input
+                                        id="buyerEntityType"
+                                        type="text"
+                                        name="buyerEntityType"
+                                        value={form.buyerEntityType}
+                                        onChange={handleChange}
+                                        className={inputClasses}
+                                    />
+                                </div>
+                            </div>
                         </div>
-                        <label className={labelClasses}>
-                            Buyer Address
-                            <textarea
-                                name="buyerAddress"
-                                value={form.buyerAddress}
-                                onChange={handleChange}
-                                className={`${inputClasses} min-h-[100px]`}
-                            />
-                        </label>
-                        <label className={labelClasses}>
-                            Data Description
-                            <textarea
-                                name="dataDescription"
-                                value={form.dataDescription}
-                                onChange={handleChange}
-                                className={`${inputClasses} min-h-[120px]`}
-                                placeholder="Outline the dataset content, granularity, and key attributes"
-                            />
-                        </label>
+                        <div className={fieldGroupClasses}>
+                            <div className={controlStackClasses}>
+                                <label htmlFor="buyerAddress" className={labelClasses}>
+                                    Buyer Address
+                                </label>
+                                <textarea
+                                    id="buyerAddress"
+                                    name="buyerAddress"
+                                    value={form.buyerAddress}
+                                    onChange={handleChange}
+                                    className={`${inputClasses} min-h-[100px]`}
+                                />
+                            </div>
+                        </div>
+                        <div className={fieldGroupClasses}>
+                            <div className={controlStackClasses}>
+                                <label htmlFor="dataDescription" className={labelClasses}>
+                                    Data Description
+                                </label>
+                                <textarea
+                                    id="dataDescription"
+                                    name="dataDescription"
+                                    value={form.dataDescription}
+                                    onChange={handleChange}
+                                    className={`${inputClasses} min-h-[120px]`}
+                                    placeholder="Outline the dataset content, granularity, and key attributes"
+                                />
+                            </div>
+                        </div>
                     </div>
                 );
             case "delivery":
                 return (
                     <div className="space-y-6">
                         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                            <label className={labelClasses}>
-                                Delivery Date
-                                <input
-                                    type="date"
-                                    name="deliveryDate"
-                                    value={form.deliveryDate}
-                                    onChange={handleChange}
-                                    className={inputClasses}
-                                />
-                            </label>
-                            <label className={labelClasses}>
-                                Delivery Format
-                                <input
-                                    type="text"
-                                    name="deliveryFormat"
-                                    value={form.deliveryFormat}
-                                    onChange={handleChange}
-                                    className={inputClasses}
-                                />
-                            </label>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="deliveryDate" className={labelClasses}>
+                                        Delivery Date
+                                    </label>
+                                    <input
+                                        id="deliveryDate"
+                                        type="date"
+                                        name="deliveryDate"
+                                        value={form.deliveryDate}
+                                        onChange={handleChange}
+                                        className={inputClasses}
+                                    />
+                                </div>
+                            </div>
+                            <div className={fieldGroupClasses}>
+                                <div className={controlStackClasses}>
+                                    <label htmlFor="deliveryFormat" className={labelClasses}>
+                                        Delivery Format
+                                    </label>
+                                    <input
+                                        id="deliveryFormat"
+                                        type="text"
+                                        name="deliveryFormat"
+                                        value={form.deliveryFormat}
+                                        onChange={handleChange}
+                                        className={inputClasses}
+                                    />
+                                </div>
+                            </div>
                         </div>
-                        <label className={labelClasses}>
-                            Upload Supporting Terms
-                            <input
-                                type="file"
-                                onChange={handleFileChange}
-                                className={inputClasses}
-                            />
-                        </label>
-                        <div className="space-y-2">
+                        <div className={fieldGroupClasses}>
+                            <div className={controlStackClasses}>
+                                <label htmlFor="supportingTerms" className={labelClasses}>
+                                    Upload Supporting Terms
+                                </label>
+                                <input
+                                    id="supportingTerms"
+                                    type="file"
+                                    onChange={handleFileChange}
+                                    className={inputClasses}
+                                />
+                            </div>
+                        </div>
+                        <div className="space-y-4">
                             <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Agreement Draft</p>
-                            <div className="rounded-xl border border-slate-800/80 bg-slate-950/60 p-4 text-sm text-slate-200">
-                                <p className="mb-3 text-slate-300">
+                            <div className="space-y-4 rounded-xl border border-slate-800/80 bg-slate-950/60 p-4 text-sm text-slate-200">
+                                <p className="text-slate-300">
                                     Review or update the legal agreement that will govern this contract. Buyers will receive this
                                     text as part of the execution workflow.
                                 </p>

--- a/bellingham-frontend/src/components/Signup.jsx
+++ b/bellingham-frontend/src/components/Signup.jsx
@@ -316,32 +316,36 @@ const Signup = () => {
                             const describedBy = `${helpId}${showError ? ` ${errorId}` : ""}`;
 
                             return (
-                                <div key={field.name} className="flex flex-col w-full">
-                                    <label htmlFor={fieldId} className="mb-1 text-sm font-medium text-gray-700">
-                                        {field.label}
-                                    </label>
-                                    <input
-                                        id={fieldId}
-                                        name={field.name}
-                                        type={field.type}
-                                        placeholder={field.placeholder}
-                                        value={form[field.name]}
-                                        onChange={(e) => handleChange(field.name, e.target.value)}
-                                        onBlur={() => handleBlur(field.name)}
-                                        aria-describedby={describedBy}
-                                        aria-invalid={showError ? "true" : "false"}
-                                        className={`w-full rounded-lg border p-2 focus:outline-none focus:ring-2 focus:ring-[#00D1FF] ${
-                                            showError ? "border-red-500" : "border-gray-300"
-                                        }`}
-                                    />
-                                    <p id={helpId} className="mt-1 text-xs text-gray-500">
-                                        {field.helpText}
-                                    </p>
-                                    {showError && (
-                                        <p id={errorId} className="mt-1 text-xs text-red-600" role="alert">
-                                            {errors[field.name]}
+                                <div key={field.name} className="space-y-4">
+                                    <div className="space-y-2">
+                                        <label htmlFor={fieldId} className="text-sm font-medium text-gray-700">
+                                            {field.label}
+                                        </label>
+                                        <input
+                                            id={fieldId}
+                                            name={field.name}
+                                            type={field.type}
+                                            placeholder={field.placeholder}
+                                            value={form[field.name]}
+                                            onChange={(e) => handleChange(field.name, e.target.value)}
+                                            onBlur={() => handleBlur(field.name)}
+                                            aria-describedby={describedBy}
+                                            aria-invalid={showError ? "true" : "false"}
+                                            className={`w-full rounded-lg border p-2 focus:outline-none focus:ring-2 focus:ring-[#00D1FF] ${
+                                                showError ? "border-red-500" : "border-gray-300"
+                                            }`}
+                                        />
+                                    </div>
+                                    <div className="space-y-1 text-xs">
+                                        <p id={helpId} className="text-gray-500">
+                                            {field.helpText}
                                         </p>
-                                    )}
+                                        {showError && (
+                                            <p id={errorId} className="text-red-600" role="alert">
+                                                {errors[field.name]}
+                                            </p>
+                                        )}
+                                    </div>
                                 </div>
                             );
                         })}


### PR DESCRIPTION
## Summary
- replace manual margin utilities in key forms with space-y spacing stacks for consistent vertical rhythm
- restructure Sell and Account forms to use labelled control groups with IDs for accessibility
- update BidModal and Signup field helpers to rely on stacked spacing utilities instead of bespoke margins

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d798e2139483299e0fc32067bfd10b