### PR TITLE
Add persistent quick link buttons to header

### DIFF
--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -5,6 +5,19 @@ import { AuthContext, useNotifications } from "../context";
 import navItems from "../config/navItems";
 import NavMenuItem from "./ui/NavMenuItem";
 
+const headerButtons = [
+    { label: "Home", path: "/" },
+    { label: "Buy", path: "/buy" },
+    { label: "Sell", path: "/sell" },
+    { label: "Reports", path: "/reports" },
+    { label: "Sales", path: "/sales" },
+    { label: "Calendar", path: "/calendar" },
+    { label: "History", path: "/history" },
+    { label: "Settings", path: "/settings" },
+    { label: "Account", path: "/account" },
+    { label: "Notifications", path: "/notifications" },
+];
+
 const NotificationBellIcon = ({ className = "", ...props }) => (
     <svg
         aria-hidden="true"
@@ -126,6 +139,21 @@ const Header = ({ onLogout, showNavigation = true }) => {
                         )}
                     </div>
                 </div>
+
+                <nav
+                    aria-label="Quick links"
+                    className="grid grid-cols-2 gap-2 rounded-2xl border border-[#1E2F53]/60 bg-[linear-gradient(140deg,rgba(20,36,70,0.78),rgba(12,22,42,0.7))] p-2 shadow-[0_24px_60px_rgba(5,9,20,0.55)] sm:grid-cols-5 xl:grid-cols-10"
+                >
+                    {headerButtons.map((button) => (
+                        <Link
+                            key={button.path}
+                            to={button.path}
+                            className="flex w-full items-center justify-center rounded-xl border border-[#2F4F78]/60 bg-[linear-gradient(145deg,rgba(30,60,95,0.78),rgba(20,38,68,0.68))] px-4 py-2 text-[0.6rem] font-semibold uppercase tracking-[0.24em] text-[#C7E7FF] transition-colors hover:border-[#4DD1FF]/80 hover:bg-[#4DD1FF]/80 hover:text-[#0A1222] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#4DD1FF] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A1222]"
+                        >
+                            {button.label}
+                        </Link>
+                    ))}
+                </nav>
 
                 {shouldRenderNavigation && (
                     <nav


### PR DESCRIPTION
## Summary
- add a dedicated set of quick link buttons to the header for key platform sections
- style the buttons with gradient backgrounds, hover states, and responsive layout so they remain evenly spaced across viewports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2d62c9b40832989059bff309cb4ca