### PR TITLE
Add persistent sidebar navigation layout

### DIFF
--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -25,7 +25,7 @@ const NotificationBellIcon = ({ className = "", ...props }) => (
     </svg>
 );
 
-const Header = ({ onLogout }) => {
+const Header = ({ onLogout, showNavigation = true }) => {
     const { username, permissions = [], role } = useContext(AuthContext);
     const { unreadCount } = useNotifications();
     const [isNavOpen, setIsNavOpen] = useState(false);
@@ -39,6 +39,8 @@ const Header = ({ onLogout }) => {
         }
         return true;
     }), [permissions, role]);
+
+    const shouldRenderNavigation = showNavigation && filteredNavItems.length > 0;
 
     const toggleNavigation = () => {
         setIsNavOpen((prev) => !prev);
@@ -99,43 +101,45 @@ const Header = ({ onLogout }) => {
                     </div>
                 </div>
 
-                <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-3 shadow-inner shadow-black/20">
-                    <div className="flex items-center justify-between gap-4 lg:hidden">
-                        <span className="text-[0.65rem] font-semibold uppercase tracking-[0.32em] text-slate-400">
-                            Navigation
-                        </span>
-                        <button
-                            type="button"
-                            onClick={toggleNavigation}
-                            aria-expanded={isNavOpen}
-                            aria-controls="primary-navigation"
-                            className="inline-flex items-center gap-2 rounded-lg border border-[#00D1FF]/40 bg-slate-900/80 px-3 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.26em] text-[#00D1FF] transition-colors hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]"
-                        >
-                            <span>{isNavOpen ? "Close" : "Menu"}</span>
-                            <svg
-                                aria-hidden="true"
-                                className={`h-4 w-4 transition-transform ${isNavOpen ? "rotate-180" : ""}`}
-                                xmlns="http://www.w3.org/2000/svg"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                strokeWidth="1.5"
-                                stroke="currentColor"
+                {shouldRenderNavigation && (
+                    <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-3 shadow-inner shadow-black/20">
+                        <div className="flex items-center justify-between gap-4 lg:hidden">
+                            <span className="text-[0.65rem] font-semibold uppercase tracking-[0.32em] text-slate-400">
+                                Navigation
+                            </span>
+                            <button
+                                type="button"
+                                onClick={toggleNavigation}
+                                aria-expanded={isNavOpen}
+                                aria-controls="primary-navigation"
+                                className="inline-flex items-center gap-2 rounded-lg border border-[#00D1FF]/40 bg-slate-900/80 px-3 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.26em] text-[#00D1FF] transition-colors hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]"
                             >
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-                            </svg>
-                        </button>
+                                <span>{isNavOpen ? "Close" : "Menu"}</span>
+                                <svg
+                                    aria-hidden="true"
+                                    className={`h-4 w-4 transition-transform ${isNavOpen ? "rotate-180" : ""}`}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    strokeWidth="1.5"
+                                    stroke="currentColor"
+                                >
+                                    <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                                </svg>
+                            </button>
+                        </div>
+                        <nav
+                            id="primary-navigation"
+                            className={`${
+                                isNavOpen ? "flex" : "hidden"
+                            } flex-col items-stretch gap-4 pt-3 lg:flex lg:flex-row lg:flex-wrap lg:items-center lg:gap-6 lg:pt-0`}
+                        >
+                            {filteredNavItems.map((item) => (
+                                <NavMenuItem key={item.path} item={item} layout="header" onNavigate={handleNavigate} />
+                            ))}
+                        </nav>
                     </div>
-                    <nav
-                        id="primary-navigation"
-                        className={`${
-                            isNavOpen ? "flex" : "hidden"
-                        } flex-col items-stretch gap-4 pt-3 lg:flex lg:flex-row lg:flex-wrap lg:items-center lg:gap-6 lg:pt-0`}
-                    >
-                        {filteredNavItems.map((item) => (
-                            <NavMenuItem key={item.path} item={item} layout="header" onNavigate={handleNavigate} />
-                        ))}
-                    </nav>
-                </div>
+                )}
             </div>
         </header>
     );

--- a/bellingham-frontend/src/components/Layout.jsx
+++ b/bellingham-frontend/src/components/Layout.jsx
@@ -1,10 +1,11 @@
 import React from "react";
 import Header from "./Header";
 import NotificationPopup from "./NotificationPopup";
+import Sidebar from "./Sidebar";
 
 const Layout = ({ children, onLogout }) => (
     <div
-        className="flex min-h-screen flex-col font-sans text-contrast"
+        className="min-h-screen font-sans text-contrast"
         style={{
             backgroundColor: 'var(--bg-color)',
             backgroundImage: 'var(--bg-gradient)',
@@ -13,12 +14,17 @@ const Layout = ({ children, onLogout }) => (
         <a href="#main-content" className="skip-link">
             Skip to main content
         </a>
-        <Header onLogout={onLogout} />
-        <main id="main-content" tabIndex="-1" className="flex-1">
-            <div className="mx-auto w-full max-w-7xl px-6 py-8 lg:px-10 lg:py-12">
-                {children}
+        <div className="flex min-h-screen">
+            <Sidebar onLogout={onLogout} />
+            <div className="flex flex-1 flex-col">
+                <Header onLogout={onLogout} showNavigation={false} />
+                <main id="main-content" tabIndex="-1" className="flex-1">
+                    <div className="mx-auto w-full max-w-7xl px-6 py-8 lg:px-10 lg:py-12">
+                        {children}
+                    </div>
+                </main>
             </div>
-        </main>
+        </div>
         <NotificationPopup />
     </div>
 );

--- a/bellingham-frontend/src/components/Sidebar.jsx
+++ b/bellingham-frontend/src/components/Sidebar.jsx
@@ -1,17 +1,29 @@
-import React, { useMemo, useState } from "react";
+import React, { useContext, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Button from "./ui/Button";
 import navItems from "../config/navItems";
 import NavMenuItem from "./ui/NavMenuItem";
+import { AuthContext } from "../context";
 
 const Sidebar = ({ onLogout }) => {
     const navigate = useNavigate();
     const [isMobileOpen, setIsMobileOpen] = useState(false);
+    const { permissions = [], role } = useContext(AuthContext);
+
+    const filteredNavItems = useMemo(() => navItems.filter((item) => {
+        if (item.requiresRole && item.requiresRole !== role) {
+            return false;
+        }
+        if (item.requiresPermission && !permissions.includes(item.requiresPermission)) {
+            return false;
+        }
+        return true;
+    }), [permissions, role]);
 
     const groupedNavItems = useMemo(() => {
         const sections = new Map();
 
-        navItems.forEach((item) => {
+        filteredNavItems.forEach((item) => {
             const section = item.section || "General";
             if (!sections.has(section)) {
                 sections.set(section, []);
@@ -20,7 +32,7 @@ const Sidebar = ({ onLogout }) => {
         });
 
         return sections;
-    }, []);
+    }, [filteredNavItems]);
 
     const toggleMobile = () => setIsMobileOpen((prev) => !prev);
     const closeMobile = () => setIsMobileOpen(false);


### PR DESCRIPTION
## Summary
- wrap authenticated layouts with a sidebar navigation shell
- hide header navigation controls when the sidebar is displayed and filter sidebar links by access

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df9df312f08329bb7e0b9c3c8dd79f