### PR TITLE
Add real-time market streaming and UI updates

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/dto/market/MarketDelta.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/dto/market/MarketDelta.java
@@ -1,0 +1,108 @@
+package com.bellingham.datafutures.dto.market;
+
+import java.math.BigDecimal;
+
+public class MarketDelta {
+
+    private long openContracts;
+    private long marketDepth;
+    private BigDecimal totalVolume;
+    private BigDecimal averageAsk;
+    private long activeSellers;
+    private BigDecimal spread;
+    private BigDecimal bestAsk;
+    private long executionsLastHour;
+
+    public static MarketDelta empty() {
+        MarketDelta delta = new MarketDelta();
+        delta.setOpenContracts(0L);
+        delta.setMarketDepth(0L);
+        delta.setTotalVolume(BigDecimal.ZERO);
+        delta.setAverageAsk(BigDecimal.ZERO);
+        delta.setActiveSellers(0L);
+        delta.setSpread(BigDecimal.ZERO);
+        delta.setBestAsk(BigDecimal.ZERO);
+        delta.setExecutionsLastHour(0L);
+        return delta;
+    }
+
+    public static MarketDelta from(MarketKpis previous, MarketKpis current) {
+        MarketKpis safePrevious = previous != null ? previous : MarketKpis.empty();
+        MarketKpis safeCurrent = current != null ? current : MarketKpis.empty();
+
+        MarketDelta delta = new MarketDelta();
+        delta.setOpenContracts(safeCurrent.getOpenContracts() - safePrevious.getOpenContracts());
+        delta.setMarketDepth(safeCurrent.getMarketDepth() - safePrevious.getMarketDepth());
+        delta.setTotalVolume(safeCurrent.getTotalVolume().subtract(safePrevious.getTotalVolume()));
+        delta.setAverageAsk(safeCurrent.getAverageAsk().subtract(safePrevious.getAverageAsk()));
+        delta.setActiveSellers(safeCurrent.getActiveSellers() - safePrevious.getActiveSellers());
+        delta.setSpread(safeCurrent.getSpread().subtract(safePrevious.getSpread()));
+        delta.setBestAsk(safeCurrent.getBestAsk().subtract(safePrevious.getBestAsk()));
+        delta.setExecutionsLastHour(safeCurrent.getExecutionsLastHour() - safePrevious.getExecutionsLastHour());
+        return delta;
+    }
+
+    public long getOpenContracts() {
+        return openContracts;
+    }
+
+    public void setOpenContracts(long openContracts) {
+        this.openContracts = openContracts;
+    }
+
+    public long getMarketDepth() {
+        return marketDepth;
+    }
+
+    public void setMarketDepth(long marketDepth) {
+        this.marketDepth = marketDepth;
+    }
+
+    public BigDecimal getTotalVolume() {
+        return totalVolume;
+    }
+
+    public void setTotalVolume(BigDecimal totalVolume) {
+        this.totalVolume = totalVolume;
+    }
+
+    public BigDecimal getAverageAsk() {
+        return averageAsk;
+    }
+
+    public void setAverageAsk(BigDecimal averageAsk) {
+        this.averageAsk = averageAsk;
+    }
+
+    public long getActiveSellers() {
+        return activeSellers;
+    }
+
+    public void setActiveSellers(long activeSellers) {
+        this.activeSellers = activeSellers;
+    }
+
+    public BigDecimal getSpread() {
+        return spread;
+    }
+
+    public void setSpread(BigDecimal spread) {
+        this.spread = spread;
+    }
+
+    public BigDecimal getBestAsk() {
+        return bestAsk;
+    }
+
+    public void setBestAsk(BigDecimal bestAsk) {
+        this.bestAsk = bestAsk;
+    }
+
+    public long getExecutionsLastHour() {
+        return executionsLastHour;
+    }
+
+    public void setExecutionsLastHour(long executionsLastHour) {
+        this.executionsLastHour = executionsLastHour;
+    }
+}

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/dto/market/MarketKpis.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/dto/market/MarketKpis.java
@@ -1,0 +1,92 @@
+package com.bellingham.datafutures.dto.market;
+
+import java.math.BigDecimal;
+
+public class MarketKpis {
+
+    private long openContracts;
+    private long marketDepth;
+    private BigDecimal totalVolume;
+    private BigDecimal averageAsk;
+    private long activeSellers;
+    private BigDecimal spread;
+    private BigDecimal bestAsk;
+    private long executionsLastHour;
+
+    public static MarketKpis empty() {
+        MarketKpis kpis = new MarketKpis();
+        kpis.setOpenContracts(0L);
+        kpis.setMarketDepth(0L);
+        kpis.setTotalVolume(BigDecimal.ZERO);
+        kpis.setAverageAsk(BigDecimal.ZERO);
+        kpis.setActiveSellers(0L);
+        kpis.setSpread(BigDecimal.ZERO);
+        kpis.setBestAsk(BigDecimal.ZERO);
+        kpis.setExecutionsLastHour(0L);
+        return kpis;
+    }
+
+    public long getOpenContracts() {
+        return openContracts;
+    }
+
+    public void setOpenContracts(long openContracts) {
+        this.openContracts = openContracts;
+    }
+
+    public long getMarketDepth() {
+        return marketDepth;
+    }
+
+    public void setMarketDepth(long marketDepth) {
+        this.marketDepth = marketDepth;
+    }
+
+    public BigDecimal getTotalVolume() {
+        return totalVolume;
+    }
+
+    public void setTotalVolume(BigDecimal totalVolume) {
+        this.totalVolume = totalVolume;
+    }
+
+    public BigDecimal getAverageAsk() {
+        return averageAsk;
+    }
+
+    public void setAverageAsk(BigDecimal averageAsk) {
+        this.averageAsk = averageAsk;
+    }
+
+    public long getActiveSellers() {
+        return activeSellers;
+    }
+
+    public void setActiveSellers(long activeSellers) {
+        this.activeSellers = activeSellers;
+    }
+
+    public BigDecimal getSpread() {
+        return spread;
+    }
+
+    public void setSpread(BigDecimal spread) {
+        this.spread = spread;
+    }
+
+    public BigDecimal getBestAsk() {
+        return bestAsk;
+    }
+
+    public void setBestAsk(BigDecimal bestAsk) {
+        this.bestAsk = bestAsk;
+    }
+
+    public long getExecutionsLastHour() {
+        return executionsLastHour;
+    }
+
+    public void setExecutionsLastHour(long executionsLastHour) {
+        this.executionsLastHour = executionsLastHour;
+    }
+}

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/dto/market/MarketSnapshot.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/dto/market/MarketSnapshot.java
@@ -1,0 +1,46 @@
+package com.bellingham.datafutures.dto.market;
+
+import com.bellingham.datafutures.model.ForwardContract;
+
+import java.time.Instant;
+import java.util.List;
+
+public class MarketSnapshot {
+
+    private List<ForwardContract> contracts;
+    private MarketKpis kpis;
+    private MarketDelta delta;
+    private Instant generatedAt;
+
+    public List<ForwardContract> getContracts() {
+        return contracts;
+    }
+
+    public void setContracts(List<ForwardContract> contracts) {
+        this.contracts = contracts;
+    }
+
+    public MarketKpis getKpis() {
+        return kpis;
+    }
+
+    public void setKpis(MarketKpis kpis) {
+        this.kpis = kpis;
+    }
+
+    public MarketDelta getDelta() {
+        return delta;
+    }
+
+    public void setDelta(MarketDelta delta) {
+        this.delta = delta;
+    }
+
+    public Instant getGeneratedAt() {
+        return generatedAt;
+    }
+
+    public void setGeneratedAt(Instant generatedAt) {
+        this.generatedAt = generatedAt;
+    }
+}

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/repository/ContractActivityRepository.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/repository/ContractActivityRepository.java
@@ -5,9 +5,12 @@ import com.bellingham.datafutures.model.ForwardContract;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
 public interface ContractActivityRepository extends JpaRepository<ContractActivity, Long> {
     List<ContractActivity> findByContractOrderByTimestampAsc(ForwardContract contract);
+
+    long countByActionAndTimestampAfter(String action, LocalDateTime timestamp);
 }

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/service/MarketDataService.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/service/MarketDataService.java
@@ -1,0 +1,151 @@
+package com.bellingham.datafutures.service;
+
+import com.bellingham.datafutures.dto.market.MarketDelta;
+import com.bellingham.datafutures.dto.market.MarketKpis;
+import com.bellingham.datafutures.dto.market.MarketSnapshot;
+import com.bellingham.datafutures.model.ForwardContract;
+import com.bellingham.datafutures.repository.ContractActivityRepository;
+import com.bellingham.datafutures.repository.ForwardContractRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+@Service
+public class MarketDataService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MarketDataService.class);
+    private static final String PURCHASE_ACTION = "Purchased contract";
+
+    private final ForwardContractRepository contractRepository;
+    private final ContractActivityRepository activityRepository;
+    private final MarketDataStreamService streamService;
+    private final AtomicReference<MarketKpis> baseline = new AtomicReference<>(MarketKpis.empty());
+
+    public MarketDataService(ForwardContractRepository contractRepository,
+                             ContractActivityRepository activityRepository,
+                             MarketDataStreamService streamService) {
+        this.contractRepository = contractRepository;
+        this.activityRepository = activityRepository;
+        this.streamService = streamService;
+    }
+
+    public void publishSnapshot() {
+        MarketSnapshot snapshot = computeSnapshot(true);
+        streamService.broadcast(snapshot);
+    }
+
+    public MarketSnapshot getSnapshot() {
+        MarketSnapshot snapshot = computeSnapshot(false);
+        snapshot.setDelta(MarketDelta.empty());
+        return snapshot;
+    }
+
+    public void sendSnapshot(SseEmitter emitter) {
+        try {
+            MarketSnapshot snapshot = computeSnapshot(false);
+            snapshot.setDelta(MarketDelta.empty());
+            streamService.sendSnapshot(emitter, snapshot);
+        } catch (IOException ex) {
+            LOGGER.warn("Failed to send initial market snapshot", ex);
+            emitter.completeWithError(ex);
+        }
+    }
+
+    private MarketSnapshot computeSnapshot(boolean updateBaseline) {
+        List<ForwardContract> available = contractRepository
+                .findByStatus("Available", Pageable.unpaged())
+                .getContent();
+
+        List<ForwardContract> orderBook = available.stream()
+                .sorted(Comparator.comparing(ForwardContract::getPrice, (left, right) -> {
+                    if (left == null && right == null) {
+                        return 0;
+                    }
+                    if (left == null) {
+                        return 1;
+                    }
+                    if (right == null) {
+                        return -1;
+                    }
+                    return left.compareTo(right);
+                }))
+                .limit(50)
+                .collect(Collectors.toList());
+
+        MarketKpis kpis = calculateKpis(available, orderBook);
+        MarketKpis previous = baseline.get();
+        MarketDelta delta = MarketDelta.from(previous, kpis);
+
+        if (updateBaseline) {
+            baseline.set(kpis);
+        }
+
+        MarketSnapshot snapshot = new MarketSnapshot();
+        snapshot.setContracts(orderBook);
+        snapshot.setKpis(kpis);
+        snapshot.setDelta(delta);
+        snapshot.setGeneratedAt(Instant.now());
+        return snapshot;
+    }
+
+    private MarketKpis calculateKpis(List<ForwardContract> available, List<ForwardContract> orderBook) {
+        BigDecimal totalVolume = available.stream()
+                .map(ForwardContract::getPrice)
+                .filter(Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        long availableCount = available.size();
+        BigDecimal averageAsk = availableCount == 0
+                ? BigDecimal.ZERO
+                : totalVolume.divide(BigDecimal.valueOf(availableCount), 2, RoundingMode.HALF_UP);
+
+        BigDecimal bestAsk = orderBook.stream()
+                .map(ForwardContract::getPrice)
+                .filter(Objects::nonNull)
+                .min(BigDecimal::compareTo)
+                .orElse(BigDecimal.ZERO);
+
+        BigDecimal tailAsk = orderBook.stream()
+                .map(ForwardContract::getPrice)
+                .filter(Objects::nonNull)
+                .max(BigDecimal::compareTo)
+                .orElse(bestAsk);
+
+        BigDecimal spread = tailAsk.subtract(bestAsk);
+
+        long activeSellers = available.stream()
+                .map(ForwardContract::getSeller)
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .distinct()
+                .count();
+
+        LocalDateTime cutoff = LocalDateTime.now().minusHours(1);
+        long executionsLastHour = activityRepository.countByActionAndTimestampAfter(PURCHASE_ACTION, cutoff);
+
+        MarketKpis kpis = new MarketKpis();
+        kpis.setOpenContracts(availableCount);
+        kpis.setMarketDepth(availableCount);
+        kpis.setTotalVolume(totalVolume);
+        kpis.setAverageAsk(averageAsk);
+        kpis.setActiveSellers(activeSellers);
+        kpis.setSpread(spread);
+        kpis.setBestAsk(bestAsk);
+        kpis.setExecutionsLastHour(executionsLastHour);
+        return kpis;
+    }
+}

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/service/MarketDataStreamService.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/service/MarketDataStreamService.java
@@ -1,0 +1,52 @@
+package com.bellingham.datafutures.service;
+
+import com.bellingham.datafutures.dto.market.MarketSnapshot;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Service
+public class MarketDataStreamService {
+
+    public static final String MARKET_EVENT_NAME = "market-update";
+    private static final long TIMEOUT = 0L;
+
+    private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+
+    public SseEmitter subscribe() {
+        SseEmitter emitter = new SseEmitter(TIMEOUT);
+        emitters.add(emitter);
+
+        emitter.onCompletion(() -> emitters.remove(emitter));
+        emitter.onTimeout(() -> emitters.remove(emitter));
+        emitter.onError((ex) -> emitters.remove(emitter));
+
+        return emitter;
+    }
+
+    public void broadcast(MarketSnapshot snapshot) {
+        List<SseEmitter> deadEmitters = new ArrayList<>();
+
+        for (SseEmitter emitter : emitters) {
+            try {
+                sendSnapshot(emitter, snapshot);
+            } catch (IOException ex) {
+                deadEmitters.add(emitter);
+            }
+        }
+
+        if (!deadEmitters.isEmpty()) {
+            emitters.removeAll(deadEmitters);
+        }
+    }
+
+    public void sendSnapshot(SseEmitter emitter, MarketSnapshot snapshot) throws IOException {
+        emitter.send(SseEmitter.event()
+                .name(MARKET_EVENT_NAME)
+                .data(snapshot));
+    }
+}

