### PR TITLE
Revamp chrome layout for neon trading aesthetic

### DIFF
--- a/bellingham-frontend/src/__tests__/Button.test.jsx
+++ b/bellingham-frontend/src/__tests__/Button.test.jsx
@@ -11,9 +11,11 @@ test('applies variant classes', () => {
       <Button variant="ghost">Ghost</Button>
     </div>
   );
-  expect(screen.getByText('Primary')).toHaveClass('bg-[#00D1FF]');
+  expect(screen.getByText('Primary')).toHaveClass(
+    'bg-[linear-gradient(140deg,rgba(38,78,130,0.95),rgba(27,52,92,0.88))]',
+  );
   expect(screen.getByText('Danger')).toHaveClass('bg-red-600');
-  expect(screen.getByText('Ghost')).toHaveClass('bg-gray-600');
+  expect(screen.getByText('Ghost')).toHaveClass('bg-[rgba(14,24,44,0.75)]');
 });
 
 test('handles click events', () => {

--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -79,26 +79,26 @@ const Header = ({ onLogout, showNavigation = true }) => {
     };
 
     return (
-        <header className="sticky top-0 z-20 border-b border-slate-800/60 bg-gradient-to-b from-slate-950/80 via-slate-950/65 to-slate-950/40 backdrop-blur-xl">
-            <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-6 px-6 py-6 sm:px-8">
+        <header className="sticky top-0 z-20 border-b border-[#1B2543]/80 bg-[linear-gradient(180deg,rgba(24,34,61,0.95)_0%,rgba(10,16,30,0.9)_100%)] shadow-[0_38px_110px_rgba(5,9,20,0.7)] backdrop-blur-xl">
+            <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-6 px-6 py-7 sm:px-9">
                 <div className="flex flex-wrap items-start justify-between gap-6">
                     <div className="space-y-2">
                         <Link to="/" className="group flex flex-col leading-tight text-left">
-                            <span className="text-[0.65rem] font-semibold uppercase tracking-[0.42em] text-[#00D1FF]/75">
+                            <span className="text-[0.6rem] font-semibold uppercase tracking-[0.48em] text-[#4DD1FF]/80">
                                 Bellingham Markets
                             </span>
-                            <span className="text-2xl font-semibold text-white">
+                            <span className="text-2xl font-semibold text-white drop-shadow-[0_10px_25px_rgba(0,0,0,0.45)]">
                                 {pageTitle}
                             </span>
                         </Link>
-                        <p className="max-w-xl text-sm text-slate-300/90">
+                        <p className="max-w-xl text-sm text-slate-200/85">
                             {pageDescription}
                         </p>
                     </div>
                     <div className="flex items-center gap-4">
                         <Link
                             to="/notifications"
-                            className="relative flex h-12 w-12 items-center justify-center rounded-2xl border border-[#00D1FF]/40 bg-slate-900/70 text-[#00D1FF] shadow-[0_18px_48px_rgba(0,209,255,0.32)] transition-all hover:-translate-y-0.5 hover:bg-slate-900/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                            className="relative flex h-12 w-12 items-center justify-center rounded-2xl border border-[#21416F]/80 bg-[linear-gradient(145deg,rgba(34,64,109,0.95),rgba(19,35,64,0.85))] text-[#4DD1FF] shadow-[0_22px_48px_rgba(20,70,120,0.55)] transition-all hover:-translate-y-0.5 hover:shadow-[0_28px_60px_rgba(20,70,120,0.65)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#4DD1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A1222]"
                             aria-label={
                                 unreadCount > 0
                                     ? `${unreadCount} unread notifications`
@@ -108,7 +108,7 @@ const Header = ({ onLogout, showNavigation = true }) => {
                             <NotificationBellIcon className="h-5 w-5" />
                             <span className="sr-only">Open notifications</span>
                             {unreadCount > 0 && (
-                                <span className="numeric-text absolute -right-1 -top-1 min-w-[1.5rem] rounded-full bg-[#7465A8] px-1.5 py-0.5 text-center text-[0.65rem] font-semibold leading-none text-white shadow-lg">
+                                <span className="numeric-text absolute -right-1 -top-1 min-w-[1.5rem] rounded-full bg-[#7465A8] px-1.5 py-0.5 text-center text-[0.65rem] font-semibold leading-none text-white shadow-[0_10px_30px_rgba(116,101,168,0.6)]">
                                     {unreadCount > 99 ? "99+" : unreadCount}
                                 </span>
                             )}
@@ -117,7 +117,7 @@ const Header = ({ onLogout, showNavigation = true }) => {
                         {username && (
                             <div className="flex items-center gap-4">
                                 <div className="text-right">
-                                    <p className="text-[0.65rem] font-semibold uppercase tracking-[0.38em] text-slate-400">
+                                    <p className="text-[0.6rem] font-semibold uppercase tracking-[0.4em] text-slate-400">
                                         Logged in as
                                     </p>
                                     <p className="text-sm font-semibold text-white">{username}</p>
@@ -126,7 +126,7 @@ const Header = ({ onLogout, showNavigation = true }) => {
                                     <button
                                         type="button"
                                         onClick={onLogout}
-                                        className="rounded-2xl border border-[#3BAEAB]/50 bg-[#3BAEAB]/10 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.28em] text-[#9CD8D6] transition-all hover:-translate-y-0.5 hover:bg-[#3BAEAB]/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                                        className="rounded-2xl border border-[#2F4F78]/70 bg-[linear-gradient(145deg,rgba(30,60,95,0.85),rgba(24,42,70,0.7))] px-5 py-2 text-[0.6rem] font-semibold uppercase tracking-[0.3em] text-[#9BD8FF] transition-all hover:-translate-y-0.5 hover:shadow-[0_22px_45px_rgba(47,79,120,0.55)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#4DD1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A1222]"
                                     >
                                         Log Out
                                     </button>
@@ -137,9 +137,9 @@ const Header = ({ onLogout, showNavigation = true }) => {
                 </div>
 
                 {shouldRenderNavigation && (
-                    <div className="rounded-2xl border border-slate-800/60 bg-slate-950/60 px-3 py-4 shadow-[0_24px_60px_rgba(8,20,45,0.4)]">
+                    <div className="rounded-2xl border border-[#1E2F53]/70 bg-[linear-gradient(140deg,rgba(20,36,70,0.9),rgba(12,22,42,0.85))] px-3 py-4 shadow-[0_30px_70px_rgba(5,9,20,0.55)]">
                         <div className="flex items-center justify-between gap-4 lg:hidden">
-                            <span className="text-[0.65rem] font-semibold uppercase tracking-[0.32em] text-slate-400">
+                            <span className="text-[0.6rem] font-semibold uppercase tracking-[0.34em] text-slate-400">
                                 Navigation
                             </span>
                             <button
@@ -147,7 +147,7 @@ const Header = ({ onLogout, showNavigation = true }) => {
                                 onClick={toggleNavigation}
                                 aria-expanded={isNavOpen}
                                 aria-controls="primary-navigation"
-                                className="inline-flex items-center gap-2 rounded-xl border border-[#00D1FF]/40 bg-slate-900/70 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.26em] text-[#00D1FF] transition-colors hover:bg-slate-900/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]"
+                                className="inline-flex items-center gap-2 rounded-xl border border-[#294674]/70 bg-[#142543]/80 px-4 py-2 text-[0.6rem] font-semibold uppercase tracking-[0.26em] text-[#9BD8FF] transition-colors hover:bg-[#1A3157]/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#4DD1FF]"
                             >
                                 <span>{isNavOpen ? "Close" : "Menu"}</span>
                                 <svg

--- a/bellingham-frontend/src/components/Layout.jsx
+++ b/bellingham-frontend/src/components/Layout.jsx
@@ -7,23 +7,27 @@ const sidebarWidth = "clamp(220px, 11.111vw, 280px)";
 
 const Layout = ({ children, onLogout }) => (
     <div
-        className="relative min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top,_rgba(0,209,255,0.12),_transparent_55%),_var(--bg-gradient)] font-sans text-contrast"
+        className="relative min-h-screen overflow-hidden bg-[#050912] font-sans text-contrast"
         style={{
-            backgroundColor: "var(--bg-color)",
+            backgroundImage:
+                "radial-gradient(circle at 15% 20%, rgba(0, 209, 255, 0.16), transparent 55%), " +
+                "radial-gradient(circle at 85% 10%, rgba(116, 101, 168, 0.18), transparent 60%), " +
+                "radial-gradient(circle at 50% 75%, rgba(59, 174, 171, 0.12), transparent 65%), " +
+                "linear-gradient(180deg, #0A1021 0%, #050912 60%, #03050D 100%)",
         }}
     >
         <a href="#main-content" className="skip-link">
             Skip to main content
         </a>
         <div
-            className="relative mx-auto flex min-h-screen w-full max-w-[1600px] flex-col gap-6 px-4 py-6 lg:flex-row lg:px-8 lg:py-10"
+            className="relative mx-auto flex min-h-screen w-full max-w-[1620px] flex-col gap-6 px-4 py-8 lg:flex-row lg:gap-8 lg:px-10 lg:py-12"
             style={{ "--sidebar-width": sidebarWidth }}
         >
             <Sidebar onLogout={onLogout} sidebarWidth={sidebarWidth} />
-            <div className="flex flex-1 flex-col rounded-3xl border border-slate-800/60 bg-slate-950/70 backdrop-blur-xl shadow-[0_45px_140px_rgba(8,20,45,0.45)]">
+            <div className="flex flex-1 flex-col rounded-[28px] border border-[#1B2543]/70 bg-[linear-gradient(160deg,rgba(23,34,58,0.95)_0%,rgba(9,14,27,0.92)_100%)] shadow-[0_50px_140px_rgba(5,9,20,0.55)] backdrop-blur-xl">
                 <Header onLogout={onLogout} showNavigation={false} />
                 <main id="main-content" tabIndex="-1" className="flex-1 overflow-y-auto">
-                    <div className="w-full px-6 pb-12 pt-8 sm:px-8 lg:px-12">
+                    <div className="w-full px-6 pb-12 pt-8 sm:px-9 lg:px-14">
                         {children}
                     </div>
                 </main>

--- a/bellingham-frontend/src/components/Sidebar.jsx
+++ b/bellingham-frontend/src/components/Sidebar.jsx
@@ -50,7 +50,7 @@ const Sidebar = ({ onLogout, sidebarWidth }) => {
             <button
                 type="button"
                 onClick={toggleMobile}
-                className="fixed left-4 top-6 z-50 inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-slate-800/60 bg-slate-950/90 text-white shadow-[0_18px_45px_rgba(8,20,45,0.55)] backdrop-blur focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 lg:hidden"
+                className="fixed left-4 top-6 z-50 inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-[#20355E]/70 bg-[linear-gradient(145deg,rgba(28,46,83,0.92),rgba(16,27,52,0.88))] text-[#A9C9FF] shadow-[0_25px_60px_rgba(12,22,42,0.65)] backdrop-blur focus:outline-none focus-visible:ring-2 focus-visible:ring-[#4DD1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-[#050912] lg:hidden"
                 aria-label={isMobileOpen ? "Close navigation" : "Open navigation"}
                 aria-expanded={isMobileOpen}
             >
@@ -69,7 +69,7 @@ const Sidebar = ({ onLogout, sidebarWidth }) => {
             )}
 
             <aside
-                className={`fixed inset-y-0 left-0 z-50 flex h-full transform flex-col overflow-hidden border-r border-slate-800/60 bg-slate-950/95 px-6 pb-8 pt-10 text-slate-100 shadow-[0_45px_120px_rgba(8,20,45,0.55)] backdrop-blur-xl transition-transform duration-300 ease-in-out lg:static lg:z-auto lg:translate-x-0 lg:rounded-3xl lg:border lg:border-slate-800/60 lg:bg-slate-950/60 lg:px-7 lg:py-10 lg:shadow-[0_35px_110px_rgba(8,20,45,0.45)] ${
+                className={`fixed inset-y-0 left-0 z-50 flex h-full transform flex-col overflow-hidden border-r border-[#1B2744]/80 bg-[linear-gradient(185deg,rgba(20,33,60,0.95)_0%,rgba(10,18,36,0.92)_100%)] px-6 pb-9 pt-10 text-slate-100 shadow-[0_55px_140px_rgba(5,10,25,0.7)] backdrop-blur-2xl transition-transform duration-300 ease-in-out lg:static lg:z-auto lg:translate-x-0 lg:rounded-[28px] lg:border lg:border-[#1B2744]/80 lg:px-8 lg:py-11 lg:shadow-[0_45px_120px_rgba(5,10,25,0.6)] ${
                     isMobileOpen ? "translate-x-0" : "-translate-x-full"
                 }`}
                 style={{ width: "var(--sidebar-width)", flexBasis: "var(--sidebar-width)" }}
@@ -78,20 +78,20 @@ const Sidebar = ({ onLogout, sidebarWidth }) => {
                     <button
                         type="button"
                         onClick={() => handleNavigate("/")}
-                        className="group flex items-center gap-3 rounded-2xl border border-transparent bg-slate-900/70 px-3 py-2 text-left transition-colors hover:border-[#00D1FF]/40 hover:bg-slate-900/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                        className="group flex items-center gap-3 rounded-2xl border border-transparent bg-[linear-gradient(145deg,rgba(22,38,70,0.85),rgba(12,22,46,0.75))] px-3 py-2 text-left transition-colors hover:border-[#4DD1FF]/50 hover:bg-[rgba(22,38,70,0.95)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#4DD1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-[#050912]"
                     >
-                        <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-[#00D1FF]/80 to-[#7465A8]/70 text-base font-bold text-slate-950 shadow-[0_12px_35px_rgba(0,209,255,0.45)]">
+                        <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[radial-gradient(circle_at_30%_20%,rgba(77,209,255,0.85),rgba(116,101,168,0.65))] text-base font-bold text-slate-950 shadow-[0_16px_40px_rgba(45,130,210,0.6)]">
                             BM
                         </span>
                         <span className="flex flex-col leading-tight">
-                            <span className="text-[0.65rem] font-semibold uppercase tracking-[0.38em] text-[#9CD8D6]">Bellingham</span>
+                            <span className="text-[0.6rem] font-semibold uppercase tracking-[0.42em] text-[#8BB8FF]">Bellingham</span>
                             <span className="text-sm font-semibold text-white">Markets Platform</span>
                         </span>
                     </button>
                     <button
                         type="button"
                         onClick={closeMobile}
-                        className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-slate-800/60 bg-slate-900/60 text-slate-300 transition-colors hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF] lg:hidden"
+                        className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-[#24395F]/70 bg-[#111D36]/80 text-slate-300 transition-colors hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#4DD1FF] lg:hidden"
                     >
                         <span className="sr-only">Close navigation</span>
                         <svg className="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
@@ -103,7 +103,7 @@ const Sidebar = ({ onLogout, sidebarWidth }) => {
                 <div className="mt-8 flex-1 space-y-8 overflow-y-auto pr-1">
                     {Array.from(groupedNavItems.entries()).map(([section, items]) => (
                         <div key={section} className="space-y-3">
-                            <p className="px-1 text-[0.65rem] font-semibold uppercase tracking-[0.42em] text-slate-400/80">{section}</p>
+                            <p className="px-1 text-[0.6rem] font-semibold uppercase tracking-[0.44em] text-[#4C6FA8]/80">{section}</p>
                             <div className="space-y-1.5">
                                 {items.map((item) => (
                                     <NavMenuItem key={item.path} item={item} layout="sidebar" onNavigate={handleNavigate} />
@@ -113,15 +113,15 @@ const Sidebar = ({ onLogout, sidebarWidth }) => {
                     ))}
                 </div>
 
-                <div className="mt-8 space-y-3 border-t border-slate-800/70 pt-6">
-                    <div className="rounded-2xl border border-[#00D1FF]/25 bg-gradient-to-br from-[#00D1FF]/10 via-transparent to-[#7465A8]/20 p-4 text-sm text-slate-200 shadow-[0_12px_45px_rgba(0,209,255,0.35)]">
+                <div className="mt-8 space-y-3 border-t border-[#1B2744]/80 pt-6">
+                    <div className="rounded-2xl border border-[#2F4F78]/70 bg-[linear-gradient(150deg,rgba(34,64,109,0.28),rgba(25,44,78,0.2))] p-4 text-sm text-slate-200 shadow-[0_20px_60px_rgba(10,18,36,0.55)]">
                         <p className="font-semibold text-white">Need to move quickly?</p>
-                        <p className="mt-1 text-xs text-slate-300/80">
+                        <p className="mt-1 text-xs text-slate-300/85">
                             Launch a new marketplace listing right from here.
                         </p>
                         <Button
                             variant="primary"
-                            className="mt-4 w-full"
+                            className="mt-4 w-full border border-[#4DD1FF]/30 bg-[linear-gradient(145deg,rgba(35,70,120,0.9),rgba(20,40,75,0.85))] text-[#9BD8FF] shadow-[0_20px_45px_rgba(34,64,109,0.45)] hover:border-[#4DD1FF]/60"
                             onClick={() => handleNavigate("/sell")}
                         >
                             Create Listing
@@ -130,7 +130,7 @@ const Sidebar = ({ onLogout, sidebarWidth }) => {
                     {onLogout && (
                         <Button
                             variant="ghost"
-                            className="w-full justify-center border border-slate-800/60 bg-slate-900/70 text-slate-200 hover:border-[#00D1FF]/50 hover:text-white"
+                            className="w-full justify-center border border-[#22365A]/70 bg-[#111D36]/85 text-slate-200 hover:border-[#4DD1FF]/60 hover:text-white"
                             onClick={() => {
                                 closeMobile();
                                 onLogout();

--- a/bellingham-frontend/src/components/ui/Button.jsx
+++ b/bellingham-frontend/src/components/ui/Button.jsx
@@ -3,14 +3,15 @@ import React, { cloneElement, forwardRef, isValidElement } from 'react';
 const classNames = (...classes) => classes.filter(Boolean).join(' ');
 
 const baseClasses =
-  'inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
+  'inline-flex items-center justify-center gap-2 rounded-xl px-5 py-2 text-sm font-semibold uppercase tracking-[0.22em] transition-transform transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
 
 const variantClasses = {
   primary:
-    'bg-[#00D1FF] text-slate-900 shadow-[0_10px_30px_rgba(0,209,255,0.35)] hover:bg-[#7465A8] hover:text-white focus-visible:ring-[#00D1FF] focus-visible:ring-offset-slate-900',
+    'border border-transparent bg-[linear-gradient(140deg,rgba(38,78,130,0.95),rgba(27,52,92,0.88))] text-[#9BD8FF] shadow-[0_22px_55px_rgba(22,42,78,0.55)] hover:shadow-[0_26px_70px_rgba(22,42,78,0.6)] hover:border-[#4DD1FF]/60 focus-visible:ring-[#4DD1FF] focus-visible:ring-offset-[#050912] hover:-translate-y-0.5',
   success: 'bg-green-600 text-white hover:bg-green-500 focus-visible:ring-green-500',
   danger: 'bg-red-600 text-white hover:bg-red-500 focus-visible:ring-red-500',
-  ghost: 'bg-gray-600 text-white hover:bg-gray-700 focus-visible:ring-gray-500',
+  ghost:
+    'border border-transparent bg-[rgba(14,24,44,0.75)] text-slate-200 shadow-[0_14px_32px_rgba(5,10,25,0.55)] hover:border-[#4DD1FF]/60 hover:bg-[rgba(20,36,70,0.65)] focus-visible:ring-[#4DD1FF] focus-visible:ring-offset-[#050912]',
   link:
     'bg-transparent px-0 py-0 text-[#00D1FF] underline-offset-4 hover:text-[#3BAEAB] hover:underline focus-visible:ring-[#00D1FF] focus-visible:ring-offset-0 rounded-none',
 };

--- a/bellingham-frontend/src/components/ui/NavMenuItem.jsx
+++ b/bellingham-frontend/src/components/ui/NavMenuItem.jsx
@@ -3,23 +3,23 @@ import { NavLink } from "react-router-dom";
 
 const baseClasses = {
     header:
-        "group relative inline-flex items-center gap-2 rounded-xl px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.22em] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950",
+        "group relative inline-flex items-center gap-2 rounded-xl border border-transparent bg-transparent px-4 py-2 text-[0.66rem] font-semibold uppercase tracking-[0.22em] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-[#4DD1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A1222]",
     sidebar:
-        "group relative flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00D1FF]/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950",
+        "group relative flex items-center gap-3 rounded-2xl border border-transparent px-4 py-3 text-sm font-medium transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-[#4DD1FF]/80 focus-visible:ring-offset-2 focus-visible:ring-offset-[#050912]",
 };
 
 const activeClasses = {
     header:
-        "bg-gradient-to-r from-[#00D1FF]/20 via-[#7465A8]/20 to-transparent text-[#00D1FF] shadow-[0_18px_45px_rgba(0,209,255,0.25)]",
+        "border-[#294E86]/70 bg-[linear-gradient(140deg,rgba(34,64,109,0.45),rgba(22,38,70,0.35))] text-[#9BD8FF] shadow-[0_18px_45px_rgba(34,64,109,0.45)]",
     sidebar:
-        "bg-gradient-to-r from-[#00D1FF]/18 via-[#7465A8]/14 to-transparent text-white shadow-[inset_0_0_0_1px_rgba(0,209,255,0.35)]",
+        "border-[#294E86]/70 bg-[linear-gradient(120deg,rgba(34,64,109,0.35),rgba(22,38,70,0.28))] text-white shadow-[inset_0_0_0_1px_rgba(77,209,255,0.35)]",
 };
 
 const inactiveClasses = {
     header:
-        "text-slate-300 hover:text-[#9CD8D6]",
+        "text-slate-300 hover:text-[#9BD8FF] hover:bg-[rgba(20,36,70,0.25)]",
     sidebar:
-        "text-slate-300 hover:bg-slate-900/60 hover:text-white",
+        "text-slate-300 hover:border-[#2C4B7D]/50 hover:bg-[rgba(20,36,70,0.22)] hover:text-white",
 };
 
 const NavMenuItem = ({ item, layout = "header", onNavigate }) => {


### PR DESCRIPTION
## Summary
- Restyle the application layout background with layered neon gradients and updated container chrome to match the trading dashboard reference.
- Rebuild the header and sidebar treatments with cohesive teal and indigo accents, refreshed navigation states, and updated action buttons.
- Refresh shared button styling and navigation item classes to support the new look and align unit tests with the revised utility classes.

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e0c9472b4083299313d16d7bb11f73