### PR TITLE
Allow configuring server port via common environment variables

### DIFF
--- a/bellingham-datafutures/README.md
+++ b/bellingham-datafutures/README.md
@@ -68,6 +68,14 @@ The following environment variables can be used to configure the runtime:
   provide the same value via the Spring property
   `app.bootstrap.admin-password`.
 
+You can also set the more common `PORT` or `SERVER_PORT` environment
+variables to avoid conflicts if something else is already bound to 8080.
+For example:
+
+```bash
+PORT=8081 ./mvnw spring-boot:run
+```
+
 Start the service with the Maven wrapper:
 
 ```bash

--- a/bellingham-datafutures/src/main/resources/application.properties
+++ b/bellingham-datafutures/src/main/resources/application.properties
@@ -3,6 +3,11 @@ spring.datasource.url=jdbc:postgresql://localhost:5432/bdf
 spring.datasource.username=bdf_user
 spring.datasource.password=bdf_pass
 
+# === Server Port ===
+# Allow overriding the port with either SERVER_PORT or PORT environment
+# variables to avoid conflicts with other local services.
+server.port=${SERVER_PORT:${PORT:8080}}
+
 # === Hibernate Settings ===
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true


### PR DESCRIPTION
## Summary
- allow the Spring Boot server port to be overridden with SERVER_PORT or PORT to avoid local conflicts
- document the alternate environment variables with a usage example in the README

## Testing
- ./mvnw test -Dspring.profiles.active=test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935978d94e08329ab3f68efbd97e303)