### PR TITLE
Allow session endpoint to accept bearer tokens

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
@@ -238,14 +238,19 @@ public class AuthController {
 
     private String resolveTokenFromRequest(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
-        if (cookies == null) {
-            return null;
-        }
-        for (Cookie cookie : cookies) {
-            if (jwtProperties.getCookie().getName().equals(cookie.getName())) {
-                return cookie.getValue();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (jwtProperties.getCookie().getName().equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
             }
         }
+
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith("Bearer ")) {
+            return header.substring(7);
+        }
+
         return null;
     }
 }


### PR DESCRIPTION
## Summary
- allow the session endpoint to reuse bearer tokens from the Authorization header when no cookie is present
- cover the authorization-header path with a Spring MVC test

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68dfb95233c083299fbefd29baf19678