### PR TITLE
Disable login for permissionless accounts

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/AuthController.java
@@ -18,6 +18,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.bellingham.datafutures.config.JwtProperties;
 import com.bellingham.datafutures.controller.dto.LoginRequest;
@@ -78,6 +79,9 @@ public class AuthController {
                     .body(response);
         } catch (AuthenticationException e) {
             logger.warn("Authentication failed for user: {}", creds.getUsername(), e);
+            if (e instanceof DisabledException) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Account disabled", e);
+            }
             throw new BadCredentialsException("Invalid username or password");
         }
     }

--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/security/CustomUserDetailsService.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/security/CustomUserDetailsService.java
@@ -26,11 +26,13 @@ public class CustomUserDetailsService implements UserDetailsService {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found"));
         logger.debug("Loaded user: {}", user.getUsername());
-        return new org.springframework.security.core.userdetails.User(
-                user.getUsername(),
-                user.getPassword(),
-                Collections.singletonList(new SimpleGrantedAuthority(user.getRole()))
-        );
+        boolean disabled = user.getPermissions().isEmpty();
+
+        return org.springframework.security.core.userdetails.User.withUsername(user.getUsername())
+                .password(user.getPassword())
+                .authorities(Collections.singletonList(new SimpleGrantedAuthority(user.getRole())))
+                .disabled(disabled)
+                .build();
     }
 }
 

--- a/bellingham-datafutures/src/test/java/com/bellingham/datafutures/AuthControllerTest.java
+++ b/bellingham-datafutures/src/test/java/com/bellingham/datafutures/AuthControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
@@ -81,6 +82,17 @@ class AuthControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("SameSite=None")))
                 .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("Secure")));
+    }
+
+    @Test
+    void loginReturnsForbiddenWhenAccountDisabled() throws Exception {
+        when(authenticationManager.authenticate(any(Authentication.class)))
+                .thenThrow(new DisabledException("Account disabled"));
+
+        mockMvc.perform(post("/api/authenticate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"user\",\"password\":\"pass\"}"))
+                .andExpect(status().isForbidden());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- mark marketplace users without any permissions as disabled so Spring Security blocks authentication
- surface disabled accounts as HTTP 403 responses from the login endpoint
- cover the new behaviour with a dedicated controller test

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68dfbcca1cd88329869f348d587cb111