### PR TITLE
Add outer spacing around layout panels

### DIFF
--- a/bellingham-frontend/src/components/Layout.jsx
+++ b/bellingham-frontend/src/components/Layout.jsx
@@ -7,7 +7,7 @@ const sidebarWidth = "clamp(220px, 11.111vw, 280px)";
 
 const Layout = ({ children, onLogout }) => (
     <div
-        className="relative min-h-screen overflow-hidden bg-[#050912] font-sans text-contrast"
+        className="relative min-h-screen overflow-hidden bg-[#050912] px-4 py-6 font-sans text-contrast sm:px-6 sm:py-8 lg:px-12 lg:py-12"
         style={{
             backgroundImage:
                 "radial-gradient(circle at 15% 20%, rgba(0, 209, 255, 0.16), transparent 55%), " +


### PR DESCRIPTION
## Summary
- add responsive outer padding to the layout container so the panels no longer reach the viewport edge

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e0ccf206148329bdd6dd66fcd226c3