### PR TITLE
Allow buying without signature

### DIFF
--- a/bellingham-frontend/src/__tests__/Buy.test.jsx
+++ b/bellingham-frontend/src/__tests__/Buy.test.jsx
@@ -96,4 +96,23 @@ describe('Buy component', () => {
       );
     });
   });
+
+  test('allows confirming purchase without providing a signature', async () => {
+    renderWithProviders(<Buy />);
+
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith('/api/contracts/available'));
+
+    const buyButton = screen.getAllByRole('button', { name: 'Buy' })[0];
+    fireEvent.click(buyButton);
+
+    const continueButton = await screen.findByRole('button', { name: 'Continue without signature' });
+    fireEvent.click(continueButton);
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith(
+        '/api/contracts/1/buy',
+        undefined,
+      );
+    });
+  });
 });

--- a/bellingham-frontend/src/__tests__/SignatureModal.test.jsx
+++ b/bellingham-frontend/src/__tests__/SignatureModal.test.jsx
@@ -43,6 +43,9 @@ test('invokes handlers for actions', () => {
   expect(isEmptySpy).toHaveBeenCalled();
   expect(onConfirm).toHaveBeenCalledWith('mock-data-url');
 
+  fireEvent.click(screen.getByText('Continue without signature'));
+  expect(onConfirm).toHaveBeenCalledWith(null);
+
   fireEvent.click(screen.getByText('Cancel'));
   expect(onCancel).toHaveBeenCalled();
 

--- a/bellingham-frontend/src/components/SignatureModal.jsx
+++ b/bellingham-frontend/src/components/SignatureModal.jsx
@@ -91,6 +91,11 @@ const SignatureModal = ({ onConfirm, onCancel }) => {
     onConfirm(data);
   };
 
+  const handleConfirmWithoutSignature = () => {
+    setError('');
+    onConfirm(null);
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 backdrop-blur-sm">
       <div className="w-full max-w-xl rounded-2xl border border-slate-700 bg-slate-900 p-6 shadow-2xl">
@@ -113,6 +118,13 @@ const SignatureModal = ({ onConfirm, onCancel }) => {
         <div className="mt-6 flex flex-wrap justify-end gap-2">
           <Button variant="ghost" className="border border-slate-600/60 bg-slate-800 text-slate-100 hover:bg-slate-700" onClick={handleClear}>Clear</Button>
           <Button variant="danger" className="shadow-lg shadow-red-900/40" onClick={onCancel}>Cancel</Button>
+          <Button
+            variant="primary"
+            className="font-semibold shadow-lg shadow-[#00D1FF]/25"
+            onClick={handleConfirmWithoutSignature}
+          >
+            Continue without signature
+          </Button>
           <Button variant="success" className="font-semibold shadow-lg shadow-[#00D1FF]/25" onClick={handleSave}>Save</Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add an explicit option in the signature modal to confirm a purchase without providing a drawn signature
- extend the signature modal and buy page tests to cover the new confirmation path

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da7c30140c8329a3b9e150f8ce11b9