### PR TITLE
Add token-based auth fallback for frontend API requests

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
@@ -69,6 +69,7 @@ public class AuthController {
             Map<String, Object> response = new HashMap<>();
             response.put("username", creds.getUsername());
             response.put("expiresAt", expiresAt.toString());
+            response.put("token", token);
 
             return ResponseEntity.ok()
                     .header(HttpHeaders.SET_COOKIE, cookie.toString())

--- a/bellingham-frontend/src/__tests__/AuthContext.test.jsx
+++ b/bellingham-frontend/src/__tests__/AuthContext.test.jsx
@@ -5,12 +5,13 @@ vi.mock('../utils/api', () => ({
     get: vi.fn(() => Promise.resolve({ data: {} })),
     post: vi.fn(() => Promise.resolve({ data: {} })),
   },
+  setAuthToken: vi.fn(),
 }));
 
 import React from 'react';
 import { renderHook, act } from '@testing-library/react';
 import { AuthProvider, AuthContext } from '../context';
-import api from '../utils/api';
+import api, { setAuthToken } from '../utils/api';
 
 describe('AuthProvider', () => {
   beforeEach(() => {
@@ -28,13 +29,16 @@ describe('AuthProvider', () => {
     });
 
     act(() => {
-      result.current.login({ username: 'user', expiresAt: futureExpiry });
+      result.current.login({ username: 'user', expiresAt: futureExpiry, token: 'abc123' });
     });
 
     expect(result.current.isAuthenticated).toBe(true);
     expect(result.current.username).toBe('user');
+    expect(result.current.token).toBe('abc123');
     expect(localStorage.getItem('auth.username')).toBe('user');
     expect(localStorage.getItem('auth.expiresAt')).toBe(futureExpiry);
+    expect(localStorage.getItem('auth.token')).toBe('abc123');
+    expect(setAuthToken).toHaveBeenCalledWith('abc123');
 
     await act(async () => {
       await result.current.logout();
@@ -42,8 +46,11 @@ describe('AuthProvider', () => {
 
     expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.username).toBeNull();
+    expect(result.current.token).toBeNull();
     expect(localStorage.getItem('auth.username')).toBeNull();
     expect(localStorage.getItem('auth.expiresAt')).toBeNull();
+    expect(localStorage.getItem('auth.token')).toBeNull();
     expect(api.post).toHaveBeenCalledWith('/api/logout');
+    expect(setAuthToken).toHaveBeenCalledWith(null);
   });
 });

--- a/bellingham-frontend/src/__tests__/Login.test.jsx
+++ b/bellingham-frontend/src/__tests__/Login.test.jsx
@@ -10,7 +10,9 @@ import { AuthProvider } from '../context';
 vi.mock('../utils/api', () => ({
   default: {
     post: vi.fn(),
+    get: vi.fn(() => Promise.resolve({ data: {} })),
   },
+  setAuthToken: vi.fn(),
 }));
 
 afterEach(() => {

--- a/bellingham-frontend/src/components/Login.jsx
+++ b/bellingham-frontend/src/components/Login.jsx
@@ -24,9 +24,9 @@ const Login = () => {
 
         try {
             const res = await api.post(`/api/authenticate`, { username, password });
-            const { username: responseUsername, expiresAt } = res.data || {};
-            if (responseUsername && expiresAt) {
-                login({ username: responseUsername, expiresAt });
+            const { username: responseUsername, expiresAt, token } = res.data || {};
+            if (responseUsername && expiresAt && token) {
+                login({ username: responseUsername, expiresAt, token });
                 navigate("/");
             } else {
                 setError("Login failed: Invalid session response.");

--- a/bellingham-frontend/src/context/AuthContext.js
+++ b/bellingham-frontend/src/context/AuthContext.js
@@ -4,6 +4,7 @@ const AuthContext = createContext({
   isAuthenticated: false,
   username: null,
   expiresAt: null,
+  token: null,
   login: () => {},
   logout: async () => {},
 });

--- a/bellingham-frontend/src/utils/api.js
+++ b/bellingham-frontend/src/utils/api.js
@@ -1,9 +1,22 @@
 import axios from 'axios';
 
+const rawBaseURL = import.meta.env.VITE_API_BASE_URL;
+const resolvedBaseURL = typeof rawBaseURL === 'string' && rawBaseURL.trim().length > 0
+  ? rawBaseURL.trim()
+  : '/api';
+
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
+  baseURL: resolvedBaseURL,
   withCredentials: true,
 });
+
+export const setAuthToken = (token) => {
+  if (token) {
+    api.defaults.headers.common.Authorization = `Bearer ${token}`;
+  } else {
+    delete api.defaults.headers.common.Authorization;
+  }
+};
 
 const parseRetryCount = (value, fallback) => {
   if (typeof value === 'number') {


### PR DESCRIPTION
## Summary
- return the generated JWT token from the login endpoint so clients can reuse it
- persist the token in the frontend auth context and attach it to axios requests when present
- refresh login handling, API utilities, and related tests to cover the token-aware flow and default base URL

## Testing
- npm test
- ./mvnw test


------
https://chatgpt.com/codex/tasks/task_e_68daa6a6025c8329b8b2bd0e17d334fb