### PR TITLE
Enforce buy permission when purchasing contracts

### DIFF
--- a/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
+++ b/bellingham-datafutures/src/main/java/com/bellingham/datafutures/controller/ForwardContractController.java
@@ -335,9 +335,13 @@ public class ForwardContractController {
                     }
                     String username = org.springframework.security.core.context.SecurityContextHolder
                             .getContext().getAuthentication().getName();
-                    userRepository.findByUsername(username)
+                    User buyer = userRepository.findByUsername(username)
                             .orElseThrow(() -> new ResponseStatusException(
                                     org.springframework.http.HttpStatus.FORBIDDEN, "User profile not found"));
+                    if (!buyer.hasPermission(UserPermission.BUY)) {
+                        return ResponseEntity.status(org.springframework.http.HttpStatus.FORBIDDEN)
+                                .<ForwardContract>build();
+                    }
                     if (username != null && username.equals(contract.getCreatorUsername())) {
                         return ResponseEntity.status(org.springframework.http.HttpStatus.FORBIDDEN)
                                 .<ForwardContract>build();

--- a/bellingham-datafutures/src/test/java/com/bellingham/datafutures/ForwardContractControllerTest.java
+++ b/bellingham-datafutures/src/test/java/com/bellingham/datafutures/ForwardContractControllerTest.java
@@ -195,6 +195,27 @@ class ForwardContractControllerTest {
     }
 
     @Test
+    void buyingContractWithoutBuyPermissionIsForbidden() throws Exception {
+        ForwardContract contract = new ForwardContract();
+        contract.setId(4L);
+        contract.setStatus("Available");
+        contract.setTitle("Restricted Contract");
+        contract.setCreatorUsername("seller");
+        given(repository.findById(4L)).willReturn(java.util.Optional.of(contract));
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken("buyer", "pass"));
+        given(userRepository.findByUsername("buyer"))
+                .willReturn(Optional.of(userWithPermissions("buyer")));
+
+        mockMvc.perform(post("/api/contracts/4/buy")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+
+        org.mockito.Mockito.verify(repository, org.mockito.Mockito.never()).save(any());
+        org.mockito.Mockito.verify(notificationService, org.mockito.Mockito.never()).notifyUser(any(), any(), any());
+    }
+
+    @Test
     void createContractWithoutSellPermissionIsForbidden() throws Exception {
         ForwardContractCreateRequest request = new ForwardContractCreateRequest();
         request.setTitle("Contract");


### PR DESCRIPTION
## Summary
- ensure contract purchases verify that the buyer has the BUY permission before completing the transaction
- add a controller test that covers the forbidden response when a user lacks BUY permission

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68e42397e6ac83298938206a1572cc8a