### PR TITLE
Fix frontend API base URL handling

### DIFF
--- a/bellingham-frontend/src/utils/api.js
+++ b/bellingham-frontend/src/utils/api.js
@@ -1,9 +1,22 @@
 import axios from 'axios';
 
+const normalizeBaseURL = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed === '/') {
+    return '';
+  }
+
+  return trimmed.replace(/\/+$/, '');
+};
+
+export const resolveBaseURL = (rawValue) => normalizeBaseURL(rawValue);
+
 const rawBaseURL = import.meta.env.VITE_API_BASE_URL;
-const resolvedBaseURL = typeof rawBaseURL === 'string' && rawBaseURL.trim().length > 0
-  ? rawBaseURL.trim()
-  : '/api';
+const resolvedBaseURL = resolveBaseURL(rawBaseURL);
 
 const api = axios.create({
   baseURL: resolvedBaseURL,

--- a/bellingham-frontend/src/utils/api.test.js
+++ b/bellingham-frontend/src/utils/api.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { resolveBaseURL } from './api';
+
+describe('resolveBaseURL', () => {
+  it('returns empty string when value is missing', () => {
+    expect(resolveBaseURL(undefined)).toBe('');
+    expect(resolveBaseURL(null)).toBe('');
+  });
+
+  it('trims whitespace and strips trailing slashes', () => {
+    expect(resolveBaseURL('  https://example.com/api/  ')).toBe('https://example.com/api');
+    expect(resolveBaseURL('http://localhost:8080/')).toBe('http://localhost:8080');
+  });
+
+  it('normalises a solitary slash to the empty string', () => {
+    expect(resolveBaseURL('/')).toBe('');
+    expect(resolveBaseURL('   /   ')).toBe('');
+  });
+
+  it('returns relative paths unchanged aside from trimming', () => {
+    expect(resolveBaseURL(' api/base ')).toBe('api/base');
+  });
+});


### PR DESCRIPTION
## Summary
- normalise the frontend API client base URL so requests no longer include a duplicated /api prefix
- add unit coverage for the base URL resolver to prevent regressions

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e41f5c4f8c8329b65c7cb95510f1b0