### PR TITLE
Allow any user except the creator to buy contracts

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -335,19 +335,10 @@ public class ForwardContractController {
                     }
                     String username = org.springframework.security.core.context.SecurityContextHolder
                             .getContext().getAuthentication().getName();
-                    User buyer = userRepository.findByUsername(username)
+                    userRepository.findByUsername(username)
                             .orElseThrow(() -> new ResponseStatusException(
                                     org.springframework.http.HttpStatus.FORBIDDEN, "User profile not found"));
-                    if (!buyer.hasPermission(UserPermission.BUY)) {
-                        return ResponseEntity.status(org.springframework.http.HttpStatus.FORBIDDEN)
-                                .<ForwardContract>build();
-                    }
-                    Collection<? extends GrantedAuthority> authorities = SecurityContextHolder.getContext()
-                            .getAuthentication().getAuthorities();
-                    Set<String> authorityNames = authorities.stream()
-                            .map(GrantedAuthority::getAuthority)
-                            .collect(Collectors.toSet());
-                    if (!contract.canProgress(authorityNames)) {
+                    if (username != null && username.equals(contract.getCreatorUsername())) {
                         return ResponseEntity.status(org.springframework.http.HttpStatus.FORBIDDEN)
                                 .<ForwardContract>build();
                     }

--- a/bellingham-datafutures/src/test/java/com/bellingham/datafutures/ForwardContractControllerTest.java
+++ b/bellingham-datafutures/src/test/java/com/bellingham/datafutures/ForwardContractControllerTest.java
@@ -174,6 +174,27 @@ class ForwardContractControllerTest {
     }
 
     @Test
+    void buyingOwnContractIsForbidden() throws Exception {
+        ForwardContract contract = new ForwardContract();
+        contract.setId(3L);
+        contract.setStatus("Available");
+        contract.setTitle("Own Contract");
+        contract.setCreatorUsername("owner");
+        given(repository.findById(3L)).willReturn(java.util.Optional.of(contract));
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken("owner", "pass"));
+        given(userRepository.findByUsername("owner"))
+                .willReturn(Optional.of(userWithPermissions("owner", UserPermission.BUY)));
+
+        mockMvc.perform(post("/api/contracts/3/buy")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+
+        org.mockito.Mockito.verify(repository, org.mockito.Mockito.never()).save(any());
+        org.mockito.Mockito.verify(notificationService, org.mockito.Mockito.never()).notifyUser(any(), any(), any());
+    }
+
+    @Test
     void createContractWithoutSellPermissionIsForbidden() throws Exception {
         ForwardContractCreateRequest request = new ForwardContractCreateRequest();
         request.setTitle("Contract");

--- a/bellingham-frontend/src/App.jsx
+++ b/bellingham-frontend/src/App.jsx
@@ -57,7 +57,7 @@ const App = () => {
             <Route path="/signup" element={<Signup />} />
             <Route
                 path="/buy"
-                element={renderGuarded(Buy, { requiresPermission: "BUY" })}
+                element={renderGuarded(Buy)}
             />
             <Route
                 path="/sell"

--- a/bellingham-frontend/src/config/navItems.js
+++ b/bellingham-frontend/src/config/navItems.js
@@ -1,6 +1,6 @@
 const navItems = [
     { path: "/", label: "Home" },
-    { path: "/buy", label: "Buy", requiresPermission: "BUY" },
+    { path: "/buy", label: "Buy" },
     { path: "/reports", label: "Reports" },
     { path: "/sell", label: "Sell", requiresPermission: "SELL" },
     { path: "/sales", label: "Sales" },


### PR DESCRIPTION
## Summary
- allow authenticated users to buy available contracts while blocking self-purchases on the backend
- cover the self-purchase restriction with controller tests and keep seller notifications unchanged
- expose the buy route and navigation entry to all logged-in users in the frontend

## Testing
- ./mvnw test
- npm test -- src/__tests__/Buy.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e41d5a32a08329b1aa997b81743dbd