### PR TITLE
Clarify sell submission errors for unauthorized users

### DIFF
--- a/bellingham-frontend/src/components/Sell.jsx
+++ b/bellingham-frontend/src/components/Sell.jsx
@@ -235,11 +235,21 @@ const Sell = () => {
         } catch (err) {
             console.error(err);
             const status = err.response?.status;
-            const message = err.response?.data?.message || err.message || "Submission failed.";
+            const defaultMessage = err.response?.data?.message || err.message || "Submission failed.";
+
+            let friendlyMessage = defaultMessage;
+            if (status === 401) {
+                friendlyMessage =
+                    "Your session has expired. Please sign in again to list your data contract.";
+            } else if (status === 403) {
+                friendlyMessage =
+                    "We couldn't verify your access. Make sure you're signed in—data samples are optional.";
+            }
+
             setMessage(
                 status
-                    ? `❌ Submission failed (${status}): ${message}`
-                    : `❌ Submission failed: ${message}`
+                    ? `❌ Submission failed (${status}): ${friendlyMessage}`
+                    : `❌ Submission failed: ${friendlyMessage}`
             );
         } finally {
             setIsSubmitting(false);


### PR DESCRIPTION
## Summary
- add friendly messaging for 401 and 403 responses when submitting a sell listing so users know to sign in and that samples are optional

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da9ffbfc1883298bee479d21ca456e