### PR TITLE
Revamp platform shell with modern left navigation

### DIFF
--- a/bellingham-frontend/src/__tests__/Sidebar.test.jsx
+++ b/bellingham-frontend/src/__tests__/Sidebar.test.jsx
@@ -3,13 +3,24 @@ import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import Sidebar from '../components/Sidebar';
 import navItems from '../config/navItems';
+import { AuthContext } from '../context';
 
-test('renders navigation links from configuration', () => {
+const renderSidebar = (initialEntries = ['/']) =>
     render(
-        <MemoryRouter>
-            <Sidebar />
+        <MemoryRouter initialEntries={initialEntries}>
+            <AuthContext.Provider
+                value={{
+                    permissions: ['BUY', 'SELL'],
+                    role: 'ROLE_ADMIN',
+                }}
+            >
+                <Sidebar />
+            </AuthContext.Provider>
         </MemoryRouter>
     );
+
+test('renders navigation links from configuration', () => {
+    renderSidebar();
     navItems.forEach((item) => {
         const matches = screen.getAllByText(item.label);
         expect(matches.some((match) => match.closest('a')?.getAttribute('href') === item.path)).toBe(true);
@@ -17,11 +28,7 @@ test('renders navigation links from configuration', () => {
 });
 
 test('renders section headings for grouped navigation', () => {
-    render(
-        <MemoryRouter>
-            <Sidebar />
-        </MemoryRouter>
-    );
+    renderSidebar();
 
     const sections = [...new Set(navItems.map((item) => item.section || 'General'))];
 
@@ -32,21 +39,13 @@ test('renders section headings for grouped navigation', () => {
 });
 
 test('highlights the active link', () => {
-    render(
-        <MemoryRouter initialEntries={['/sell']}>
-            <Sidebar />
-        </MemoryRouter>
-    );
-    expect(screen.getByRole('link', { name: 'Sell' })).toHaveClass('bg-slate-800');
-    expect(screen.getByRole('link', { name: 'Home' })).not.toHaveClass('bg-slate-800');
+    renderSidebar(['/sell']);
+    expect(screen.getByRole('link', { name: 'Sell' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'Home' })).not.toHaveAttribute('aria-current', 'page');
 });
 
 test('shows contextual action button', () => {
-    render(
-        <MemoryRouter>
-            <Sidebar />
-        </MemoryRouter>
-    );
+    renderSidebar();
 
-    expect(screen.getByText('New Listing')).toBeInTheDocument();
+    expect(screen.getByText('Create Listing')).toBeInTheDocument();
 });

--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 
 import { AuthContext, useNotifications } from "../context";
 import navItems from "../config/navItems";
@@ -25,10 +25,25 @@ const NotificationBellIcon = ({ className = "", ...props }) => (
     </svg>
 );
 
+const pageDescriptions = {
+    "/": "Live market intelligence and real-time execution metrics.",
+    "/buy": "Discover opportunities that match your sourcing strategy.",
+    "/sell": "Craft competitive listings and reach active buyers instantly.",
+    "/reports": "Visualise platform performance and compliance insights.",
+    "/sales": "Track pipeline health and completed market activity.",
+    "/calendar": "Coordinate market events, closings, and settlement windows.",
+    "/history": "Review historical transactions and audit-ready activity logs.",
+    "/settings": "Fine-tune platform preferences to suit your workflow.",
+    "/account": "Manage account details, security, and collaboration settings.",
+    "/notifications": "Stay ahead with timely alerts from across the exchange.",
+    "/admin/users": "Curate access controls for your organisation.",
+};
+
 const Header = ({ onLogout, showNavigation = true }) => {
     const { username, permissions = [], role } = useContext(AuthContext);
     const { unreadCount } = useNotifications();
     const [isNavOpen, setIsNavOpen] = useState(false);
+    const location = useLocation();
 
     const filteredNavItems = useMemo(() => navItems.filter((item) => {
         if (item.requiresRole && item.requiresRole !== role) {
@@ -42,6 +57,19 @@ const Header = ({ onLogout, showNavigation = true }) => {
 
     const shouldRenderNavigation = showNavigation && filteredNavItems.length > 0;
 
+    const activeItem = useMemo(() => {
+        const pathName = location.pathname;
+        return filteredNavItems.find((item) =>
+            item.path === "/"
+                ? pathName === "/"
+                : pathName.startsWith(item.path)
+        );
+    }, [filteredNavItems, location.pathname]);
+
+    const pageTitle = activeItem?.label || "Bellingham Markets Platform";
+    const pageDescription = pageDescriptions[activeItem?.path ?? location.pathname] ||
+        "A modern trading experience tailored for the Bellingham marketplace.";
+
     const toggleNavigation = () => {
         setIsNavOpen((prev) => !prev);
     };
@@ -51,19 +79,26 @@ const Header = ({ onLogout, showNavigation = true }) => {
     };
 
     return (
-        <header className="relative z-20 border-b border-slate-800/70 bg-slate-950/95 shadow-[0_16px_40px_rgba(8,20,45,0.65)]">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 py-4 lg:px-10">
-                <div className="flex flex-wrap items-center justify-between gap-4">
-                    <Link to="/" className="flex flex-col leading-tight">
-                        <span className="text-xs font-semibold uppercase tracking-[0.4em] text-[#00D1FF]/80">
-                            Bellingham
-                        </span>
-                        <span className="text-lg font-semibold text-white">Markets Platform</span>
-                    </Link>
-                    <div className="flex items-center gap-4 lg:gap-6">
+        <header className="sticky top-0 z-20 border-b border-slate-800/60 bg-gradient-to-b from-slate-950/80 via-slate-950/65 to-slate-950/40 backdrop-blur-xl">
+            <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-6 px-6 py-6 sm:px-8">
+                <div className="flex flex-wrap items-start justify-between gap-6">
+                    <div className="space-y-2">
+                        <Link to="/" className="group flex flex-col leading-tight text-left">
+                            <span className="text-[0.65rem] font-semibold uppercase tracking-[0.42em] text-[#00D1FF]/75">
+                                Bellingham Markets
+                            </span>
+                            <span className="text-2xl font-semibold text-white">
+                                {pageTitle}
+                            </span>
+                        </Link>
+                        <p className="max-w-xl text-sm text-slate-300/90">
+                            {pageDescription}
+                        </p>
+                    </div>
+                    <div className="flex items-center gap-4">
                         <Link
                             to="/notifications"
-                            className="relative flex h-10 w-10 items-center justify-center rounded-full border border-[#00D1FF]/40 bg-slate-900/80 text-[#00D1FF] shadow-[0_6px_18px_rgba(0,209,255,0.3)] transition-colors hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]"
+                            className="relative flex h-12 w-12 items-center justify-center rounded-2xl border border-[#00D1FF]/40 bg-slate-900/70 text-[#00D1FF] shadow-[0_18px_48px_rgba(0,209,255,0.32)] transition-all hover:-translate-y-0.5 hover:bg-slate-900/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                             aria-label={
                                 unreadCount > 0
                                     ? `${unreadCount} unread notifications`
@@ -80,7 +115,7 @@ const Header = ({ onLogout, showNavigation = true }) => {
                         </Link>
 
                         {username && (
-                            <>
+                            <div className="flex items-center gap-4">
                                 <div className="text-right">
                                     <p className="text-[0.65rem] font-semibold uppercase tracking-[0.38em] text-slate-400">
                                         Logged in as
@@ -91,18 +126,18 @@ const Header = ({ onLogout, showNavigation = true }) => {
                                     <button
                                         type="button"
                                         onClick={onLogout}
-                                        className="rounded-lg border border-[#3BAEAB]/60 bg-[#3BAEAB]/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-[#9CD8D6] transition-colors hover:bg-[#3BAEAB]/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]"
+                                        className="rounded-2xl border border-[#3BAEAB]/50 bg-[#3BAEAB]/10 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.28em] text-[#9CD8D6] transition-all hover:-translate-y-0.5 hover:bg-[#3BAEAB]/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                                     >
                                         Log Out
                                     </button>
                                 )}
-                            </>
+                            </div>
                         )}
                     </div>
                 </div>
 
                 {shouldRenderNavigation && (
-                    <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-3 shadow-inner shadow-black/20">
+                    <div className="rounded-2xl border border-slate-800/60 bg-slate-950/60 px-3 py-4 shadow-[0_24px_60px_rgba(8,20,45,0.4)]">
                         <div className="flex items-center justify-between gap-4 lg:hidden">
                             <span className="text-[0.65rem] font-semibold uppercase tracking-[0.32em] text-slate-400">
                                 Navigation
@@ -112,7 +147,7 @@ const Header = ({ onLogout, showNavigation = true }) => {
                                 onClick={toggleNavigation}
                                 aria-expanded={isNavOpen}
                                 aria-controls="primary-navigation"
-                                className="inline-flex items-center gap-2 rounded-lg border border-[#00D1FF]/40 bg-slate-900/80 px-3 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.26em] text-[#00D1FF] transition-colors hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]"
+                                className="inline-flex items-center gap-2 rounded-xl border border-[#00D1FF]/40 bg-slate-900/70 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.26em] text-[#00D1FF] transition-colors hover:bg-slate-900/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]"
                             >
                                 <span>{isNavOpen ? "Close" : "Menu"}</span>
                                 <svg
@@ -132,7 +167,7 @@ const Header = ({ onLogout, showNavigation = true }) => {
                             id="primary-navigation"
                             className={`${
                                 isNavOpen ? "flex" : "hidden"
-                            } flex-col items-stretch gap-4 pt-3 lg:flex lg:flex-row lg:flex-wrap lg:items-center lg:gap-6 lg:pt-0`}
+                            } flex-col items-stretch gap-3 pt-3 lg:flex lg:flex-row lg:flex-wrap lg:items-center lg:gap-4 lg:pt-0`}
                         >
                             {filteredNavItems.map((item) => (
                                 <NavMenuItem key={item.path} item={item} layout="header" onNavigate={handleNavigate} />

--- a/bellingham-frontend/src/components/Layout.jsx
+++ b/bellingham-frontend/src/components/Layout.jsx
@@ -3,23 +3,27 @@ import Header from "./Header";
 import NotificationPopup from "./NotificationPopup";
 import Sidebar from "./Sidebar";
 
+const sidebarWidth = "clamp(220px, 11.111vw, 280px)";
+
 const Layout = ({ children, onLogout }) => (
     <div
-        className="min-h-screen font-sans text-contrast"
+        className="relative min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top,_rgba(0,209,255,0.12),_transparent_55%),_var(--bg-gradient)] font-sans text-contrast"
         style={{
-            backgroundColor: 'var(--bg-color)',
-            backgroundImage: 'var(--bg-gradient)',
+            backgroundColor: "var(--bg-color)",
         }}
     >
         <a href="#main-content" className="skip-link">
             Skip to main content
         </a>
-        <div className="flex min-h-screen">
-            <Sidebar onLogout={onLogout} />
-            <div className="flex flex-1 flex-col">
+        <div
+            className="relative mx-auto flex min-h-screen w-full max-w-[1600px] flex-col gap-6 px-4 py-6 lg:flex-row lg:px-8 lg:py-10"
+            style={{ "--sidebar-width": sidebarWidth }}
+        >
+            <Sidebar onLogout={onLogout} sidebarWidth={sidebarWidth} />
+            <div className="flex flex-1 flex-col rounded-3xl border border-slate-800/60 bg-slate-950/70 backdrop-blur-xl shadow-[0_45px_140px_rgba(8,20,45,0.45)]">
                 <Header onLogout={onLogout} showNavigation={false} />
-                <main id="main-content" tabIndex="-1" className="flex-1">
-                    <div className="mx-auto w-full max-w-7xl px-6 py-8 lg:px-10 lg:py-12">
+                <main id="main-content" tabIndex="-1" className="flex-1 overflow-y-auto">
+                    <div className="w-full px-6 pb-12 pt-8 sm:px-8 lg:px-12">
                         {children}
                     </div>
                 </main>

--- a/bellingham-frontend/src/components/Sidebar.jsx
+++ b/bellingham-frontend/src/components/Sidebar.jsx
@@ -5,7 +5,7 @@ import navItems from "../config/navItems";
 import NavMenuItem from "./ui/NavMenuItem";
 import { AuthContext } from "../context";
 
-const Sidebar = ({ onLogout }) => {
+const Sidebar = ({ onLogout, sidebarWidth }) => {
     const navigate = useNavigate();
     const [isMobileOpen, setIsMobileOpen] = useState(false);
     const { permissions = [], role } = useContext(AuthContext);
@@ -43,11 +43,14 @@ const Sidebar = ({ onLogout }) => {
     };
 
     return (
-        <div className="relative flex-shrink-0 md:w-64">
+        <div
+            className="relative z-40 flex-shrink-0"
+            style={{ "--sidebar-width": sidebarWidth }}
+        >
             <button
                 type="button"
                 onClick={toggleMobile}
-                className="md:hidden fixed top-20 left-4 z-50 inline-flex items-center justify-center rounded-full bg-slate-900 p-3 text-white shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-950 focus:ring-[#00D1FF]"
+                className="fixed left-4 top-6 z-50 inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-slate-800/60 bg-slate-950/90 text-white shadow-[0_18px_45px_rgba(8,20,45,0.55)] backdrop-blur focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 lg:hidden"
                 aria-label={isMobileOpen ? "Close navigation" : "Open navigation"}
                 aria-expanded={isMobileOpen}
             >
@@ -56,58 +59,78 @@ const Sidebar = ({ onLogout }) => {
                     {isMobileOpen ? (
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
                     ) : (
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4.5 6.75h15M4.5 12h15M4.5 17.25h15" />
                     )}
                 </svg>
             </button>
 
             {isMobileOpen && (
-                <div className="fixed inset-0 z-40 bg-black/50 md:hidden" role="presentation" onClick={closeMobile} />
+                <div className="fixed inset-0 z-40 bg-slate-900/70 backdrop-blur-sm lg:hidden" role="presentation" onClick={closeMobile} />
             )}
 
             <aside
-                className={`fixed inset-y-0 left-0 z-50 flex w-64 transform flex-col justify-between border-r border-slate-800 bg-slate-950/95 p-6 shadow-xl shadow-black/20 backdrop-blur transition-transform duration-300 ease-in-out md:static md:z-auto md:translate-x-0 md:transform-none md:w-64 ${
+                className={`fixed inset-y-0 left-0 z-50 flex h-full transform flex-col overflow-hidden border-r border-slate-800/60 bg-slate-950/95 px-6 pb-8 pt-10 text-slate-100 shadow-[0_45px_120px_rgba(8,20,45,0.55)] backdrop-blur-xl transition-transform duration-300 ease-in-out lg:static lg:z-auto lg:translate-x-0 lg:rounded-3xl lg:border lg:border-slate-800/60 lg:bg-slate-950/60 lg:px-7 lg:py-10 lg:shadow-[0_35px_110px_rgba(8,20,45,0.45)] ${
                     isMobileOpen ? "translate-x-0" : "-translate-x-full"
                 }`}
+                style={{ width: "var(--sidebar-width)", flexBasis: "var(--sidebar-width)" }}
             >
-                <div className="flex items-center justify-between pb-4 md:hidden">
-                    <h2 className="text-base font-semibold text-white">Navigation</h2>
+                <div className="flex items-center justify-between gap-3">
+                    <button
+                        type="button"
+                        onClick={() => handleNavigate("/")}
+                        className="group flex items-center gap-3 rounded-2xl border border-transparent bg-slate-900/70 px-3 py-2 text-left transition-colors hover:border-[#00D1FF]/40 hover:bg-slate-900/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                    >
+                        <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-[#00D1FF]/80 to-[#7465A8]/70 text-base font-bold text-slate-950 shadow-[0_12px_35px_rgba(0,209,255,0.45)]">
+                            BM
+                        </span>
+                        <span className="flex flex-col leading-tight">
+                            <span className="text-[0.65rem] font-semibold uppercase tracking-[0.38em] text-[#9CD8D6]">Bellingham</span>
+                            <span className="text-sm font-semibold text-white">Markets Platform</span>
+                        </span>
+                    </button>
                     <button
                         type="button"
                         onClick={closeMobile}
-                        className="inline-flex items-center justify-center rounded-full bg-slate-800 p-2 text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]"
+                        className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-slate-800/60 bg-slate-900/60 text-slate-300 transition-colors hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF] lg:hidden"
                     >
                         <span className="sr-only">Close navigation</span>
-                        <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <svg className="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
                         </svg>
                     </button>
                 </div>
 
-                <nav className="flex flex-1 flex-col gap-6 overflow-y-auto pr-2">
+                <div className="mt-8 flex-1 space-y-8 overflow-y-auto pr-1">
                     {Array.from(groupedNavItems.entries()).map(([section, items]) => (
-                        <div key={section} className="flex flex-col gap-2">
-                            <p className="px-1 text-xs font-semibold uppercase tracking-widest text-slate-400/90">{section}</p>
-                            <div className="flex flex-col gap-1">
+                        <div key={section} className="space-y-3">
+                            <p className="px-1 text-[0.65rem] font-semibold uppercase tracking-[0.42em] text-slate-400/80">{section}</p>
+                            <div className="space-y-1.5">
                                 {items.map((item) => (
                                     <NavMenuItem key={item.path} item={item} layout="sidebar" onNavigate={handleNavigate} />
                                 ))}
                             </div>
                         </div>
                     ))}
-                </nav>
-                <div className="mt-6 flex flex-col space-y-2 border-t border-slate-800 pt-4">
-                    <Button
-                        variant="success"
-                        className="w-full"
-                        onClick={() => handleNavigate("/sell")}
-                    >
-                        New Listing
-                    </Button>
+                </div>
+
+                <div className="mt-8 space-y-3 border-t border-slate-800/70 pt-6">
+                    <div className="rounded-2xl border border-[#00D1FF]/25 bg-gradient-to-br from-[#00D1FF]/10 via-transparent to-[#7465A8]/20 p-4 text-sm text-slate-200 shadow-[0_12px_45px_rgba(0,209,255,0.35)]">
+                        <p className="font-semibold text-white">Need to move quickly?</p>
+                        <p className="mt-1 text-xs text-slate-300/80">
+                            Launch a new marketplace listing right from here.
+                        </p>
+                        <Button
+                            variant="primary"
+                            className="mt-4 w-full"
+                            onClick={() => handleNavigate("/sell")}
+                        >
+                            Create Listing
+                        </Button>
+                    </div>
                     {onLogout && (
                         <Button
-                            variant="danger"
-                            className="w-full"
+                            variant="ghost"
+                            className="w-full justify-center border border-slate-800/60 bg-slate-900/70 text-slate-200 hover:border-[#00D1FF]/50 hover:text-white"
                             onClick={() => {
                                 closeMobile();
                                 onLogout();

--- a/bellingham-frontend/src/components/ui/NavMenuItem.jsx
+++ b/bellingham-frontend/src/components/ui/NavMenuItem.jsx
@@ -3,21 +3,23 @@ import { NavLink } from "react-router-dom";
 
 const baseClasses = {
     header:
-        "group relative inline-flex rounded-lg px-4 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.18em] transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]",
+        "group relative inline-flex items-center gap-2 rounded-xl px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.22em] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950",
     sidebar:
-        "group flex rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900",
+        "group relative flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950",
 };
 
 const activeClasses = {
     header:
-        "border border-[#00D1FF]/80 bg-[#00D1FF]/15 text-[#00D1FF] shadow-[0_10px_30px_rgba(0,209,255,0.3)]",
-    sidebar: "bg-slate-800 text-white",
+        "bg-gradient-to-r from-[#00D1FF]/20 via-[#7465A8]/20 to-transparent text-[#00D1FF] shadow-[0_18px_45px_rgba(0,209,255,0.25)]",
+    sidebar:
+        "bg-gradient-to-r from-[#00D1FF]/18 via-[#7465A8]/14 to-transparent text-white shadow-[inset_0_0_0_1px_rgba(0,209,255,0.35)]",
 };
 
 const inactiveClasses = {
     header:
-        "border border-transparent text-slate-300 hover:border-[#7465A8]/50 hover:bg-slate-800/60 hover:text-[#3BAEAB]",
-    sidebar: "text-slate-200 hover:bg-slate-800/70",
+        "text-slate-300 hover:text-[#9CD8D6]",
+    sidebar:
+        "text-slate-300 hover:bg-slate-900/60 hover:text-white",
 };
 
 const NavMenuItem = ({ item, layout = "header", onNavigate }) => {
@@ -33,7 +35,21 @@ const NavMenuItem = ({ item, layout = "header", onNavigate }) => {
                 `${baseClasses[layout]} ${isActive ? activeClasses[layout] : inactiveClasses[layout]}`
             }
         >
-            {() => <span>{label}</span>}
+            {({ isActive }) => (
+                <span className="flex w-full items-center gap-3">
+                    {layout === "sidebar" && (
+                        <span
+                            className={`h-2 w-2 rounded-full transition-colors ${
+                                isActive
+                                    ? "bg-[#00D1FF]"
+                                    : "bg-slate-600 group-hover:bg-[#00D1FF]"
+                            }`}
+                            aria-hidden="true"
+                        />
+                    )}
+                    <span>{label}</span>
+                </span>
+            )}
         </NavLink>
     );
 };


### PR DESCRIPTION
## Summary
- redesign the application layout with a left-aligned navigation rail and glassmorphism shell while preserving the existing colour palette
- refresh the header and navigation components to provide contextual page messaging and updated styling cues
- update the sidebar tests to account for permission-aware rendering and the new call-to-action copy

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dfb2366b4083299f9bef056779af23