### PR TITLE
Fix buy flow to submit signature data

### DIFF
--- a/bellingham-frontend/src/__tests__/Buy.test.jsx
+++ b/bellingham-frontend/src/__tests__/Buy.test.jsx
@@ -55,6 +55,12 @@ describe('Buy component', () => {
       }
       return Promise.resolve({ data: [] });
     });
+    api.post.mockResolvedValue({
+      data: {
+        id: 1,
+        title: 'Contract A',
+      },
+    });
   });
 
   afterEach(() => {
@@ -70,5 +76,24 @@ describe('Buy component', () => {
     fireEvent.click(buyButton);
 
     expect(await screen.findByTestId('signature-canvas')).toBeInTheDocument();
+  });
+
+  test('sends captured signature when confirming purchase', async () => {
+    renderWithProviders(<Buy />);
+
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith('/api/contracts/available'));
+
+    const buyButton = screen.getAllByRole('button', { name: 'Buy' })[0];
+    fireEvent.click(buyButton);
+
+    const saveButton = await screen.findByRole('button', { name: 'Save' });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith(
+        '/api/contracts/1/buy',
+        { signature: 'data:image/png;base64,mock-signature' },
+      );
+    });
   });
 });

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -52,10 +52,14 @@ const Buy = () => {
         fetchContracts();
     }, [fetchContracts]);
 
-    const handleBuy = async (contractId) => {
+    const handleBuy = async (contractId, signatureData = null) => {
         setNotification(null);
         try {
-            const response = await api.post(`/api/contracts/${contractId}/buy`, {});
+            const payload = signatureData ? { signature: signatureData } : undefined;
+            const response = await api.post(
+                `/api/contracts/${contractId}/buy`,
+                payload,
+            );
             const purchased = response?.data;
             setNotification({
                 type: "success",
@@ -80,12 +84,12 @@ const Buy = () => {
         setPendingContractId(contractId);
     };
 
-    const handleSignatureConfirm = async () => {
+    const handleSignatureConfirm = async (signatureData) => {
         if (!pendingContractId) {
             return;
         }
 
-        await handleBuy(pendingContractId);
+        await handleBuy(pendingContractId, signatureData);
         setPendingContractId(null);
     };
 


### PR DESCRIPTION
## Summary
- include the captured signature when completing a contract purchase
- wire the signature modal confirmation through to the buy API call
- extend the Buy component test suite to verify the signature payload

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d79b7417d88329a167cc0992b6befb