### PR TITLE
Update header branding copy

### DIFF
--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -41,7 +41,7 @@ const NotificationBellIcon = ({ className = "", ...props }) => (
 const pageDescriptions = {
     "/": "Live market intelligence and real-time execution metrics.",
     "/buy": "Discover opportunities that match your sourcing strategy.",
-    "/sell": "Craft competitive listings and reach active buyers instantly.",
+    "/sell": "The Forwards Data Contracts Market",
     "/reports": "Visualise platform performance and compliance insights.",
     "/sales": "Track pipeline health and completed market activity.",
     "/calendar": "Coordinate market events, closings, and settlement windows.",
@@ -89,7 +89,7 @@ const Header = ({ onLogout, showNavigation = true }) => {
                     <div className="space-y-2">
                         <Link to="/" className="group flex flex-col leading-tight text-left">
                             <span className="text-[0.6rem] font-semibold uppercase tracking-[0.48em] text-[#4DD1FF]/80">
-                                Bellingham Markets
+                                Bellingham Data Futures
                             </span>
                             <span className="text-2xl font-semibold text-white drop-shadow-[0_10px_25px_rgba(0,0,0,0.45)]">
                                 {pageTitle}


### PR DESCRIPTION
## Summary
- update the header branding text to display "Bellingham Data Futures"
- refresh the Sell page description to read "The Forwards Data Contracts Market"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2db59748c83298bf88626a885b8bb