### PR TITLE
Fix buy modal toggle for zero-id contracts

### DIFF
--- a/bellingham-frontend/src/__tests__/Buy.test.jsx
+++ b/bellingham-frontend/src/__tests__/Buy.test.jsx
@@ -115,4 +115,34 @@ describe('Buy component', () => {
       );
     });
   });
+
+  test('opens the signature modal for contracts with id 0', async () => {
+    api.get.mockImplementationOnce((url) => {
+      if (url === '/api/contracts/available') {
+        return Promise.resolve({
+          data: {
+            content: [
+              {
+                id: 0,
+                title: 'Contract Zero',
+                seller: 'Seller Zero',
+                price: 50,
+                deliveryDate: '2024-01-01',
+              },
+            ],
+          },
+        });
+      }
+      return Promise.resolve({ data: [] });
+    });
+
+    renderWithProviders(<Buy />);
+
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith('/api/contracts/available'));
+
+    const buyButton = screen.getAllByRole('button', { name: 'Buy' })[0];
+    fireEvent.click(buyButton);
+
+    expect(await screen.findByTestId('signature-canvas')).toBeInTheDocument();
+  });
 });

--- a/bellingham-frontend/src/components/Buy.jsx
+++ b/bellingham-frontend/src/components/Buy.jsx
@@ -437,7 +437,7 @@ const Buy = () => {
                     />
                 </div>
             </div>
-            {pendingContractId && (
+            {pendingContractId != null && (
                 <SignatureModal
                     onConfirm={handleSignatureConfirm}
                     onCancel={handleSignatureCancel}


### PR DESCRIPTION
## Summary
- ensure the Buy screen renders the signature modal even when a contract id resolves to 0
- add a regression test that covers zero-id contracts on the Buy page

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e428118a8883299c46cfad00713c31