### PR TITLE
Double the header logo size

### DIFF
--- a/bellingham-frontend/src/components/Header.jsx
+++ b/bellingham-frontend/src/components/Header.jsx
@@ -88,7 +88,7 @@ const Header = ({ onLogout, showNavigation = true }) => {
                 <div className="flex flex-wrap items-start justify-between gap-6">
                     <div className="space-y-2">
                         <Link to="/" className="group flex flex-col leading-tight text-left">
-                            <span className="text-[0.6rem] font-semibold uppercase tracking-[0.48em] text-[#4DD1FF]/80">
+                            <span className="text-[1.2rem] font-semibold uppercase tracking-[0.48em] text-[#4DD1FF]/80">
                                 Bellingham Data Futures
                             </span>
                             <span className="text-2xl font-semibold text-white drop-shadow-[0_10px_25px_rgba(0,0,0,0.45)]">


### PR DESCRIPTION
## Summary
- double the displayed size of the Bellingham Data Futures logotype in the header

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2de1435c0832997b6a3f68ef45d75