### PR TITLE
Add margin around grid content in layout

### DIFF
--- a/bellingham-frontend/src/components/Layout.jsx
+++ b/bellingham-frontend/src/components/Layout.jsx
@@ -27,7 +27,9 @@ const Layout = ({ children, onLogout }) => (
             <div className="flex flex-1 flex-col rounded-[28px] border border-[#1B2543]/70 bg-[linear-gradient(160deg,rgba(23,34,58,0.95)_0%,rgba(9,14,27,0.92)_100%)] shadow-[0_50px_140px_rgba(5,9,20,0.55)] backdrop-blur-xl">
                 <Header onLogout={onLogout} showNavigation={false} />
                 <main id="main-content" tabIndex="-1" className="flex-1 overflow-y-auto">
-                    <div className="w-full px-6 pb-12 pt-8 sm:px-9 lg:px-14">
+                    <div
+                        className="w-full px-6 pb-12 pt-8 sm:px-9 lg:px-14 [&_.grid]:px-3 [&_.grid]:py-3 [&_.grid]:sm:px-4 [&_.grid]:sm:py-4 [&_.grid]:lg:px-6 [&_.grid]:lg:py-6"
+                    >
                         {children}
                     </div>
                 </main>


### PR DESCRIPTION
## Summary
- add responsive padding rules to the layout content wrapper to ensure descendant grids have breathing room
- prevent dashboard and other grid-based pages from touching the viewport edges

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e21efdeb088329859ee2474b288c94