--- a/bellingham-frontend/src/hooks/useMarketStream.js
+++ b/bellingham-frontend/src/hooks/useMarketStream.js
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from "react";
+
+const createStreamUrl = () => {
+    if (typeof window === "undefined") {
+        return null;
+    }
+
+    const baseUrl = import.meta.env.VITE_API_BASE_URL;
+    try {
+        return new URL("/api/contracts/stream", baseUrl || window.location.origin).toString();
+    } catch (error) {
+        console.error("Failed to construct market stream URL", error);
+        return "/api/contracts/stream";
+    }
+};
+
+const useMarketStream = ({ enabled, onSnapshot }) => {
+    const callbackRef = useRef(onSnapshot);
+
+    useEffect(() => {
+        callbackRef.current = onSnapshot;
+    }, [onSnapshot]);
+
+    useEffect(() => {
+        if (!enabled) {
+            return undefined;
+        }
+
+        if (typeof window === "undefined" || typeof window.EventSource === "undefined") {
+            console.warn("EventSource is not supported in this environment; real-time market updates disabled.");
+            return undefined;
+        }
+
+        const streamUrl = createStreamUrl();
+        if (!streamUrl) {
+            return undefined;
+        }
+
+        const eventSource = new EventSource(streamUrl, { withCredentials: true });
+
+        const handleEvent = (event) => {
+            try {
+                const data = JSON.parse(event.data);
+                if (callbackRef.current) {
+                    callbackRef.current(data);
+                }
+            } catch (error) {
+                console.error("Failed to parse market update event", error);
+            }
+        };
+
+        eventSource.addEventListener("market-update", handleEvent);
+        eventSource.onerror = (error) => {
+            console.error("Market data stream error", error);
+        };
+
+        return () => {
+            eventSource.removeEventListener("market-update", handleEvent);
+            eventSource.close();
+        };
+    }, [enabled]);
+};
+
+export default useMarketStream;


### PR DESCRIPTION
## Summary
- add market snapshot DTOs and services that broadcast contract and KPI changes over an SSE channel
- hook contract mutations and maintenance routines into the streaming service while exposing /api/contracts/market and /stream endpoints
- update the dashboard to subscribe to the market stream, surface KPI deltas, and render live pricing data with a reusable useMarketStream hook

## Testing
- npm run lint *(fails: existing `handleFileChange` is not defined in Sell.jsx)*
- ./mvnw -q test *(fails: missing JwtUtil bean for JwtFilter in test context)*

------
https://chatgpt.com/codex/tasks/task_e_68da3215dbf483298d93c2ab1c049d01